### PR TITLE
Polite baseline for <table>, <code>, and ::selection in reset.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ If you need a different order, declare it in your *own* CSS file that loads **be
 
 CSS custom properties (the `:root { --… }` declarations in `tokens.css`) stay unlayered so they take effect everywhere unconditionally.
 
+> **Gotcha: unlayered hard resets defeat Anta's element rules.**
+>
+> A snippet like this in your global CSS — common copy-paste from older reset guides — silently overrides every element rule Anta ships:
+>
+> ```css
+> *, *::before, *::after { box-sizing: border-box; }
+> * { margin: 0; }
+> ```
+>
+> Unlayered styles **always** beat layered ones in the cascade, regardless of specificity. So `* { margin: 0 }` outranks Anta's `caption { margin-bottom: 0.25em }`, `p { margin: 0 0 1em }`, `ul / ol` padding, and any other per-element default Anta provides — even though those use stronger selectors.
+>
+> If you're importing `@antadesign/anta/reset.css`, Anta already does the same universal `box-sizing` and margin reset, *inside* `@layer anta`. The element-level rules sitting on top are intentionally polite defaults — sensible out of the box, trivially overridable when you want something else (any rule in `@layer components` / `@layer utilities`, or any unlayered rule of your own that targets specific elements, wins automatically). **Delete the duplicate hard reset from your global CSS** so those defaults can apply. If you want to keep your own reset, wrap it in `@layer base { … }` so it sits below `anta` in the declared order and Anta's rules still win element-by-element.
+
 ## Registering elements
 
 The JSX wrappers (React components) as `Progress` render custom DOM elements as `<a-progress>`. The custom elements themselves must be registered with the browser **before** they appear in the DOM, and registration only works where `HTMLElement` exists — i.e. the UI thread of a real browser. **Node.js (SSR) and Worker threads don't have `HTMLElement`**, so the import is harmless in those environments: it does nothing — registration is skipped silently and the class uses a stand-in base instead of crashing — though it might extend your worker's bundle size a bit.

--- a/site/src/components/TextDemo.tsx
+++ b/site/src/components/TextDemo.tsx
@@ -17,7 +17,7 @@ export default function TextDemo() {
           <div key={p} class="demoRow">
             <span class="demoLabel upper">priority="{p}"</span>
             <Text priority={p}>
-              The quick brown fox jumps over the lazy dog with a <a href="#">link inside</a> the sentence.
+              The quick brown fox jumps over the lazy dog with a <code>code pill</code> and a <a href="#">link inside</a> the sentence.
             </Text>
           </div>
         ))}
@@ -30,7 +30,7 @@ export default function TextDemo() {
             <div key={`${tone}-${p}`} class="demoRow">
               <span class="demoLabel upper">priority="{p}"</span>
               <Text tone={tone} priority={p}>
-                The quick brown fox jumps over the lazy dog with a <a href="#">link inside</a> the sentence.
+                The quick brown fox jumps over the lazy dog with a <code>code pill</code> and a <a href="#">link inside</a> the sentence.
               </Text>
             </div>
           ))}

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -308,8 +308,8 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
   /* Show the icon that matches the current mode: sun in light mode,
      moon in dark mode. */
   .theme-toggle a-icon[shape="moon"] { display: none; }
