### PR TITLE
code-block themes follow the docs theme toggle

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -55,6 +55,15 @@ export default defineConfig({
     preact({ compat: true }),
     astroExpressiveCode({
       themes: ['github-light', 'tokyo-night'],
+      // Switch themes by the docs site's `.dark` class on <html>,
+      // not by `prefers-color-scheme`. The theme toggle in the
+      // sidebar lives in user-space — the OS preference is only the
+      // fallback when the user has never toggled — so binding code-
+      // block themes to the media query made them lag behind the
+      // explicit choice. github-light (first in the array) stays as
+      // the unscoped default; tokyo-night applies under `.dark`.
+      useDarkModeMediaQuery: false,
+      themeCssSelector: (theme) => theme.type === 'dark' ? '.dark' : '',
       styleOverrides: {
         borderWidth: '1px',
         borderColor: 'var(--border-1)',


### PR DESCRIPTION
## Summary

`astro-expressive-code` was wrapping the second theme (`tokyo-night`) in `@media (prefers-color-scheme: dark)` — so syntax-highlighted code blocks switched by OS preference, ignoring the docs site's `.dark` toggle. Once the user clicked the theme button away from their OS default, the rest of the page flipped but code blocks stayed on the OS-preferred theme. Visible mismatch.

Configure the integration to scope the dark theme under `.dark` instead:

\`\`\`js
astroExpressiveCode({
  themes: ['github-light', 'tokyo-night'],
  useDarkModeMediaQuery: false,
  themeCssSelector: (theme) => theme.type === 'dark' ? '.dark' : '',
  // …existing styleOverrides…
})
\`\`\`

`github-light` (first in the array) stays the unscoped default; `tokyo-night` applies under `.dark`, matching the rest of the site's theme model. OS preference is still the fallback for users who've never toggled (the head script in `DocsLayout.astro` reads localStorage first, then `prefers-color-scheme`).

## Test plan

- [x] Token colors in a code block flip with the sidebar theme button: light → `rgb(36, 41, 46)` (github-light fg), dark → `rgb(206, 116, 181)` (tokyo-night accent). Verified live.
- [x] No regression in code-block frame styling — `--bg-section` background, `--border-1` border, padding overrides still apply.
- [x] First visit on a fresh browser still honours `prefers-color-scheme` (via the head script).