### PR TITLE
Multi-example playground driven by JSDoc-headed JSX blocks

### DIFF
--- a/site/lib/sandbox/bundler.ts
+++ b/site/lib/sandbox/bundler.ts
@@ -48,7 +48,10 @@ export type BundleResult = BundleSuccess | BundleFailure
  *  If `userStyles` is provided (non-empty), the bundle prepends a
  *  small preamble that injects the styles as a `<style id="user-
  *  styles">` element in the iframe head — replacing any previous one. */
-export async function bundle(userCode: string, userStyles?: string): Promise<BundleResult> {
+export async function bundle(
+  userCode: string,
+  userStyles?: string,
+): Promise<BundleResult> {
   let esbuild: typeof import('esbuild-wasm')
   try {
     esbuild = await ensureInit()
@@ -194,6 +197,17 @@ function wrapWithRender(code: string): string | null {
   if (jsxStart === -1) return null
   const before = lines.slice(0, jsxStart).join('\n').trimEnd()
   let jsxBlock = lines.slice(jsxStart).join('\n').trim().replace(/;?\s*$/, '')
+
+  // Strip every `/** … */` block comment from the JSX region. JSX
+  // treats anything between two sibling JSX nodes that isn't `{…}`
+  // as text — so a JSDoc that lives inside the Fragment would render
+  // as visible text in the preview, not as a JS comment. The
+  // playground uses these JSDocs as metadata for the Props panel and
+  // for source-code readers; they have no role at runtime, so drop
+  // them before the Fragment wrap. (JSDocs in the *preamble* — above
+  // the first `<` line — are left alone; they're regular JS comments
+  // documenting helper functions and never end up inside JSX.)
+  jsxBlock = jsxBlock.replace(/\/\*\*[\s\S]*?\*\//g, '')
 
   // Strip `<script>` tags from the user's JSX block — Preact (like
   // React) renders them as inert DOM nodes the browser refuses to

--- a/site/lib/sandbox/locate-tag.ts
+++ b/site/lib/sandbox/locate-tag.ts
@@ -66,7 +66,7 @@ export function locateOpeningTag(source: string, componentName: string): OpenTag
  * and `{…}` nesting. Returns `null` if the source ends without a
  * closer (malformed JSX during typing — caller will leave code alone).
  */
-function findOpenTagClose(
+export function findOpenTagClose(
   source: string,
   from: number,
 ): { end: number; selfClosing: boolean; markerStart: number } | null {
@@ -103,7 +103,7 @@ function findOpenTagClose(
 }
 
 /** Skip a `{…}` block starting at `i` (which must be `{`). Handles nested braces, strings, templates. */
-function skipBraced(source: string, start: number): number | null {
+export function skipBraced(source: string, start: number): number | null {
   let i = start + 1
   let depth = 1
   while (i < source.length && depth > 0) {
@@ -254,4 +254,46 @@ export function findAttribute(
     return null
   }
   return null
+}
+
+/**
+ * Enumerate the attribute names present on the opening tag in source
+ * order. Skips spread attributes (`{...rest}`), unquoted forms we
+ * don't understand, and obviously malformed cases.
+ */
+export function listAttributes(source: string, open: OpenTagRange): string[] {
+  const names: string[] = []
+  let i = open.attrsStart
+  while (i < open.attrsEnd) {
+    const c = source[i]
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') { i++; continue }
+    if (c === '{') {
+      const j = skipBraced(source, i)
+      if (j == null) break
+      i = j
+      continue
+    }
+    // Identifier characters per JSX attribute names.
+    let nameEnd = i
+    while (nameEnd < open.attrsEnd && /[A-Za-z0-9_$\-:]/.test(source[nameEnd])) nameEnd++
+    if (nameEnd === i) { i++; continue }
+    names.push(source.slice(i, nameEnd))
+    i = nameEnd
+    while (i < open.attrsEnd && (source[i] === ' ' || source[i] === '\t')) i++
+    if (source[i] === '=') {
+      i++
+      while (i < open.attrsEnd && (source[i] === ' ' || source[i] === '\t')) i++
+      const v = source[i]
+      if (v === '"' || v === "'") {
+        const j = skipQuoted(source, i, v)
+        if (j == null) break
+        i = j
+      } else if (v === '{') {
+        const j = skipBraced(source, i)
+        if (j == null) break
+        i = j
+      }
+    }
+  }
+  return names
 }

--- a/site/lib/sandbox/parse-examples.ts
+++ b/site/lib/sandbox/parse-examples.ts
@@ -136,9 +136,15 @@ export function parseExamples(source: string): Example[] {
 }
 
 /** Find a `# Heading` line in the JSDoc body and split it into label
- *  + description. Returns null if there's no heading at all. */
+ *  + description. Returns null if there's no heading at all. The
+ *  heading may sit on the opening `/​**` line (so Monaco's fold range
+ *  keeps the heading visible when the comment is collapsed) or on a
+ *  subsequent ` * ` line — both shapes are recognised. */
 function extractHeading(body: string): { label: string; description: string } | null {
-  const lines = body.split('\n').map((l) => l.replace(/^\s*\*\s?/, ''))
+  // Strip the standard ` * ` JSDoc prefix; on the first line (no
+  // leading `*`) just strip leading whitespace so headings authored
+  // inline with `/​**` are still recognised.
+  const lines = body.split('\n').map((l) => l.replace(/^\s*\*?\s?/, ''))
   let headingIdx = -1
   for (let i = 0; i < lines.length; i++) {
     const m = lines[i].match(/^#\s+(.+?)\s*$/)

--- a/site/lib/sandbox/parse-examples.ts
+++ b/site/lib/sandbox/parse-examples.ts
@@ -1,0 +1,199 @@
+/**
+ * parse-examples.ts — extract JSDoc-headed JSX blocks from playground
+ * source code.
+ *
+ * The authoring model: a single TSX source contains multiple top-level
+ * JSX expressions, each preceded by a `/** … *​/` block comment whose
+ * body starts with a `# Title` markdown heading. Each such pairing is
+ * an "example" the playground surfaces in the Props panel.
+ *
+ * This module does no rendering — it just maps source offsets to
+ * labels / descriptions / JSX ranges. The bundler and the per-example
+ * Props form consume those offsets.
+ */
+import { findOpenTagClose, skipBraced } from './locate-tag.ts'
+
+export interface Example {
+  /** Stable identifier — slug of the label. */
+  id: string
+  /** First `# heading` line in the JSDoc, sans the `#`. */
+  label: string
+  /** Remaining JSDoc body (lines after the `# heading`, joined). */
+  description: string
+  /** Character offsets into the source for the leading JSDoc block. */
+  jsdocStart: number
+  jsdocEnd: number
+  /** Character offsets into the source for the JSX expression that
+   *  follows the JSDoc. */
+  jsxStart: number
+  jsxEnd: number
+  /** What kind of expression follows the JSDoc.
+   *  - `'jsx'`: a `<Tag …>` element — the Props form can bind to
+   *    it and surface that element's literal props.
+   *  - `'expression'`: a `{ … }` container (typically an IIFE
+   *    returning JSX) — too dynamic to bind a form to. The
+   *    accordion entry shows the heading + description only. */
+  kind: 'jsx' | 'expression'
+  /** For `kind: 'jsx'`, the tag name (e.g. `'Progress'` or
+   *  `'AnimatedProgress'`). Drives the form's source of prop
+   *  schema: known components use api.json; unknown ones infer
+   *  fields from the JSX's currently-set attributes. */
+  tagName?: string
+}
+
+/**
+ * Walk the source and return every JSDoc-headed JSX block in order
+ * of appearance. JSDoc comments without a `# heading` first line are
+ * ignored (they're regular documentation, not example markers).
+ */
+export function parseExamples(source: string): Example[] {
+  const out: Example[] = []
+  let i = 0
+  const usedIds = new Set<string>()
+  while (i < source.length) {
+    const blockStart = source.indexOf('/**', i)
+    if (blockStart === -1) break
+    const blockEndDelim = source.indexOf('*/', blockStart + 3)
+    if (blockEndDelim === -1) break
+    const blockEnd = blockEndDelim + 2
+
+    const body = source.slice(blockStart + 3, blockEndDelim)
+    const heading = extractHeading(body)
+    if (!heading) {
+      i = blockEnd
+      continue
+    }
+
+    // An example body is whatever JSX-ish expression follows the
+    // JSDoc — either a plain `<Tag …>` element (Props panel binds
+    // directly to it) or a `{ expression }` container (typically an
+    // IIFE that returns a JSX node; the form scans the inside for
+    // the bound component and surfaces whatever literal props it
+    // finds). Anything else is ignored. The JSDoc is the trigger
+    // for accordion-entry creation.
+    const afterDoc = skipWhitespaceAndComments(source, blockEnd)
+    if (afterDoc == null) {
+      i = blockEnd
+      continue
+    }
+    const first = source[afterDoc]
+    let jsxEnd: number
+    let kind: 'jsx' | 'expression'
+    let tagName: string | undefined
+
+    if (first === '<') {
+      kind = 'jsx'
+      let nameEnd = afterDoc + 1
+      while (nameEnd < source.length && /[A-Za-z0-9_$.]/.test(source[nameEnd])) {
+        nameEnd++
+      }
+      tagName = source.slice(afterDoc + 1, nameEnd)
+      const opening = findOpenTagClose(source, nameEnd)
+      if (!opening) {
+        i = blockEnd
+        continue
+      }
+      if (opening.selfClosing) {
+        jsxEnd = opening.end
+      } else {
+        const closer = `</${tagName}>`
+        const idx = source.indexOf(closer, opening.end)
+        if (idx === -1) {
+          i = blockEnd
+          continue
+        }
+        jsxEnd = idx + closer.length
+      }
+    } else if (first === '{') {
+      kind = 'expression'
+      const end = skipBraced(source, afterDoc)
+      if (end == null) {
+        i = blockEnd
+        continue
+      }
+      jsxEnd = end
+    } else {
+      i = blockEnd
+      continue
+    }
+
+    const id = uniqueId(heading.label, usedIds)
+    out.push({
+      id,
+      label: heading.label,
+      description: heading.description,
+      jsdocStart: blockStart,
+      jsdocEnd: blockEnd,
+      jsxStart: afterDoc,
+      jsxEnd,
+      kind,
+      tagName,
+    })
+    usedIds.add(id)
+    i = jsxEnd
+  }
+  return out
+}
+
+/** Find a `# Heading` line in the JSDoc body and split it into label
+ *  + description. Returns null if there's no heading at all. */
+function extractHeading(body: string): { label: string; description: string } | null {
+  const lines = body.split('\n').map((l) => l.replace(/^\s*\*\s?/, ''))
+  let headingIdx = -1
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(/^#\s+(.+?)\s*$/)
+    if (m) {
+      headingIdx = i
+      break
+    }
+  }
+  if (headingIdx === -1) return null
+  const label = lines[headingIdx].replace(/^#\s+/, '').trim()
+  // Description: every line after the heading, trimmed of leading /
+  // trailing blank lines and joined as a single string.
+  const rest = lines.slice(headingIdx + 1)
+  while (rest.length && rest[0].trim() === '') rest.shift()
+  while (rest.length && rest[rest.length - 1].trim() === '') rest.pop()
+  return { label, description: rest.join('\n').trim() }
+}
+
+/** Advance past whitespace and `//` / `/* … *​/` comments. Returns the
+ *  first index of a non-whitespace, non-comment character, or null
+ *  if the source ends. */
+function skipWhitespaceAndComments(source: string, from: number): number | null {
+  let i = from
+  while (i < source.length) {
+    const c = source[i]
+    if (c === ' ' || c === '\t' || c === '\n' || c === '\r') {
+      i++
+      continue
+    }
+    if (c === '/' && source[i + 1] === '/') {
+      const nl = source.indexOf('\n', i + 2)
+      if (nl === -1) return null
+      i = nl + 1
+      continue
+    }
+    if (c === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2)
+      if (end === -1) return null
+      i = end + 2
+      continue
+    }
+    return i
+  }
+  return null
+}
+
+/** Slug-ify a label, suffixing `-2`, `-3`, … when the same slug
+ *  already exists in `used`. */
+function uniqueId(label: string, used: Set<string>): string {
+  const base = label
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'example'
+  if (!used.has(base)) return base
+  let n = 2
+  while (used.has(`${base}-${n}`)) n++
+  return `${base}-${n}`
+}

--- a/site/lib/sandbox/prop-patch.ts
+++ b/site/lib/sandbox/prop-patch.ts
@@ -26,29 +26,63 @@ export interface PropDescriptor {
  * Replace (or insert or remove) a single attribute of the target
  * element. Returns the new source. If the target element can't be
  * located the original source is returned unchanged.
+ *
+ * When `range` is supplied, the locator is constrained to that slice
+ * of the source — used by the multi-example playground so a form
+ * tied to one example only edits that example's JSX.
  */
 export function replaceProp(
   source: string,
   componentName: string,
   prop: PropDescriptor,
   nextValue: string | number | boolean | null | undefined,
+  range?: { start: number; end: number },
 ): string {
+  if (range) {
+    const slice = source.slice(range.start, range.end)
+    const open = locateOpeningTag(slice, componentName)
+    if (!open) return source
+    const offsetOpen = shiftOpenTag(open, range.start)
+    const existing = findAttribute(source, offsetOpen, prop.name)
+    return applyEdit(source, prop, nextValue, offsetOpen, existing)
+  }
   const open = locateOpeningTag(source, componentName)
   if (!open) return source
-
   const existing = findAttribute(source, open, prop.name)
-  const shouldRemove = isAtDefault(nextValue, prop) || nextValue === '' || nextValue == null
+  return applyEdit(source, prop, nextValue, open, existing)
+}
 
+function applyEdit(
+  source: string,
+  prop: PropDescriptor,
+  nextValue: string | number | boolean | null | undefined,
+  open: ReturnType<typeof locateOpeningTag> & object,
+  existing: ReturnType<typeof findAttribute>,
+): string {
+  const shouldRemove = isAtDefault(nextValue, prop) || nextValue === '' || nextValue == null
   if (shouldRemove) {
     if (!existing) return source
     return removeAttribute(source, existing.start, existing.end)
   }
-
-  const serialized = serializeAttribute(prop, nextValue)
+  const serialized = serializeAttribute(prop, nextValue!)
   if (existing) {
     return source.slice(0, existing.start) + serialized + source.slice(existing.end)
   }
   return insertAttribute(source, open, serialized)
+}
+
+function shiftOpenTag(
+  open: NonNullable<ReturnType<typeof locateOpeningTag>>,
+  delta: number,
+): NonNullable<ReturnType<typeof locateOpeningTag>> {
+  return {
+    start: open.start + delta,
+    end: open.end + delta,
+    selfClosing: open.selfClosing,
+    text: open.text,
+    attrsStart: open.attrsStart + delta,
+    attrsEnd: open.attrsEnd + delta,
+  }
 }
 
 function isAtDefault(value: unknown, prop: PropDescriptor): boolean {

--- a/site/lib/sandbox/prop-read.ts
+++ b/site/lib/sandbox/prop-read.ts
@@ -21,9 +21,29 @@ export type ReadResult = { kind: 'literal'; value: string | number | boolean } |
  *   - undefined if the attribute isn't present at all — the form should
  *     show its default value.
  */
-export function readProp(source: string, componentName: string, prop: PropDescriptor): ReadResult {
-  const open = locateOpeningTag(source, componentName)
-  if (!open) return undefined
+export function readProp(
+  source: string,
+  componentName: string,
+  prop: PropDescriptor,
+  range?: { start: number; end: number },
+): ReadResult {
+  let open
+  if (range) {
+    const slice = source.slice(range.start, range.end)
+    const localOpen = locateOpeningTag(slice, componentName)
+    if (!localOpen) return undefined
+    open = {
+      start: localOpen.start + range.start,
+      end: localOpen.end + range.start,
+      selfClosing: localOpen.selfClosing,
+      text: localOpen.text,
+      attrsStart: localOpen.attrsStart + range.start,
+      attrsEnd: localOpen.attrsEnd + range.start,
+    }
+  } else {
+    open = locateOpeningTag(source, componentName)
+    if (!open) return undefined
+  }
   const attr = findAttribute(source, open, prop.name)
   if (!attr) return undefined
 

--- a/site/lib/sandbox/props-form.ts
+++ b/site/lib/sandbox/props-form.ts
@@ -11,6 +11,12 @@
  */
 import api from '../../src/api.json'
 import type { PropDescriptor } from './prop-patch.ts'
+import { findAttribute, listAttributes, locateOpeningTag } from './locate-tag.ts'
+
+/** Framework-internal props that have no place on a documentation
+ *  surface — they're plumbing for the renderer, not part of the
+ *  component's authored API. */
+const EXCLUDED_PROP_NAMES = new Set(['key', 'ref'])
 
 export type Control =
   | { kind: 'slider'; name: string; min: number; max: number; step: number; defaultValue?: number; description?: string }
@@ -18,6 +24,11 @@ export type Control =
   | { kind: 'text'; name: string; defaultValue?: string; description?: string }
   | { kind: 'boolean'; name: string; defaultValue?: boolean; description?: string }
   | { kind: 'segmented'; name: string; options: string[]; defaultValue?: string; description?: string }
+  /** Read-only entry for props we can't drive with a generic input
+   *  — `children`, `style`, `ReactNode`, named references, etc. The
+   *  form renders the name + type + description so the prop is
+   *  documented in place, without offering an edit affordance. */
+  | { kind: 'documentation'; name: string; type: string; description?: string }
 
 export interface PropEntry {
   control: Control
@@ -35,11 +46,14 @@ export function controlsFor(componentName: string): PropEntry[] {
   const iface = root.children?.find((c: any) => c.name === ifaceName)
   if (!iface) return []
 
-  // Component-own props come first; `className` rides along even
-  // though it's inherited from BaseProps, because typing into it is
-  // how the playground unlocks the CSS tab.
+  // Include component-own props plus inherited props from BaseProps
+  // (`className`, `style`, `children`). The former get full editors;
+  // the latter typically render as `documentation` rows so the form
+  // doubles as a complete prop reference — that's why a separate
+  // static Props table isn't needed on the docs page. Framework
+  // plumbing (`key`, `ref`) stays out.
   const props = (iface.children ?? []).filter(
-    (p: any) => !p.inheritedFrom || p.name === 'className',
+    (p: any) => !EXCLUDED_PROP_NAMES.has(p.name),
   )
 
   const entries: PropEntry[] = []
@@ -66,10 +80,6 @@ function controlFor(p: any): PropEntry | null {
   // `intrinsic` types: string / number / boolean.
   if (t.type === 'intrinsic') {
     if (t.name === 'number') {
-      // All numeric props render as a plain number input. A slider
-      // variant lived here for `value`-style props, but we can't yet
-      // infer min/max from sibling props (e.g. Progress's `max`), and
-      // a slider with hardcoded 0..100 misled users on other ranges.
       return wrap(
         { kind: 'number', name, description },
         { name, kind: 'number' },
@@ -87,7 +97,7 @@ function controlFor(p: any): PropEntry | null {
         { name, kind: 'boolean' },
       )
     }
-    return null
+    // Fall through to the documentation row for anything else.
   }
 
   // `union` of all `literal` members → segmented buttons.
@@ -95,19 +105,51 @@ function controlFor(p: any): PropEntry | null {
     const literals = t.types.filter((x: any) => x.type === 'literal' && typeof x.value === 'string')
     if (literals.length === t.types.length && literals.length > 0) {
       const options = literals.map((x: any) => String(x.value))
-      // Heuristic: first option is typically the default (matches Anta's
-      // pattern of `tone?: 'neutral' | 'info'` — neutral first).
       const defaultValue = options[0]
       return wrap(
         { kind: 'segmented', name, options, defaultValue, description },
         { name, kind: 'literal-union', defaultValue },
       )
     }
-    return null
+    // Fall through.
   }
 
-  // Anything else (ReactNode, CSSProperties, named references) — v1 skip.
-  return null
+  // Anything else — `ReactNode`, `CSSProperties`, named references,
+  // intersection / mapped types, etc. Surface as a documentation
+  // row: name + rendered type + description, no input. Lets the
+  // panel double as the prop reference, eliminating the need for a
+  // separate Props table beneath the playground.
+  return wrap(
+    { kind: 'documentation', name, type: renderType(t), description },
+    // PropDescriptor isn't meaningful for read-only docs; use a
+    // placeholder that the form's onChange path never references.
+    { name, kind: 'string' },
+  )
+}
+
+/** Render a TypeDoc type node as a short, human-readable string —
+ *  shared format with `PropsTable.astro` so the playground reads
+ *  the same way as the static reference table did. */
+function renderType(type: any): string {
+  if (!type) return '—'
+  switch (type.type) {
+    case 'intrinsic':
+      return type.name
+    case 'literal':
+      return typeof type.value === 'string' ? `'${type.value}'` : String(type.value)
+    case 'union':
+      return type.types.map(renderType).join(' | ')
+    case 'reference':
+      if (type.name) return type.name
+      return '—'
+    case 'array':
+      return `${renderType(type.elementType)}[]`
+    case 'typeOperator':
+      if (type.operator === 'keyof' && type.target?.name === 'IconShapes') return 'IconShape'
+      return `${type.operator} ${renderType(type.target)}`
+    default:
+      return type.name || '—'
+  }
 }
 
 function renderComment(comment: any): string | undefined {
@@ -117,4 +159,98 @@ function renderComment(comment: any): string | undefined {
     .join('')
     .trim()
   return text || undefined
+}
+
+/** Derive a Control schema for a JSX example by introspecting the
+ *  tag in the source. Two paths:
+ *
+ *  1. If `tagName` is documented in `api.json` (e.g. `Progress`),
+ *     return its full schema via `controlsFor`.
+ *  2. Otherwise, walk the opening tag's attributes and emit a
+ *     control per attribute whose value we can infer a kind from
+ *     (string / number / boolean). Useful when the example uses a
+ *     local helper component (`AnimatedProgress`) defined in the
+ *     preamble — we can't know its full prop surface, but we can
+ *     surface whatever the JSX is currently passing.
+ *
+ *  Both paths filter out `children`, `style`, `key`, `ref`. */
+export function controlsForExample(
+  tagName: string,
+  source: string,
+  range: { start: number; end: number },
+): PropEntry[] {
+  const known = controlsFor(tagName)
+  if (known.length > 0) {
+    return known.filter((e) => !EXCLUDED_PROP_NAMES.has(e.control.name))
+  }
+  return controlsFromJsxAttributes(tagName, source, range)
+}
+
+function controlsFromJsxAttributes(
+  tagName: string,
+  source: string,
+  range: { start: number; end: number },
+): PropEntry[] {
+  const slice = source.slice(range.start, range.end)
+  const open = locateOpeningTag(slice, tagName)
+  if (!open) return []
+  // Translate slice-local OpenTagRange back to absolute coordinates
+  // so findAttribute matches `source` indexes.
+  const absOpen = {
+    start: open.start + range.start,
+    end: open.end + range.start,
+    selfClosing: open.selfClosing,
+    text: open.text,
+    attrsStart: open.attrsStart + range.start,
+    attrsEnd: open.attrsEnd + range.start,
+  }
+  const names = listAttributes(source, absOpen)
+  const entries: PropEntry[] = []
+  const seen = new Set<string>()
+  for (const name of names) {
+    if (EXCLUDED_PROP_NAMES.has(name) || seen.has(name)) continue
+    seen.add(name)
+    const attr = findAttribute(source, absOpen, name)
+    if (!attr) continue
+    const kind = inferAttributeKind(attr)
+    if (!kind) continue
+    if (kind === 'number') {
+      entries.push({
+        prop: { name, kind: 'number' },
+        control: { kind: 'number', name },
+        optional: true,
+      })
+    } else if (kind === 'boolean') {
+      entries.push({
+        prop: { name, kind: 'boolean' },
+        control: { kind: 'boolean', name },
+        optional: true,
+      })
+    } else {
+      entries.push({
+        prop: { name, kind: 'string' },
+        control: { kind: 'text', name },
+        optional: true,
+      })
+    }
+  }
+  return entries
+}
+
+/** Infer a kind for an attribute by sniffing its value text.
+ *  Returns null if we don't recognise the value at all (e.g. spread
+ *  or unparseable expression). */
+function inferAttributeKind(
+  attr: { valueRange: { kind: 'string' | 'expression'; text: string } | null },
+): 'string' | 'number' | 'boolean' | null {
+  if (!attr.valueRange) return 'boolean'
+  if (attr.valueRange.kind === 'string') return 'string'
+  const inner = attr.valueRange.text.slice(1, -1).trim()
+  if (/^-?\d+(\.\d+)?$/.test(inner)) return 'number'
+  if (inner === 'true' || inner === 'false') return 'boolean'
+  // String wrapped in `{'…'}` or `{"…"}` literal.
+  if (/^(['"`]).*\1$/.test(inner)) return 'string'
+  // Unrecognised expression — show as text so the user can still see it
+  // (and the field will read as "set by code" via readProp's expression path).
+  return 'string'
 }

--- a/site/src/components/InteractiveDemo.module.css
+++ b/site/src/components/InteractiveDemo.module.css
@@ -103,10 +103,11 @@
   background: var(--bg-pane);
   display: flex;
   flex-direction: column;
-  /* Floor on the panel height (the `--demo-panel-min` inline var is
-     set from the panelHeight prop, default 400). The panel grows
-     past this floor when its content needs more space. */
-  min-height: var(--demo-panel-min, 400px);
+  /* Fixed height (the `--demo-panel-h` inline var is set from the
+     panelHeight prop, default 400). Content that exceeds this height
+     scrolls internally — no special handling, just regular HTML
+     overflow rules. */
+  height: var(--demo-panel-h, 400px);
   /* Clip Monaco's canvas to the rounded corners. Hover / suggestion
      popups escape via `fixedOverflowWidgets` in the editor options. */
   overflow: hidden;
@@ -243,6 +244,82 @@
   pointer-events: none;
 }
 
+/* List of JSDoc-headed examples. Scrolls when there's more than the
+   panel can show; section dividers come from each example's
+   border-bottom. */
+.examplesList {
+  flex: 1;
+  min-height: 0;
+  min-width: 0;
+  overflow-y: auto;
+}
+
+.example {
+  border-bottom: 1px solid var(--border-1);
+}
+.example:last-child {
+  border-bottom: none;
+}
+
+/* Header is the whole clickable strip — chevron + label, takes the
+   full width so the hit area covers the row. Matches the tab strip's
+   visual rhythm (12px font, uppercase, 0.06em tracking). */
+.exampleHeader {
+  appearance: none;
+  border: none;
+  background: transparent;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 12px 10px 8px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-3);
+  cursor: pointer;
+  user-select: none;
+  -webkit-user-select: none;
+  text-align: left;
+  transition: color 120ms ease-out;
+}
+
+.exampleHeader:hover,
+.exampleHeader:focus-visible {
+  color: var(--text-1);
+  outline: none;
+}
+
+.exampleHeaderOpen {
+  color: var(--text-2);
+}
+
+/* Chevron shape is swapped between `chevron-right` (collapsed) and
+   `chevron-down` (expanded) by the JSX, so no rotation needed. */
+.exampleChevron {
+  flex-shrink: 0;
+}
+
+.exampleLabel {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.exampleBody {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-bottom: 4px;
+}
+
+.exampleDescription {
+  padding: 0 12px;
+  font-size: 12px;
+  color: var(--text-3);
+  white-space: pre-wrap;
+}
+
 .form {
   padding: 12px;
   display: flex;
@@ -282,6 +359,14 @@
 }
 
 .fieldValueLabel {
+  font-family: var(--monospace);
+  font-size: 12px;
+  color: var(--text-3);
+}
+
+/* Documentation row — read-only type for complex props (children,
+   style, ReactNode, …). Renders the type in monospace; no input. */
+.docType {
   font-family: var(--monospace);
   font-size: 12px;
   color: var(--text-3);

--- a/site/src/components/InteractiveDemo.tsx
+++ b/site/src/components/InteractiveDemo.tsx
@@ -447,37 +447,15 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
                     onMonacoMount(editor, monaco)
                     installJsxAwareCommentToggle(editor, monaco)
                     editor.layout()
-                    // Collapse every code fold region on first mount,
-                    // but keep JSDoc block comments expanded so
-                    // example labels + descriptions stay readable.
-                    // Monaco has `foldAllBlockComments` but no
-                    // symmetric `unfoldAllBlockComments`, so instead
-                    // of folding everything and un-folding comments,
-                    // talk to the folding controller directly: each
-                    // region exposes a `getType(i)` ('comment' for
-                    // JSDoc, undefined for code blocks). Collect the
-                    // non-comment regions and collapse them in one
-                    // `toggleCollapseState` call. Deferred so the
-                    // language service has time to compute ranges.
+                    // Collapse every foldable region on first mount.
+                    // The authoring convention is to put the `# Heading`
+                    // on the opening `/​**` line, which Monaco keeps
+                    // visible when the comment is folded — so the
+                    // example label stays readable while the body
+                    // collapses away. Deferred so the language service
+                    // has time to compute fold ranges before we run.
                     setTimeout(() => {
-                      const controller = editor.getContribution(
-                        'editor.contrib.folding',
-                      ) as any
-                      const promise = controller?.getFoldingModel?.()
-                      if (!promise) return
-                      Promise.resolve(promise).then((foldingModel: any) => {
-                        if (!foldingModel) return
-                        const regions = foldingModel.regions
-                        const toCollapse: any[] = []
-                        for (let i = 0; i < regions.length; i++) {
-                          if (regions.getType(i) === 'comment') continue
-                          if (regions.isCollapsed(i)) continue
-                          toCollapse.push(regions.toRegion(i))
-                        }
-                        if (toCollapse.length > 0) {
-                          foldingModel.toggleCollapseState(toCollapse)
-                        }
-                      })
+                      editor.getAction('editor.foldAll')?.run()
                     }, 400)
                   }}
                   options={editorOptions(monoFontFamily)}

--- a/site/src/components/InteractiveDemo.tsx
+++ b/site/src/components/InteractiveDemo.tsx
@@ -19,11 +19,12 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import s from './InteractiveDemo.module.css'
 
-import { controlsFor, type Control, type PropEntry } from '../../lib/sandbox/props-form.ts'
+import { controlsFor, controlsForExample, type Control, type PropEntry } from '../../lib/sandbox/props-form.ts'
 import { bundle, type BundleResult } from '../../lib/sandbox/bundler.ts'
 import { getDemoModules } from '../../lib/sandbox/modules.ts'
 import { replaceProp } from '../../lib/sandbox/prop-patch.ts'
 import { readProp } from '../../lib/sandbox/prop-read.ts'
+import { parseExamples, type Example } from '../../lib/sandbox/parse-examples.ts'
 
 /** Path served from `site/public/`. The script is a self-contained
  *  browser ESM bundle of @antadesign/anta/elements + per-element CSS;
@@ -53,46 +54,13 @@ interface Props {
 
 type Tab = 'props' | 'code' | 'css'
 
-/** Read the bound component's `className` attribute from the user's
- *  source. If it's a non-empty literal string, return that name —
- *  used to (a) decide whether to surface the CSS tab and (b) seed
- *  the CSS editor with a `.<name> { }` skeleton on first appearance. */
-function readClassNameLiteral(code: string, component: string): string | null {
-  const r = readProp(code, component, { name: 'className', kind: 'string' })
-  if (r?.kind === 'literal' && typeof r.value === 'string' && r.value.trim()) {
-    return r.value.trim()
-  }
-  return null
-}
-
-/** Make sure the CSS source contains a rule whose selector is
- *  `.<className>` — the first class rule we find is repointed to
- *  this name (preserving its body), and if no class rule exists at
- *  all we prepend an empty one. The rest of the CSS is left
- *  untouched. */
-function ensureClassRule(css: string, className: string): string {
-  // Match the FIRST `.<ident> {` selector in the source. CSS class
-  // names can contain word chars and hyphens, can't start with a digit.
-  const re = /\.([a-zA-Z_][\w-]*)(\s*\{)/
-  const m = re.exec(css)
-  if (m) {
-    if (m[1] === className) return css
-    const start = m.index
-    const tail = css.slice(start + m[0].length)
-    return css.slice(0, start) + `.${className}${m[2]}` + tail
-  }
-  return `.${className} {\n  \n}\n${css}`
-}
-
 export default function InteractiveDemo({ component, initialCode, layout = 'stacked', panelHeight = 400 }: Props) {
   const [code, setCode] = useState(initialCode)
-  // CSS state is independent of the code. We seed it once on mount
-  // from whatever className the initialCode already declares, then
-  // the user owns it.
-  const [styles, setStyles] = useState<string>(() => {
-    const name = readClassNameLiteral(initialCode, component)
-    return name ? `.${name} {\n  \n}\n` : ''
-  })
+  // CSS state is independent of the code — the user owns it. The CSS
+  // tab is unconditionally available; no auto-seed from any className
+  // in the JSX. If a user wants to style a class, they write the rule
+  // by hand and add `className="…"` themselves.
+  const [styles, setStyles] = useState<string>('')
   const [bundleState, setBundleState] = useState<BundleResult | { ok: false; message: string; pending: true } | null>({
     ok: false,
     message: 'Compiling…',
@@ -117,36 +85,11 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
   const tsxHostRef = useRef<HTMLDivElement | null>(null)
   const cssHostRef = useRef<HTMLDivElement | null>(null)
 
-  // First class token of the bound component's `className`. We only
-  // ever pay attention to the first whitespace-separated class —
-  // any others the user lists are ignored by the CSS surface.
-  const firstClass = (readClassNameLiteral(code, component) ?? '').split(/\s+/)[0] ?? ''
-  const hasClassName = firstClass !== ''
-
-  // If the className disappears while the CSS tab was active, snap
-  // back to Props so we don't end up showing a hidden tab.
-  useEffect(() => {
-    if (!hasClassName && tab === 'css') setTab('props')
-  }, [hasClassName, tab])
-
-  // Track CSS in a ref so the className-watcher effect can read the
-  // latest value without re-running on every CSS edit.
-  const stylesRef = useRef(styles)
-  useEffect(() => { stylesRef.current = styles }, [styles])
-
-  // One-directional sync: when the className (first token) changes,
-  // make sure a `.<className>` rule exists in the CSS. If the CSS
-  // already has a first class rule, repoint its selector to the new
-  // name (body preserved). If there's no class rule at all, prepend
-  // an empty one. We never touch any other CSS the user wrote.
-  const prevClassRef = useRef<string>(firstClass)
-  useEffect(() => {
-    if (firstClass === prevClassRef.current) return
-    prevClassRef.current = firstClass
-    if (!firstClass) return
-    const next = ensureClassRule(stylesRef.current, firstClass)
-    if (next !== stylesRef.current) setStyles(next)
-  }, [firstClass])
+  // Parse JSDoc-headed JSX blocks out of the user's source. Each
+  // headed block becomes one entry in the Props accordion; the
+  // bundler also receives this list so it can strip JSDocs before
+  // wrapping the JSX in a Fragment.
+  const examples = useMemo(() => parseExamples(code), [code])
 
   // Track the parent's dark-mode state — drives both Monaco's theme
   // and the resolved value of --bg-section.
@@ -189,7 +132,7 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
     if (tsxHost) ro.observe(tsxHost)
     if (cssHost) ro.observe(cssHost)
     return () => ro.disconnect()
-  }, [monacoLib, hasClassName])
+  }, [monacoLib])
 
 
   // Resolve Anta's --monospace token for Monaco's fontFamily option —
@@ -285,13 +228,33 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  function handleFormChange(prop: PropEntry, value: string | number | boolean | null) {
+  function handleFormChange(
+    prop: PropEntry,
+    value: string | number | boolean | null,
+    exampleId?: string,
+  ) {
     // Compute the next code from the LATEST committed state via the
     // functional setter form. A stale closure (e.g. the user pasted
     // into Monaco while React had not yet committed the resulting
     // state) would otherwise resurrect an older source and wipe the
-    // paste.
-    setCode((prev) => replaceProp(prev, component, prop.prop, value))
+    // paste. When an exampleId is supplied, re-parse inside the
+    // updater so the range we patch is up-to-date with whatever the
+    // latest source looks like — example boundaries shift as the
+    // file grows. The bound tag name comes from the example itself,
+    // not the global `component` prop — examples can use any tag
+    // (`Progress`, `AnimatedProgress`, …) and the form binds to
+    // whichever one the example declared.
+    setCode((prev) => {
+      if (!exampleId) {
+        return replaceProp(prev, component, prop.prop, value)
+      }
+      const latest = parseExamples(prev).find((e) => e.id === exampleId)
+      if (!latest || !latest.tagName) return prev
+      return replaceProp(prev, latest.tagName, prop.prop, value, {
+        start: latest.jsxStart,
+        end: latest.jsxEnd,
+      })
+    })
   }
 
   // ────────────────────────────────────────────────────────────────
@@ -373,7 +336,7 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
           />
         )}
 
-        <div class={s.panel} style={{ '--demo-panel-min': `${panelHeight}px` } as any}>
+        <div class={s.panel} style={{ '--demo-panel-h': `${panelHeight}px` } as any}>
           <div class={s.tabs} role="tablist">
             <button
               type="button"
@@ -393,17 +356,15 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
             >
               <span class={s.tabLabel}>Code</span>
             </button>
-            {hasClassName && (
-              <button
-                type="button"
-                role="tab"
-                aria-selected={tab === 'css'}
-                class={tab === 'css' ? `${s.tabBtn} ${s.tabBtnActive}` : s.tabBtn}
-                onClick={() => setTab('css')}
-              >
-                <span class={s.tabLabel}>CSS</span>
-              </button>
-            )}
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'css'}
+              class={tab === 'css' ? `${s.tabBtn} ${s.tabBtnActive}` : s.tabBtn}
+              onClick={() => setTab('css')}
+            >
+              <span class={s.tabLabel}>CSS</span>
+            </button>
             {/* Reset edits to props / code. CSS is intentionally
                 preserved — the user owns it independently. */}
             <button
@@ -427,20 +388,37 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
               aria-hidden={tab !== 'props'}
               {...(tab !== 'props' ? { inert: '' } : {})}
             >
-              <div class={s.form}>
-                {controls.length === 0 && (
-                  <div class={s.fieldHint}>No props detected for {component}. Check api.json.</div>
-                )}
-                {controls.map((entry) => (
-                  <FormField
-                    key={entry.control.name}
-                    entry={entry}
-                    code={code}
-                    componentName={component}
-                    onChange={(v) => handleFormChange(entry, v)}
-                  />
-                ))}
-              </div>
+              {examples.length === 0 ? (
+                /* No JSDoc-headed examples in source — render a single
+                   anonymous form bound to the whole code. Backwards-
+                   compatible with the previous single-example flow. */
+                <div class={s.form}>
+                  {controls.length === 0 && (
+                    <div class={s.fieldHint}>No props detected for {component}. Check api.json.</div>
+                  )}
+                  {controls.map((entry) => (
+                    <FormField
+                      key={entry.control.name}
+                      entry={entry}
+                      code={code}
+                      componentName={component}
+                      onChange={(v) => handleFormChange(entry, v)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div class={s.examplesList}>
+                  {examples.map((ex, i) => (
+                    <ExampleAccordion
+                      key={ex.id}
+                      example={ex}
+                      defaultOpen={i === 0}
+                      code={code}
+                      onChange={handleFormChange}
+                    />
+                  ))}
+                </div>
+              )}
             </div>
             <div
               class={tab === 'code' ? s.tabPanel : `${s.tabPanel} ${s.tabPanelHidden}`}
@@ -469,6 +447,38 @@ export default function InteractiveDemo({ component, initialCode, layout = 'stac
                     onMonacoMount(editor, monaco)
                     installJsxAwareCommentToggle(editor, monaco)
                     editor.layout()
+                    // Collapse every code fold region on first mount,
+                    // but keep JSDoc block comments expanded so
+                    // example labels + descriptions stay readable.
+                    // Monaco has `foldAllBlockComments` but no
+                    // symmetric `unfoldAllBlockComments`, so instead
+                    // of folding everything and un-folding comments,
+                    // talk to the folding controller directly: each
+                    // region exposes a `getType(i)` ('comment' for
+                    // JSDoc, undefined for code blocks). Collect the
+                    // non-comment regions and collapse them in one
+                    // `toggleCollapseState` call. Deferred so the
+                    // language service has time to compute ranges.
+                    setTimeout(() => {
+                      const controller = editor.getContribution(
+                        'editor.contrib.folding',
+                      ) as any
+                      const promise = controller?.getFoldingModel?.()
+                      if (!promise) return
+                      Promise.resolve(promise).then((foldingModel: any) => {
+                        if (!foldingModel) return
+                        const regions = foldingModel.regions
+                        const toCollapse: any[] = []
+                        for (let i = 0; i < regions.length; i++) {
+                          if (regions.getType(i) === 'comment') continue
+                          if (regions.isCollapsed(i)) continue
+                          toCollapse.push(regions.toRegion(i))
+                        }
+                        if (toCollapse.length > 0) {
+                          foldingModel.toggleCollapseState(toCollapse)
+                        }
+                      })
+                    }, 400)
                   }}
                   options={editorOptions(monoFontFamily)}
                 />
@@ -539,15 +549,17 @@ function FormField({
   entry,
   code,
   componentName,
+  range,
   onChange,
 }: {
   entry: PropEntry
   code: string
   componentName: string
+  range?: { start: number; end: number }
   onChange: (v: string | number | boolean | null) => void
 }) {
   const c = entry.control
-  const read = readProp(code, componentName, entry.prop)
+  const read = readProp(code, componentName, entry.prop, range)
   const fromExpression = read?.kind === 'expression'
   // Only the literal in code populates the input; the default is
   // shown as a placeholder instead so the user can tell what Anta
@@ -663,7 +675,91 @@ function FieldControl({
         </div>
       )
     }
+    case 'documentation':
+      // Read-only documentation row — no input, just the type
+      // string so the panel doubles as a prop reference.
+      return (
+        <div class={s.docType}>
+          <code>{control.type}</code>
+        </div>
+      )
   }
+}
+
+// One accordion entry in the Props panel — collapsible section
+// per JSDoc-headed example. Sections are independent (multiple can
+// be open at once). Each section's form is range-bound so its edits
+// only touch that example's JSX. We capture `example.id` in the
+// onChange closure and look up the latest range at edit time
+// (see `handleFormChange` for the re-parse-on-update flow).
+function ExampleAccordion({
+  example,
+  defaultOpen,
+  code,
+  onChange,
+}: {
+  example: Example
+  defaultOpen: boolean
+  code: string
+  onChange: (entry: PropEntry, value: string | number | boolean | null, exampleId: string) => void
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  // Per-example control schema. JSX examples introspect their tag:
+  // known components (api.json) get their full prop set; unknown
+  // tags fall back to attribute inference from the JSX itself.
+  // Expression examples don't drive a form.
+  const controls = useMemo(() => {
+    if (example.kind !== 'jsx' || !example.tagName) return []
+    return controlsForExample(example.tagName, code, {
+      start: example.jsxStart,
+      end: example.jsxEnd,
+    })
+  }, [example.tagName, example.kind, example.jsxStart, example.jsxEnd, code])
+
+  return (
+    <div class={s.example}>
+      <button
+        type="button"
+        class={open ? `${s.exampleHeader} ${s.exampleHeaderOpen}` : s.exampleHeader}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <a-icon
+          shape={open ? 'chevron-down' : 'chevron-right'}
+          class={s.exampleChevron}
+          style={{ '--icon-size': '14px' } as any}
+        />
+        <span class={s.exampleLabel}>{example.label}</span>
+      </button>
+      {open && (
+        <div class={s.exampleBody}>
+          {example.description && (
+            <div class={s.exampleDescription}>{example.description}</div>
+          )}
+          {/* The Props form binds only when the example body is a
+              plain `<Tag …>` element — `{}` expression bodies
+              (IIFEs, inline components) are too dynamic to bind to.
+              The accordion entry still shows heading + description
+              for documented examples; the user edits the JSX in the
+              Code tab if they want to change anything. */}
+          {example.kind === 'jsx' && controls.length > 0 && (
+            <div class={s.form}>
+              {controls.map((entry) => (
+                <FormField
+                  key={entry.control.name}
+                  entry={entry}
+                  code={code}
+                  componentName={example.tagName!}
+                  range={{ start: example.jsxStart, end: example.jsxEnd }}
+                  onChange={(v) => onChange(entry, v, example.id)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ──────────────────────────────────────────────────────────────────
@@ -678,8 +774,20 @@ function FieldControl({
 const IFRAME_SRCDOC = `<!DOCTYPE html><html class="dark"><head><meta charset="utf-8"><style>
   html, body { margin: 0; background: var(--bg-base, #100e11); font-family: var(--sans-serif, sans-serif); }
   body { padding: 24px; overflow: auto; box-sizing: border-box; min-height: 100%; }
-  #root { display: block; }
-</style></head><body><div id="root"></div></body></html>`
+  /* Preview default layout: a column-flex with 16px gap so multiple
+     examples stack vertically with consistent breathing room. The
+     rule lives under a .preview class so users can re-declare it
+     from their own CSS to change the layout. Single-example renders
+     are unaffected — one column-flex child looks identical to a
+     block child. Scoped to #root inside the iframe; never touches
+     the docs-site DOM. */
+  .preview {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+  }
+</style></head><body><div id="root" class="preview"></div></body></html>`
 
 function setupIframe(iframe: HTMLIFrameElement) {
   const doc = iframe.contentDocument

--- a/site/src/pages/components/progress.demo.ts
+++ b/site/src/pages/components/progress.demo.ts
@@ -21,39 +21,29 @@ function AnimatedProgress({ speed = 1 }) {
   return <Progress value={v} label="Animated" />
 }
 
-/**
- * # Basic
+/** # Basic
  * The minimum invocation — just a value.
  */
 <Progress value={60} />
 
-/**
- * # With label and hint
+/** # With label and hint
  * Pair the progress value with a descriptive label and right-aligned hint.
  */
 <Progress value={42} label="Uploading files…" hint="3 of 7" />
 
-/**
- * # Info tone
+/** # Info tone
  * \`tone="info"\` re-tints every internal color via the global \`--*-info\` token cascade.
  */
 <Progress value={75} tone="info" label="Processing" />
 
-/**
- * # With a border
+/** # With a border
  * The host pre-declares \`border: 0px solid var(--progress-border-color)\` — colour
  * and style are wired, width is zero. Give it any width to opt in. The colour
  * auto-tracks the tone (e.g. \`--border-2-info\` for \`tone="info"\`).
  */
-<Progress
-  value={60}
-  label="Uploading"
-  hint="3 of 5"
-  style={{ borderBottomWidth: '1px' }}
-/>
+<Progress value={60} label="Uploading" hint="3 of 5" style={{ borderBottomWidth: '1px' }} />
 
-/**
- * # Animated
+/** # Animated
  * \`AnimatedProgress\` is declared in the preamble above. The Props form
  * sees only what the JSX explicitly passes — here, \`speed\` — because the
  * helper isn't in api.json. Try changing it.

--- a/site/src/pages/components/progress.demo.ts
+++ b/site/src/pages/components/progress.demo.ts
@@ -1,0 +1,62 @@
+/**
+ * Demo source code for the Progress playground.
+ *
+ * This file exists only so the template literal's whitespace is
+ * preserved verbatim. When the same string is inlined as a JSX
+ * attribute in the `.mdx` page, Astro's MDX pipeline strips a layer
+ * of common-leading-whitespace, which scrambles the indentation
+ * Monaco needs for folding ranges. A plain `.ts` file routes
+ * through Vite without that transform.
+ */
+export default `import { Progress } from '@antadesign/anta'
+import { useState, useEffect } from 'preact/hooks'
+
+// Reusable helper — declared once in the preamble, used by any JSX example below.
+function AnimatedProgress({ speed = 1 }) {
+  const [v, setV] = useState(0)
+  useEffect(() => {
+    const id = setInterval(() => setV((x) => (x + speed) % 101), 50)
+    return () => clearInterval(id)
+  }, [speed])
+  return <Progress value={v} label="Animated" />
+}
+
+/**
+ * # Basic
+ * The minimum invocation — just a value.
+ */
+<Progress value={60} />
+
+/**
+ * # With label and hint
+ * Pair the progress value with a descriptive label and right-aligned hint.
+ */
+<Progress value={42} label="Uploading files…" hint="3 of 7" />
+
+/**
+ * # Info tone
+ * \`tone="info"\` re-tints every internal color via the global \`--*-info\` token cascade.
+ */
+<Progress value={75} tone="info" label="Processing" />
+
+/**
+ * # With a border
+ * The host pre-declares \`border: 0px solid var(--progress-border-color)\` — colour
+ * and style are wired, width is zero. Give it any width to opt in. The colour
+ * auto-tracks the tone (e.g. \`--border-2-info\` for \`tone="info"\`).
+ */
+<Progress
+  value={60}
+  label="Uploading"
+  hint="3 of 5"
+  style={{ borderBottomWidth: '1px' }}
+/>
+
+/**
+ * # Animated
+ * \`AnimatedProgress\` is declared in the preamble above. The Props form
+ * sees only what the JSX explicitly passes — here, \`speed\` — because the
+ * helper isn't in api.json. Try changing it.
+ */
+<AnimatedProgress speed={2} />
+`

--- a/site/src/pages/components/progress.mdx
+++ b/site/src/pages/components/progress.mdx
@@ -3,8 +3,12 @@ layout: ../../layouts/DocsLayout.astro
 title: Progress
 ---
 import InteractiveDemo from '../../components/InteractiveDemo'
-import ProgressDemo from '../../components/ProgressDemo'
-import PropsTable from '../../components/PropsTable.astro'
+// The demo source lives in a sibling `.ts` file rather than inline
+// here because Astro's MDX pipeline trims leading whitespace from
+// JSX-attribute template literals, which scrambles the indentation
+// Monaco needs for folding ranges. A regular module import preserves
+// the template literal's bytes verbatim.
+import progressDemoCode from './progress.demo.ts'
 
 # Progress
 
@@ -15,52 +19,8 @@ A progress indicator for displaying task completion. Consists of a track
   client:load
   component="Progress"
   layout="side"
-  initialCode={`import { Progress } from '@antadesign/anta'
-
-<Progress value={42} label="Uploading files…" hint="3 of 7" />
-`}
+  initialCode={progressDemoCode}
 />
-
-## Props
-
-<PropsTable component="Progress" />
-
-## Examples
-
-### Basic
-
-```tsx
-<Progress value={60} />
-```
-
-### With label and hint
-
-```tsx
-<Progress value={42} label="Uploading files..." hint="3 of 7" />
-```
-
-### Info tone
-
-```tsx
-<Progress value={75} tone="info" label="Processing" />
-```
-
-### With a border
-
-The host element pre-declares `border: 0px solid var(--progress-border-color)` — the colour and style are already wired, only the width is zero. To enable a border on any side, just give it a width. The border colour automatically tracks `--progress-border-color`, so it retones (e.g. `border-2-info` for `tone="info"`) without any extra CSS.
-
-```tsx
-<Progress
-  value={60}
-  label="Uploading"
-  hint="3 of 5"
-  style={{ borderBottomWidth: '1px' }}
-/>
-```
-
-## Interactive demo
-
-<ProgressDemo client:load />
 
 ## Component tokens
 


### PR DESCRIPTION
## Summary

- Folds each component page's static \"Examples\" + \"Props\" sections into the playground itself. The author writes one TSX source with multiple JSDoc-headed JSX expressions; each pairing becomes an accordion entry in the Props panel, and **all** examples render side-by-side in the preview.
- The form is range-bound to its example's JSX (via new `parseExamples` + `range`-aware `replaceProp` / `readProp`), so editing one section never touches the others' source bytes. Complex props (`children`, `style`, `ReactNode`, `CSSProperties`) surface as read-only documentation rows, letting the playground double as the prop reference — the static `## Props` table is gone.
- For JSX whose tag isn't in `api.json` (e.g. a helper defined in the source preamble), the form infers controls from currently-set attributes.
- Headings go on the opening `/​**` line so Monaco's fold range keeps the label visible when the comment is collapsed. On Code-tab mount we just call `editor.foldAll` — JSDoc bodies and helper-function bodies fold away while example labels stay readable.

`progress.mdx` is the first page on the new shape; the legacy `ProgressDemo` island and `PropsTable` import are gone from it.

## Test plan

- [ ] `cd site && pnpm run dev`, open `/components/progress/`. Preview pane shows all five Progress examples laid out vertically with 16 px gaps inside the iframe.
- [ ] Props tab shows an accordion with five sections; **Basic** is open, the rest collapsed. Each opens / closes independently.
- [ ] Edit `value` inside the **Info tone** form. Only the third preview updates; the Code tab shows just the Info-tone block's `value={…}` changed, other examples are byte-identical.
- [ ] Open the **Animated** accordion — controls list `speed` only (inferred from the JSX attribute, since `AnimatedProgress` isn't in api.json). Bumping it changes the speed of the animated bar.
- [ ] **Basic** accordion shows read-only docType rows for `style` (`CSSProperties`) and `children` (`ReactNode`) — no edit affordance, just documentation.
- [ ] Code tab opens with every example's JSDoc folded — only the `# …` heading line is visible per example. The `AnimatedProgress` helper body is also folded. Click the fold gutter to expand.
- [ ] CSS tab is unconditionally available. Adding `.foo { … }` + `className=\"foo\"` to one example styles only that one (className-→-CSS auto-seed magic is gone — write rules by hand).
- [ ] `site/src/pages/components/progress.mdx` no longer contains `## Props` or `## Interactive demo`; only `## Component tokens` remains under the playground.