-  :global(html.dark) .theme-toggle a-icon[shape="sun"] { display: none; }
-  :global(html.dark) .theme-toggle a-icon[shape="moon"] { display: inline-block; }
+  :global(.dark) .theme-toggle a-icon[shape="sun"] { display: none; }
+  :global(.dark) .theme-toggle a-icon[shape="moon"] { display: inline-block; }
 
   .brand-links {
     display: flex;

--- a/site/src/pages/components/table.mdx
+++ b/site/src/pages/components/table.mdx
@@ -25,3 +25,142 @@ The Table component lives in the **Anta 0.2** Figma library:
 ## Preview
 
 <img src="/table-preview.png" alt="Anta Table component — preview from Figma" width="656" />
+
+## Plain HTML tables
+
+While the `<Table>` component is in design, Anta's `reset.css` ships a
+polite baseline for the native `<table>` element so plain HTML tables
+look intentional out of the box. The defaults are deliberately minimal:
+top-left aligned cells with 5 × 10 px padding, hairline row separators
+in `--border-5`, semibold `<thead>` cells, and no outer frame or
+column dividers. Set `font-variant-numeric: tabular-nums` so numeric
+columns line up.
+
+All rules live inside `@layer anta`, so any consumer rule outside a
+layer (or in `components` / `utilities`) overrides without specificity
+fights or `!important`.
+
+### Default
+
+<table>
+  <thead>
+    <tr>
+      <th>Token</th>
+      <th>Value</th>
+      <th>Usage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--text-1</td>
+      <td>#1c1f23</td>
+      <td>Primary body copy</td>
+    </tr>
+    <tr>
+      <td>--text-3</td>
+      <td>#52575e</td>
+      <td>Secondary labels, sidebar links</td>
+    </tr>
+    <tr>
+      <td>--border-5</td>
+      <td>#e8eaed</td>
+      <td>Hairline dividers, table row separators</td>
+    </tr>
+  </tbody>
+</table>
+
+```html
+<table>
+  <thead>
+    <tr><th>Token</th><th>Value</th><th>Usage</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>--text-1</td><td>#1c1f23</td><td>Primary body copy</td></tr>
+    …
+  </tbody>
+</table>
+```
+
+### Bordered
+
+Add `data-bordered` to draw the outer frame, vertical column dividers,
+and 3 px rounded corners. Under the hood the variant switches to
+`border-collapse: separate` because `border-radius` doesn't render
+reliably with collapsed borders.
+
+<table data-bordered>
+  <thead>
+    <tr>
+      <th>Token</th>
+      <th>Value</th>
+      <th>Usage</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--text-1</td>
+      <td>#1c1f23</td>
+      <td>Primary body copy</td>
+    </tr>
+    <tr>
+      <td>--text-3</td>
+      <td>#52575e</td>
+      <td>Secondary labels, sidebar links</td>
+    </tr>
+    <tr>
+      <td>--border-5</td>
+      <td>#e8eaed</td>
+      <td>Hairline dividers, table row separators</td>
+    </tr>
+  </tbody>
+</table>
+
+```html
+<table data-bordered>
+  …
+</table>
+```
+
+### With a caption
+
+`<caption>` is the semantic title for a data table — the first child of
+`<table>`, announced by screen readers as the table's accessible name.
+Browsers render it as a block above the rows; Anta's only opinion is
+left alignment (browser default is centered).
+
+<table data-bordered>
+  <caption>Color tokens used by the docs sidebar</caption>
+  <thead>
+    <tr>
+      <th>Token</th>
+      <th>Role</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--text-1-brand</td>
+      <td>Logo wordmark</td>
+    </tr>
+    <tr>
+      <td>--text-3</td>
+      <td>Nav link, idle state</td>
+    </tr>
+    <tr>
+      <td>--text-1</td>
+      <td>Nav link, current page</td>
+    </tr>
+  </tbody>
+</table>
+
+```html
+<table data-bordered>
+  <caption>Color tokens used by the docs sidebar</caption>
+  <thead>
+    <tr><th>Token</th><th>Role</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>--text-1-brand</td><td>Logo wordmark</td></tr>
+    …
+  </tbody>
+</table>
+```

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -129,7 +129,7 @@ and step up to the next-stronger level of the same tint on hover. At
 `priority="primary"` there is no level above, so hovering only brings
 the underline to full alpha.
 
-## Interactive demo
+## Demo
 
 <TextDemo client:load />
 

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -114,21 +114,19 @@ code {
   font-family: var(--monospace);
   font-size: 0.9em;
   color: inherit;
-  background: var(--bg-section);
-  border: 0.5px solid var(--border-4);
-  padding: 3px 3px 2px;
+  background: color-mix(in oklch, currentColor 6%, transparent);
+  border: none;
+  padding: 0.25em 0.4ch 0.2em;
   border-radius: 3px;
 }
+
 
 pre code { background: none; padding: 0; }
 
 :not(pre) > code {
   cursor: copy;
-  transition: box-shadow 150ms ease-out;
   position: relative;
 }
-:not(pre) > code:hover { box-shadow: 0 1px 5px color-mix(in oklch, var(--border-1) 50%, transparent); }
-:not(pre) > code:active { box-shadow: none; }
 
 .copyable {
   cursor: copy;
@@ -157,6 +155,16 @@ pre code { background: none; padding: 0; }
   border-radius: inherit;
 
   animation: copy-toast 500ms ease-out forwards;
+}
+
+/* The code-pill toast: the pill's own background is now a translucent
+   `currentColor` wash, so `background: inherit` would leave the
+   floating copy nearly invisible against the page (and outright
+   invisible at z-index: -1 against the page background). Layer the
+   same 6% tint over the page's base color so the toast reads as an
+   opaque ghost of the original pill. */
+code[data-copied]::after {
+  background: color-mix(in oklch, currentColor 6%, var(--bg-base));
 }
 
 @keyframes copy-toast {
@@ -206,6 +214,15 @@ pre code { background: none; padding: 0; }
   margin: 0;
 }
 
+/* Docs-site default: stretch every prose table to fill the column.
+   The package baseline leaves width alone (app tables shouldn't
+   automatically go full-bleed); the docs site overrides for the
+   rendered-MDX context where full-width is what you want. */
+.content table {
+  width: 100%;
+  margin: 0 0 24px;
+}
+
 /* Changelog stream filter. The /changelog/ page wraps each version
    block in <section data-stream="dev|main"> via the
    rehype-changelog-sections plugin. The ChangelogStreamTabs component
@@ -214,27 +231,6 @@ pre code { background: none; padding: 0; }
    sections; default (no html[data-stream]) shows everything. */
 html[data-stream="dev"]  .changelog section[data-stream="main"] { display: none; }
 html[data-stream="main"] .changelog section[data-stream="dev"]  { display: none; }
-
-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 0 0 24px;
-  font-size: 0.9rem;
-}
-
-th, td {
-  text-align: left;
-  padding: 8px 16px;
-  border-bottom: 1px solid var(--border-5);
-}
-
-th {
-  font-weight: 600;
-  color: #6c7278;
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-}
 
 /* Shared demo-island styles. Used by component demos (IconDemo,
    TruncateDemo, ExpandableDemo, TextDemo). */

