### PR TITLE
Add Cloudflare Pages production-deployment cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-cloudflare-production.yml
+++ b/.github/workflows/cleanup-cloudflare-production.yml
@@ -1,0 +1,111 @@
+name: Cleanup Cloudflare Pages production deployments
+
+# Cloudflare Pages keeps every successful production deployment
+# indefinitely. We don't use them for rollback (we redeploy from
+# git instead), so the historical list just consumes quota and clutters
+# the dashboard.
+#
+# This workflow keeps the most recently-successful production
+# deployment (the one currently aliased to the production domain) and
+# deletes every other production deployment with `?force=true` (the
+# aliased one would otherwise reject the DELETE — same gotcha as the
+# preview-cleanup workflow). Manual trigger only — fire it from the
+# Actions UI after a known-good production deploy.
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete stale production deployments
+        env:
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PROJECT: anta
+        run: |
+          set -euo pipefail
+
+          api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT}/deployments"
+
+          # Cloudflare's list-deployments endpoint caps per_page at 25
+          # and exposes no filter for "successful only", so we paginate
+          # and filter client-side. Pagination stops when a page
+          # returns fewer than 25 results.
+          PAGE_SIZE=25
+
+          echo "Listing production deployments…"
+
+          # Gather `<created_on>\t<id>` for every successful production
+          # deployment across all pages.
+          rows=""
+          page=1
+          while :; do
+            res=$(curl -sS -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "${api}?env=production&page=${page}&per_page=${PAGE_SIZE}")
+
+            success=$(echo "${res}" | jq -r '.success')
+            if [[ "${success}" != "true" ]]; then
+              echo "Cloudflare API error on page ${page}:"
+              echo "${res}" | jq '.errors // .'
+              exit 1
+            fi
+
+            page_rows=$(echo "${res}" | jq -r '
+              .result[]
+              | select(.latest_stage.status == "success")
+              | "\(.created_on)\t\(.id)"
+            ')
+            if [[ -n "${page_rows}" ]]; then
+              rows+="${page_rows}"$'\n'
+            fi
+
+            page_count=$(echo "${res}" | jq -r '.result | length')
+            if [[ "${page_count}" -lt "${PAGE_SIZE}" ]]; then
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          rows=$(printf '%s' "${rows}" | sed '/^$/d')
+          if [[ -z "${rows}" ]]; then
+            echo "No production deployments found. Nothing to do."
+            exit 0
+          fi
+
+          # Sort by created_on descending; the first row is the
+          # currently-active production deployment (newest successful),
+          # everything after it is fair game to delete.
+          sorted=$(echo "${rows}" | sort -r)
+          keep=$(echo "${sorted}" | head -n1 | cut -f2)
+          stale=$(echo "${sorted}" | tail -n +2 | cut -f2)
+
+          echo "Keeping active production deployment: ${keep}"
+
+          if [[ -z "${stale}" ]]; then
+            echo "No stale production deployments. Done."
+            exit 0
+          fi
+
+          count=$(echo "${stale}" | wc -l | tr -d ' ')
+          echo "Deleting ${count} stale production deployment(s):"
+
+          # `force=true` so deployments still carrying an alias (rare on
+          # production, but the previous deployment can briefly hold an
+          # alias during a rollout) don't 8000035-out the loop.
+          while IFS= read -r id; do
+            echo "  ${id}"
+            res=$(curl -sS -X DELETE \
+              -H "Authorization: Bearer ${CF_API_TOKEN}" \
+              "${api}/${id}?force=true")
+            success=$(echo "${res}" | jq -r '.success')
+            if [[ "${success}" != "true" ]]; then
+              echo "  failed:"
+              echo "${res}" | jq '.errors // .'
+              exit 1
+            fi
+          done <<< "${stale}"
+
+          echo "Done."


### PR DESCRIPTION
## Summary

Cloudflare Pages keeps every successful production deployment indefinitely. We don't use them for rollback (we redeploy from git instead), so they accumulate against the project's deployment quota and clutter the dashboard.

This workflow keeps only the most-recently-successful production deployment (the one currently aliased to the production domain) and force-deletes every other.

- **Trigger**: `workflow_dispatch` only — fire it from the Actions UI when you want cleanup. No automatic cron schedule.
- **Selection**: list `env=production` deployments across all pages of the API, filter to `latest_stage.status === "success"`, sort by `created_on` desc, keep the head row, delete the rest.
- **`?force=true`** on the DELETE — same Cloudflare API gotcha as the preview-cleanup workflow: deployments still carrying an alias (the active one always, the previous one briefly during rollout) refuse to delete without it.

## Test plan

- [ ] After merge, run the workflow manually (Actions → Cleanup Cloudflare Pages production deployments → Run workflow).
- [ ] Output shows it identified the active production deployment by `created_on` and listed the older ones for deletion.
- [ ] After the run, the Cloudflare Pages dashboard for the `anta` project shows only one production deployment in the history.
- [ ] Run it again immediately — should report "No stale production deployments. Done." and exit 0.