### PR TITLE
Auto-trigger Cloudflare cleanup workflows

### DIFF
--- a/.github/workflows/cleanup-cloudflare-previews.yml
+++ b/.github/workflows/cleanup-cloudflare-previews.yml
@@ -1,23 +1,30 @@
 name: Cleanup Cloudflare Pages previews
 
-# Fires when a branch (not a tag) is deleted on GitHub. Cloudflare
-# Pages keeps preview deployments around indefinitely on its own — no
-# retention, no branch-aware cleanup — so deleted branches accumulate
-# stale deploys until they hit the project deployment cap.
+# Cloudflare Pages keeps preview deployments around indefinitely —
+# no retention, no branch-aware cleanup — so they accumulate stale
+# deploys until the project deployment cap is hit.
 #
-# This workflow paginates Cloudflare's REST API for every preview
-# deployment in the project, filters to the deleted branch, and
-# removes each match.
+# This workflow runs in two modes:
 #
-# Note: GitHub's `delete` event only fires when a branch is removed
-# from the repo. PR merges that leave the source branch in place do
-# not trigger cleanup — turn on "Automatically delete head branches"
-# in Settings → General → Pull Requests if you want merge → cleanup.
+#  1. push (any non-main branch) → keep newest successful preview for
+#     the pushed branch, delete the rest. Same "newest-only" idea as
+#     the production-cleanup workflow, scoped to the pushed branch.
+#     The new Cloudflare deploy is usually still building when this
+#     runs, so the `status == "success"` filter skips it; the previous
+#     successful deploy stays kept and is reaped on the next push.
+#  2. delete (branch removed from GitHub) or workflow_dispatch with a
+#     branch input → delete every preview deployment for that branch.
+#     The branch is gone (or the user has explicitly asked), so there
+#     is nothing to keep.
+#
+# Pushes to main are ignored — production cleanup is the other
+# workflow's job. PR merges that leave the source branch in place do
+# not trigger the delete-mode cleanup; turn on "Automatically delete
+# head branches" in Settings → General → Pull Requests for that.
 on:
+  push:
+    branches-ignore: [main]
   delete:
-  # Manual trigger so previews from already-deleted branches (no
-  # `delete` event to replay) can still be reaped — supply the
-  # branch name in the GitHub Actions UI.
   workflow_dispatch:
     inputs:
       branch:
@@ -29,17 +36,32 @@ permissions: {}
 
 jobs:
   cleanup:
-    if: github.event.ref_type == 'branch' || github.event_name == 'workflow_dispatch'
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'delete' && github.event.ref_type == 'branch')
     runs-on: ubuntu-latest
     steps:
-      - name: Delete branch's Cloudflare Pages preview deployments
+      - name: Cleanup branch's Cloudflare Pages preview deployments
         env:
           CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           PROJECT: anta
-          BRANCH: ${{ github.event.ref || inputs.branch }}
+          EVENT: ${{ github.event_name }}
+          # The branch name lands here from one of three sources
+          # depending on the trigger. The script picks the right one.
+          DELETE_REF: ${{ github.event.ref }}
+          DISPATCH_BRANCH: ${{ inputs.branch }}
+          PUSH_BRANCH: ${{ github.ref_name }}
         run: |
           set -euo pipefail
+
+          case "${EVENT}" in
+            push)              BRANCH="${PUSH_BRANCH}"     ; MODE=newest_only ;;
+            delete)            BRANCH="${DELETE_REF}"      ; MODE=reap_all    ;;
+            workflow_dispatch) BRANCH="${DISPATCH_BRANCH}" ; MODE=reap_all    ;;
+            *)                 echo "Unknown event ${EVENT}; nothing to do." ; exit 0 ;;
+          esac
 
           api="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/pages/projects/${PROJECT}/deployments"
 
@@ -50,9 +72,11 @@ jobs:
           # returns fewer than 25 results (i.e. we've hit the tail).
           PAGE_SIZE=25
 
-          echo "Looking up preview deployments for branch: ${BRANCH}"
+          echo "Mode: ${MODE}; branch: ${BRANCH}"
 
