### PR TITLE
Set regular font-weight to 400 across Anta + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions ending in `-dev.N` are pre-release builds published under the npm `dev`
 
 ### Changed
 - **Convention strengthened (no API impact):** ARIA wiring (`role`, `aria-*`, `tabindex`, etc.) lives in `src/components/<Name>.tsx` JSX wrappers as attribute pass-through, never inside the web component class. Web components stay pure declarative DOM — neither the constructor nor `attributeChangedCallback` mutates host attributes or inline styles. Documented in `CLAUDE.md`.
+- Default body `font-weight` in `anta_global_tokens.css` changed to `400` for both `:root, .light` (was `390`) and `.dark` (was `350`). The previous values applied a small optical-compensation offset so dark-mode text was rendered slightly thinner; the new values are uniform regular weight. Apps that override `font-weight` on `:root` or `.dark` are unaffected.
 
 ## 0.1.1-dev.1 — May 3, 2026
 

--- a/dist/anta_global_tokens.css
+++ b/dist/anta_global_tokens.css
@@ -3,7 +3,7 @@
   --monospace: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 
   font-size: 15px;
-  font-weight: 390;
+  font-weight: 400;
   font-feature-settings: 'ss02' on, 'ss05' on;
 
   /* Colors imported from Figma library "Anta 0.2" → "Dynamic colors" collection.
@@ -198,7 +198,7 @@ a:active {
 }
 
 .dark {
-  font-weight: 350;
+  font-weight: 400;
 
   /* Backgrounds — dark, neutral */
   --bg-base: #100e11; --bg-base: oklch(0.168 0.007 315);

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -198,7 +198,7 @@ const isCurrent = (href: string) => {
     padding: 4px 0;
     color: var(--text-3);
     font-size: 14px;
-    font-weight: 450;
+    font-weight: 400;
     letter-spacing: 0.03ch;
     text-decoration: none;
     transition: color 160ms ease-out;

--- a/site/src/pages/changelog/dev.mdx
+++ b/site/src/pages/changelog/dev.mdx
@@ -19,6 +19,7 @@ import ChangelogTabs from '../../components/ChangelogTabs.astro'
 
 ### Changed
 - **Convention strengthened (no API impact):** ARIA wiring (`role`, `aria-*`, `tabindex`, etc.) lives in `src/components/<Name>.tsx` JSX wrappers as attribute pass-through, never inside the web component class. Web components stay pure declarative DOM — neither the constructor nor `attributeChangedCallback` mutates host attributes or inline styles. Documented in `CLAUDE.md`.
+- Default body `font-weight` in `anta_global_tokens.css` changed to `400` for both `:root, .light` (was `390`) and `.dark` (was `350`). The previous values applied a small optical-compensation offset so dark-mode text was rendered slightly thinner; the new values are uniform regular weight. Apps that override `font-weight` on `:root` or `.dark` are unaffected.
 
 ## 0.1.1-dev.1 — May 3, 2026
 

--- a/site/src/pages/changelog/index.mdx
+++ b/site/src/pages/changelog/index.mdx
@@ -25,6 +25,7 @@ Versions ending in `-dev.N` are pre-release builds published under the npm `dev`
 
 ### Changed
 - **Convention strengthened (no API impact):** ARIA wiring (`role`, `aria-*`, `tabindex`, etc.) lives in `src/components/<Name>.tsx` JSX wrappers as attribute pass-through, never inside the web component class. Web components stay pure declarative DOM — neither the constructor nor `attributeChangedCallback` mutates host attributes or inline styles. Documented in `CLAUDE.md`.
+- Default body `font-weight` in `anta_global_tokens.css` changed to `400` for both `:root, .light` (was `390`) and `.dark` (was `350`). The previous values applied a small optical-compensation offset so dark-mode text was rendered slightly thinner; the new values are uniform regular weight. Apps that override `font-weight` on `:root` or `.dark` are unaffected.
 
 ## 0.1.1-dev.1 — May 3, 2026
 

--- a/src/anta_global_tokens.css
+++ b/src/anta_global_tokens.css
@@ -3,7 +3,7 @@
   --monospace: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
 
   font-size: 15px;
-  font-weight: 390;
+  font-weight: 400;
   font-feature-settings: 'ss02' on, 'ss05' on;
 
   /* Colors imported from Figma library "Anta 0.2" → "Dynamic colors" collection.
@@ -198,7 +198,7 @@ a:active {
 }
 
 .dark {
-  font-weight: 350;
+  font-weight: 400;
 
   /* Backgrounds — dark, neutral */
   --bg-base: #100e11; --bg-base: oklch(0.168 0.007 315);


### PR DESCRIPTION
## Summary

Aligns the regular body font-weight to the standard `400` everywhere it was set to a non-standard value.

### Anta package (consumer-facing)
- `anta_global_tokens.css` — `:root, .light` font-weight `390 → 400`
- `anta_global_tokens.css` — `.dark` font-weight `350 → 400`

The previous `390 / 350` values were an optical-compensation split — dark-mode text was rendered slightly thinner because text reads as visually thicker on dark backgrounds. The new uniform `400` removes that compensation per design call. Consumer apps that override `font-weight` on `:root` or `.dark` are unaffected.

### Docs site
- Sidebar menu items font-weight `450 → 400` in `DocsLayout.astro`. Body text was inheriting from Anta's tokens, so it picks up the new `400` automatically — no extra change needed.

## Version & changelog
No version bump. `package.json` is at `0.1.1-dev.2`, still unpublished, so this folds in. CHANGELOG entry added under `0.1.1-dev.2` because the body weight is consumer-visible.

## Test plan
- [ ] CI green (build + typecheck + dist parity).
- [ ] Open antadesign.dev (or `cd site && pnpm run dev`) — body text reads as standard regular. Headings, table headers, logo, mobile-menu accents (550, 600 weights) remain unchanged.
- [ ] Sidebar menu items in the docs read at regular 400 (slightly lighter than before's 450).
- [ ] Toggle dark mode — body text now also at 400, no longer thinner than light mode.
- [ ] In a consumer app, install `0.1.1-dev.2` and confirm body text inherits font-weight 400 from `anta_global_tokens.css`.