### PR TITLE
Add GitHub Pages deployment for docs site

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run build
+      - run: pnpm --filter anta-site build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,10 +12,7 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMathjax from 'rehype-mathjax';
 
 export default defineConfig({
-  ...(process.env.GITHUB_ACTIONS && {
-    site: 'https://antithesishq.github.io',
-    base: '/anta',
-  }),
+  site: 'https://antadesign.dev',
   integrations: [
     preact({ compat: true }),
     astroExpressiveCode({

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,6 +12,8 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMathjax from 'rehype-mathjax';
 
 export default defineConfig({
+  site: 'https://antithesishq.github.io',
+  base: '/anta',
   integrations: [
     preact({ compat: true }),
     astroExpressiveCode({

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -12,8 +12,10 @@ import rehypeAutolinkHeadings from 'rehype-autolink-headings';
 import rehypeMathjax from 'rehype-mathjax';
 
 export default defineConfig({
-  site: 'https://antithesishq.github.io',
-  base: '/anta',
+  ...(process.env.GITHUB_ACTIONS && {
+    site: 'https://antithesishq.github.io',
+    base: '/anta',
+  }),
   integrations: [
     preact({ compat: true }),
     astroExpressiveCode({


### PR DESCRIPTION
## Summary

- Add `deploy.yml` workflow that builds and deploys the Astro docs site to GitHub Pages on push to main
- Configure Astro `site` and `base` for the `/anta/` subpath

## Setup required

After merging, go to repo **Settings → Pages → Source** and select **GitHub Actions**.

The site will be available at `https://antithesishq.github.io/anta/`

## Test plan

- [ ] Merge PR → workflow runs → site deploys
- [ ] Verify site loads at `https://antithesishq.github.io/anta/`
- [ ] Sidebar navigation and component pages work

🤖 Generated with [Claude Code](https://claude.com/claude-code)