-          ids=""
+          # Gather `<created_on>\t<status>\t<id>` rows for every
+          # preview deployment matching the branch.
+          rows=""
           page=1
           while :; do
             res=$(curl -sS -H "Authorization: Bearer ${CF_API_TOKEN}" \
@@ -65,10 +89,13 @@ jobs:
               exit 1
             fi
 
-            page_ids=$(echo "${res}" | jq -r --arg b "${BRANCH}" \
-              '.result[] | select(.deployment_trigger.metadata.branch == $b) | .id')
-            if [[ -n "${page_ids}" ]]; then
-              ids+="${page_ids}"$'\n'
+            page_rows=$(echo "${res}" | jq -r --arg b "${BRANCH}" '
+              .result[]
+              | select(.deployment_trigger.metadata.branch == $b)
+              | "\(.created_on)\t\(.latest_stage.status)\t\(.id)"
+            ')
+            if [[ -n "${page_rows}" ]]; then
+              rows+="${page_rows}"$'\n'
             fi
 
             page_count=$(echo "${res}" | jq -r '.result | length')
@@ -78,10 +105,39 @@ jobs:
             page=$((page + 1))
           done
 
+          rows=$(printf '%s' "${rows}" | sed '/^$/d')
+
+          if [[ -z "${rows}" ]]; then
+            echo "No preview deployments found for ${BRANCH}. Nothing to do."
+            exit 0
+          fi
+
+          # Pick the IDs to delete based on mode.
+          case "${MODE}" in
+            reap_all)
+              ids=$(echo "${rows}" | cut -f3)
+              ;;
+            newest_only)
+              # Sort by created_on desc; keep the newest deployment
+              # whose latest_stage.status is success (the one the
+              # branch alias currently points to). Delete everything
+              # else. If no successful deploy exists yet (first build
+              # still in flight), keep all rows — nothing to prune.
+              sorted=$(echo "${rows}" | sort -r)
+              keep=$(echo "${sorted}" | awk -F'\t' '$2 == "success" {print $3; exit}')
+              if [[ -z "${keep}" ]]; then
+                echo "No successful deployment for ${BRANCH} yet. Nothing to prune."
+                exit 0
+              fi
+              echo "Keeping newest successful deployment: ${keep}"
+              ids=$(echo "${sorted}" | awk -F'\t' -v k="${keep}" '$3 != k {print $3}')
+              ;;
+          esac
+
           ids=$(printf '%s' "${ids}" | sed '/^$/d')
 
           if [[ -z "${ids}" ]]; then
-            echo "No preview deployments found for ${BRANCH}. Nothing to do."
+            echo "Nothing to delete."
             exit 0
           fi
 
@@ -91,8 +147,9 @@ jobs:
           # `force=true` is required because Cloudflare refuses to
           # delete the deployment that currently holds the branch's
           # `<branch>.<project>.pages.dev` alias (error 8000035).
-          # Since the whole branch is gone, that alias has no future
-          # use — forcing is safe.
+          # For reap_all the branch is gone so the alias has no
+          # future use; for newest_only we've already excluded the
+          # kept deployment from the delete list.
           while IFS= read -r id; do
             echo "  ${id}"
             res=$(curl -sS -X DELETE \

--- a/.github/workflows/cleanup-cloudflare-production.yml
+++ b/.github/workflows/cleanup-cloudflare-production.yml
@@ -9,9 +9,22 @@ name: Cleanup Cloudflare Pages production deployments
 # deployment (the one currently aliased to the production domain) and
 # deletes every other production deployment with `?force=true` (the
 # aliased one would otherwise reject the DELETE — same gotcha as the
-# preview-cleanup workflow). Manual trigger only — fire it from the
-# Actions UI after a known-good production deploy.
+# preview-cleanup workflow).
+#
+# Triggers:
+#  - push to main: fires immediately when a new production deploy
+#    starts. The new Cloudflare deploy is usually still building, so
+#    the script's `status == "success"` filter skips it; the previous
+#    successful deploy stays kept and everything older is reaped.
+#  - schedule (every 30 min): catches up after the new deploy
+#    completes — the previously-kept deploy is no longer newest, so
+#    the next scheduled run prunes it.
+#  - workflow_dispatch: keep for manual / ad-hoc runs.
 on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0,30 * * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
## Summary

- Production cleanup (`cleanup-cloudflare-production.yml`) now fires on push to `main`, every 30 minutes (schedule), and via manual dispatch — instead of dispatch-only. Net effect: at most a ~30-min window between a successful production deploy and the previous one being reaped.
- Preview cleanup (`cleanup-cloudflare-previews.yml`) now also fires on push to any non-`main` branch, keeping only the newest successful preview for that branch. The existing `delete` event (full reap for a removed branch) and `workflow_dispatch` paths are unchanged.
- Script body for the production workflow is unchanged (already idempotent). Previews workflow gets a small mode switch — `newest_only` (push) vs `reap_all` (delete / dispatch).

## Test plan

- [ ] Merge to `main` and confirm the production cleanup workflow runs on the resulting push.
- [ ] After the new production deploy completes on Cloudflare, confirm the next scheduled run (within ~30 min) removes the previously-active deploy. End state: exactly one production deployment remains in the dashboard.
- [ ] Push a commit to a feature branch and confirm the previews workflow runs, keeps the newest successful preview, and removes older ones for the same branch.
- [ ] Push a second commit to the same branch and confirm the previously-kept preview is now reaped (the new deploy is the new "newest successful" after it completes).
- [ ] Delete a branch and confirm the existing `delete`-event path still wipes every preview for that branch (no regression).
- [ ] Confirm pushes to `main` do **not** enter the previews workflow (only the production one).