--- a/src/reset.css
+++ b/src/reset.css
@@ -112,4 +112,79 @@
   a:active {
     text-decoration-color: color-mix(in oklch, currentColor 75%, transparent);
   }
+
+  /* Text selection — full-chroma brand color at 15% alpha. Using
+     OKLCH relative-color syntax (not `color-mix` with `transparent`)
+     keeps the chroma intact: mixing toward `transparent` interpolates
+     in OKLCH and pulls L/C toward zero, which washes the result out.
+     `calc(c * 1.5)` bumps the saturation modestly above the source
+     token so the highlight reads as clearly brand-coloured rather
+     than a neutral grey. No `color` override on the selection, so
+     the selected text keeps its original color and contrast is
+     preserved automatically. `--text-1-brand` inverts between light
+     and dark, so the effect tracks the active palette unaided. */
+  ::selection {
+    background: oklch(from var(--text-1-brand) l calc(c * 1.5) h / 0.15);
+  }
+
+  /* ───── Tables ───────────────────────────────────────────────── */
+
+  /* Polite, element-level baseline. Rules live in `@layer anta`, so
+     any consumer rule outside a layer — or in `components` /
+     `utilities` — overrides without effort. Width is intentionally
+     left untouched so app tables stay inline-sized; full-bleed is a
+     decision for the surrounding page. */
+  table {
+    border-collapse: collapse;
+    font-variant-numeric: tabular-nums;
+  }
+
+  caption {
+    text-align: left;
+    color: var(--text-3);
+    padding-left: 10px;
+    margin-bottom: 0.25em;
+  }
+
+  th, td {
+    padding: 5px 10px;
+    text-align: left;
+    vertical-align: top;
+    border-bottom: 1px solid var(--border-5);
+  }
+
+  thead th {
+    font-weight: 600;
+  }
+
+  /* Drop the trailing hairline under the table's last row so the
+     table doesn't end with an orphan line. Handles both "tbody is
+     the final section" and "tfoot is the final section". */
+  tfoot tr:last-child > :is(th, td),
+  table:not(:has(tfoot)) tbody tr:last-child > :is(th, td) {
+    border-bottom: none;
+  }
+
+  /* Opt-in: outer frame + vertical column dividers + 3px rounded
+     corners. Switches to separate borders because `border-radius`
+     doesn't render reliably under `border-collapse: collapse` — the
+     collapsed borders override the radius. Cells draw their own
+     right edges to build the internal grid; the last cell in each
+     row drops its right border so the table's own border supplies
+     the outer frame. Row separators come from the baseline
+     `border-bottom` and continue to work under separate-collapse. */
+  table[data-bordered] {
+    border-collapse: separate;
+    border-spacing: 0;
+    border: 1px solid var(--border-5);
+    border-radius: 3px;
+  }
+
+  table[data-bordered] :is(th, td) {
+    border-right: 1px solid var(--border-5);
+  }
+
+  table[data-bordered] tr > :is(th, td):last-child {
+    border-right: 0;
+  }
 }


