### PR TITLE
Fix Safari rendering body sans as slanted

### DIFF
--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -19,7 +19,8 @@ h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
   font-weight: 100 900;
   font-stretch: 75% 100%;
   font-optical-sizing: auto;
-  font-display: block;
+  text-rendering: geometricPrecision;
+  font-display: swap;
 }
 @font-face {
   font-family: "Antithesis mono";
@@ -27,7 +28,7 @@ h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
   font-style: normal;
   font-weight: 400 700;
   text-rendering: optimizeLegibility;
-  font-display: block;
+  font-display: swap;
 }
 @font-face {
   font-family: "Antithesis mono";
@@ -35,7 +36,7 @@ h1, h2, h3, h4, h5, h6 { text-wrap: balance; }
   font-style: italic;
   font-weight: 400 700;
   text-rendering: optimizeLegibility;
-  font-display: block;
+  font-display: swap;
 }
 
 /* Brand variable overrides */
@@ -56,7 +57,23 @@ html {
   scroll-padding-top: var(--scroll-padding-top);
 }
 
-html, body { font-family: var(--sans-serif); }
+html, body {
+  font-family: var(--sans-serif);
+  /* "Antithesis sans" has a `slnt` axis whose default inside the
+     file isn't 0. Chrome normalizes it when `font-style: normal` is
+     in effect; Safari leaves it at the file default, which renders
+     the entire body slanted. Pinning the axis explicitly forces
+     upright on every browser. */
+  font-variation-settings: "slnt" 0, "ital" 0;
+}
+/* Italic markup drives the slant axis manually, since the global
+   pin above would otherwise keep them upright too. `-10deg` is a
+   reasonable starting value; tune once the file's actual range is
+   known. `ital 1` is set defensively in case the file exposes that
+   axis as well. */
+:is(em, i, address) {
+  font-variation-settings: "slnt" -10, "ital" 1;
+}
 
 /* Anta's global stylesheet provides the `a` defaults (color, underline,
    thickness, hover bump). Sidebar nav and header anchors below are the


### PR DESCRIPTION
## Summary

Site-only fix. Body sans-serif text was rendering slanted (italic-looking) in Safari while upright in Chrome.

**Cause.** "Antithesis sans" is a variable font with a `slnt` axis. The axis default *inside the file* isn't 0. Chrome normalizes the axis when `font-style: normal` is in effect; Safari honors the file's default and leaves it slanted, so every paragraph, heading, sidebar item and logo on antadesign.dev looked italic.

**Fix.** Pin `font-variation-settings: "slnt" 0` on `html, body` so the body is upright on every browser. Italic markup (`<em>`, `<i>`, MDX `*…*`) gets a manual `slnt -10` override so it can still slant — the global pin would otherwise keep italic content upright too.

Also aligned the sans `@font-face` with the working config used elsewhere for the same font:
- `font-display: swap` (was `block`)
- `text-rendering: geometricPrecision`

These don't fix the slant by themselves but are the right defaults for this font.

Mono is unaffected — separate font, no slant axis. The italic mono `@font-face` continues to handle italic mono content via its own URL.

## Version & changelog

No version bump needed — `package.json` is already at `0.1.1-dev.2` from the previous PR and that prerelease hasn't been published to npm yet, so this fix folds in. No `CHANGELOG.md` entry: this is `site/`-only and a consumer of `@antadesign/anta` wouldn't see it.

## Test plan

- [ ] Open antadesign.dev in **Safari** (the Mac app, current version) — confirm body sans (Overview heading, paragraphs, sidebar items, logo) is upright.
- [ ] Same in **Chrome** — should remain upright (already correct).
- [ ] Italic markup (e.g. `<em>threshold</em>` on `/accessibility/`, MDX `*…*` elsewhere) — confirm it still slants in both browsers.
- [ ] Bold markup (`<strong>`) — upright (only italic should slant).
- [ ] Mono inline code blocks — unchanged, upright; mono italic content (none currently) would still pick up the italic mono face.

## Follow-ups (not in this PR)

- The `-10deg` slant for italic content is a guess; once the file's actual `slnt` axis range is known we can tune to its natural italic angle.
- Long-term, hosting at Uploadcare is "temporary" per the inline comment — eventually we'd want a stable consumer-controlled CDN or a font on disk.