### PR TITLE
Clean up Cloudflare Pages previews on branch deletion

### DIFF
--- a/.github/workflows/cleanup-cloudflare-previews.yml
+++ b/.github/workflows/cleanup-cloudflare-previews.yml
@@ -1,0 +1,69 @@
+name: Cleanup Cloudflare Pages previews
+
+# Fires when a branch (not a tag) is deleted on GitHub. Cloudflare
+# Pages keeps preview deployments around indefinitely on its own — no
+# retention, no branch-aware cleanup — so deleted branches accumulate
+# stale deploys until they hit the project deployment cap.
+#
+# This workflow lists every preview deployment for the deleted branch
+# via Cloudflare's REST API and removes them. The branch's commit-
+# hash URLs stop resolving; the branch alias (e.g.
+# `feature-x.<project>.pages.dev`) goes away with the last build.
+#
+# Note: GitHub's `delete` event only fires when a branch is removed
+# from the repo. PR merges that leave the source branch in place do
+# not trigger cleanup — turn on "Automatically delete head branches"
+# in Settings → General → Pull Requests if you want merge → cleanup.
+on:
+  delete:
+
+permissions: {}
+
+jobs:
+  cleanup:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete branch's Cloudflare Pages preview deployments
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: anta
+          BRANCH: ${{ github.event.ref }}
+        run: |
+          set -euo pipefail
+
+          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT}/deployments"
+
+          echo "Looking up preview deployments for branch: ${BRANCH}"
+
+          # One page of 100 covers virtually every real-world branch
+          # (typical PRs push 1–10 deploys). If a branch exceeds that
+          # the leftover deploys still age out through the project
+          # retention cap, and a follow-up scheduled cleanup catches them.
+          ids=$(curl -fsS -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            "${api}?env=preview&per_page=100" \
+            | jq -r --arg b "${BRANCH}" \
+              '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id')
+
+          if [[ -z "${ids}" ]]; then
+            echo "No preview deployments found for ${BRANCH}. Nothing to do."
+            exit 0
+          fi
+
+          count=$(echo "${ids}" | wc -l | tr -d ' ')
+          echo "Deleting ${count} preview deployment(s):"
+
+          for id in ${ids}; do
+            echo "  ${id}"
+            status=$(curl -fsS -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "${api}/${id}" \
+              | jq -r '.success')
+            if [[ "${status}" != "true" ]]; then
+              echo "  failed to delete ${id}"
+              exit 1
+            fi
+          done
+
+          echo "Done."


### PR DESCRIPTION
## Summary

New GitHub Action that listens for branch-deletion events and removes the corresponding Cloudflare Pages preview deployments via the REST API.

Cloudflare Pages has no built-in retention or branch-aware cleanup — verified against their docs. Without something like this, deleted branches accumulate stale deployments until the project hits the deployment cap (~500 per project) and new builds start failing. This workflow keeps the project tidy without a periodic sweep.

## How it works

- Trigger: `on: delete` (filtered to `ref_type == 'branch'`, ignores tag deletions).
- Lists every preview deployment for the project and filters to those whose `deployment_trigger.metadata.branch` matches the deleted branch.
- Calls `DELETE /accounts/.../pages/projects/.../deployments/{id}` for each match.
- Uses raw `curl` + `jq` rather than Wrangler so the workflow doesn't churn with CLI version changes.

## Required secrets (already set up)

- `CLOUDFLARE_API_TOKEN` — `Account → Cloudflare Pages → Edit` permission, account-scoped.
- `CLOUDFLARE_ACCOUNT_ID` — account ID from the Cloudflare dashboard sidebar.

Project name (`anta`) is hardcoded in the workflow.

## Important behavioral notes

- `on: delete` fires when a branch is **removed from the repo**, not when a PR merges. To get post-merge cleanup, enable **Settings → General → Pull Requests → Automatically delete head branches**. With that on, merging a PR deletes the branch, which fires this workflow, which cleans the deploys.
- The workflow file has to be on `main` to fire on deletion events — `on: delete` reads from the default branch. So this PR has to land before the cleanup actually runs.

## Test plan

- [ ] Merge this PR to `main`.
- [ ] Make a throwaway branch with a small change, push it, let Cloudflare build a preview.
- [ ] Verify the deployment exists in Cloudflare → Workers & Pages → anta → Deployments.
- [ ] Delete the throwaway branch (`git push origin --delete <branch>` or via the GitHub UI).
- [ ] Check the workflow run on the Actions tab — confirm it found the deployment and deleted it.
- [ ] Verify the deployment is gone from the Cloudflare dashboard.

## Future follow-up

Long-abandoned branches that never get deleted will still accumulate. A weekly scheduled job that sweeps deployments older than N days whose source branch no longer exists would catch those — easy add later if needed.