### PR DESCRIPTION
## Summary

Three element-level baselines for `@antadesign/anta/reset.css`, all sitting in `@layer anta` so consumers override trivially. Plus the docs-site updates that demo and document them.

### Package — `src/reset.css`

- **`<table>` baseline.** Horizontal hairlines between rows, top-left aligned cells (5 × 10 px), `tabular-nums`, no outer frame, no column dividers. The last row of the table drops its bottom border so the table doesn't end with an orphan hairline (handles both \`tbody\` and \`tfoot\` last-section cases via \`:has()\`).
- **`<table data-bordered>` variant.** Adds the outer frame, column dividers, and 3 px rounded corners. Switches to `border-collapse: separate` because `border-radius` doesn't render reliably with collapsed borders; the cells then draw their own right edges to build the internal grid.
- **`<caption>`.** Left-aligned (overrides browser's centered default), \`var(--text-3)\` color, indented to align with the first column's content, half-line bottom margin.
- **`::selection`.** Full-chroma `--text-1-brand` at `0.15` alpha via OKLCH relative-color syntax (`oklch(from var(--text-1-brand) l calc(c * 1.5) h / 0.15)`). The `color-mix(... 15%, transparent)` route was rejected because OKLCH treats `transparent` as `oklch(0 0 0 / 0)` — interpolating toward it pulls lightness *and* chroma to 15% and produces a washed-out grey. No \`color\` override on the selection, so selected text keeps its original color and contrast is preserved automatically across every priority/tone.

### Docs site

- **Inline `<code>` pills** now use `color-mix(in oklch, currentColor 6%, transparent)` for the background — the pill tints with whatever color the surrounding text uses. The copy-toast (`[data-copied]::after`) gets an opaque equivalent (`color-mix(currentColor 6%, --bg-base)`) so the floating ghost still reads against the page background. Border and hover shadow removed; click-to-copy still works.
- **TextDemo** now weaves a `<code>code pill</code>` into the demo sentence, so all 30 priority × tone combinations on `/components/text/` visually validate the currentColor behavior. The section heading flipped from \"Interactive demo\" to \"Demo\" to match what it actually is.
- **DocsLayout** drops two `:global(html.dark)` references in favor of `:global(.dark)`, matching the convention `src/tokens.css` already uses for the dark-mode hook.
- **New \"Plain HTML tables\" section** on `/components/table/` with the default, the `[data-bordered]` variant, and a captioned example so the reset.css additions are documented where consumers look.
- **README \"Cascade layers\" callout.** A common gotcha: an unlayered `* { margin: 0 }` in a consumer's global CSS silently defeats every layered element rule Anta ships (caption margins, list padding, the typography defaults). The callout shows the snippet, explains the cascade rule (unlayered always beats layered), and recommends either deleting the duplicate hard reset or wrapping it in `@layer base { … }` so Anta's `@layer anta` still wins.

## Test plan

- [ ] Visit \`/components/table/\` — confirm three examples render: default (hairlines, no frame), `[data-bordered]` (rounded corners + column dividers), and caption (left-aligned, muted, indented to first column).
- [ ] Visit \`/components/text/\` Demo section — confirm code pills tint with currentColor across every priority/tone row; confirm the link case shows a blue-tinted pill.
- [ ] Click any inline code pill — confirm the floating copy-toast animation plays (sliding up, fading out).
- [ ] Select some text — confirm the highlight reads as a brand-coloured wash in both light and dark mode, and selected text remains readable in every tone.
- [ ] Open `/` (README) and scroll to the \"Cascade layers\" section — confirm the gotcha callout renders.
- [ ] Toggle dark mode — confirm tables, code pills, captions, and selection all respect the theme without per-theme rules.