### PR TITLE
Bump GitHub Actions to majors that target Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,23 +15,21 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm run build
       - run: pnpm --filter anta-site build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site/dist
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Silences the Sep 2025 Node-20 deprecation warning by moving each action to the major that natively targets Node 24, instead of relying on the `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` override.

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `pnpm/action-setup` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/upload-pages-artifact` | v3 | v5 |
| `actions/deploy-pages` | v4 | v5 |

`pnpm/action-setup@v6` still reads the `packageManager` field from `package.json` (currently `pnpm@8.13.1`), so no functional change to the pnpm version we install.

`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` is removed from both jobs — once the actions natively run on Node 24, the override is dead code.

## Test plan

- [ ] CI workflow on this PR runs green (verifies `actions/checkout@v6`, `pnpm/action-setup@v6`, `actions/setup-node@v6` work).
- [ ] No Node 20 deprecation warnings in the workflow run summary.
- [ ] After merge, Deploy workflow on `main` runs green (verifies `upload-pages-artifact@v5` + `deploy-pages@v5`) and the docs site reaches `antadesign.dev`.