### PR TITLE
Docs site: playground prod-CSS fix, faster prop inputs, collapsible Props/tokens

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,9 +55,15 @@ importers:
       astro-expressive-code:
         specifier: 0.41.7
         version: 0.41.7(astro@5.18.1)
+      es-toolkit:
+        specifier: ^1.47.0
+        version: 1.47.0
       esbuild-wasm:
         specifier: 0.25.12
         version: 0.25.12
+      marked:
+        specifier: ^18.0.4
+        version: 18.0.4
       monaco-editor:
         specifier: 0.52.2
         version: 0.52.2
@@ -2117,6 +2123,10 @@ packages:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
     dev: false
 
+  /es-toolkit@1.47.0:
+    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
+    dev: false
+
   /esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
     dependencies:
@@ -2849,6 +2859,12 @@ packages:
 
   /markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+    dev: false
+
+  /marked@18.0.4:
+    resolution: {integrity: sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==}
+    engines: {node: '>= 20'}
+    hasBin: true
     dev: false
 
   /mathjax-full@3.2.2:

--- a/site/package.json
+++ b/site/package.json
@@ -17,9 +17,12 @@
     "@astrojs/mdx": "4.3.14",
     "@astrojs/preact": "4.1.3",
     "@monaco-editor/react": "4.7.0",
+    "@shikijs/monaco": "3.23.0",
     "astro": "5.18.1",
     "astro-expressive-code": "0.41.7",
+    "es-toolkit": "^1.47.0",
     "esbuild-wasm": "0.25.12",
+    "marked": "^18.0.4",
     "monaco-editor": "0.52.2",
     "preact": "10.29.1",
     "rehype-autolink-headings": "7.1.0",
@@ -31,13 +34,12 @@
     "remark-gfm": "4.0.1",
     "remark-math": "6.0.0",
     "sharp": "0.34.5",
-    "shiki": "3.23.0",
-    "@shikijs/monaco": "3.23.0"
+    "shiki": "3.23.0"
   },
   "devDependencies": {
-    "typedoc": "0.28.19",
     "pixelmatch": "7.1.1",
     "playwright": "1.59.1",
-    "pngjs": "7.0.0"
+    "pngjs": "7.0.0",
+    "typedoc": "0.28.19"
   }
 }

--- a/site/src/components/Disclosure.astro
+++ b/site/src/components/Disclosure.astro
@@ -1,0 +1,122 @@
+---
+// A collapsible documentation section: a styled <details>/<summary>
+// whose header matches the visual scale of an `##` (h2) heading so a
+// `<Disclosure title="…">` reads like the section heading it replaces.
+// Used on the component pages to fold the Props and Component tokens
+// references away by default (the live demo stays the focus).
+//
+// `id` (or a slug derived from `title`) lands on the <details> element
+// so existing deep links — e.g. `#component-tokens` — keep resolving.
+interface Props {
+  title: string
+  /** Start expanded. Defaults to collapsed. */
+  open?: boolean
+  /** Anchor id. Defaults to a slug of `title`. */
+  id?: string
+}
+
+const { title, open = false, id } = Astro.props
+const slug = (id ?? title)
+  .toLowerCase()
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/(^-|-$)/g, '')
+---
+
+<details class="disclosure" id={slug} open={open}>
+  <summary class="summary">
+    <a-icon shape="chevron-right" class="chevron" style="--icon-size: 18px"></a-icon>
+    {/* Same anchor markup rehype-autolink-headings applies to `##`
+        headings (`behavior: 'wrap'`, classes `header-anchor muted`),
+        so the section deep-links and hover-underlines like the rest.
+        The href points at the <details>'s own id. */}
+    <a class="title header-anchor muted" href={`#${slug}`}>{title}</a>
+  </summary>
+  <div class="body">
+    <slot />
+  </div>
+</details>
+
+<style>
+  .disclosure {
+    margin-block: 32px 0;
+  }
+
+  .summary {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    color: var(--text-1);
+    /* Hide the default disclosure triangle — the chevron replaces it. */
+    list-style: none;
+  }
+  .summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .title {
+    font-size: 24px;
+    line-height: 28px;
+    font-weight: 584.62;
+    letter-spacing: 0;
+  }
+
+  .chevron {
+    color: var(--text-3);
+    flex-shrink: 0;
+    transition: transform 150ms ease-out, color 120ms ease-out;
+  }
+  .summary:hover .chevron {
+    color: var(--text-1);
+  }
+  .disclosure[open] > .summary .chevron {
+    transform: rotate(90deg);
+  }
+
+  .body {
+    margin-top: 12px;
+  }
+</style>
+
+<script>
+  // Make the disclosure headers behave like anchor-linked headings:
+  // clicking the header link always EXPANDS the section (never toggles
+  // it closed) and deep-links it, and arriving via a `#slug` URL opens
+  // the targeted section. Bundled once per page by Astro regardless of
+  // how many <Disclosure>s render, so it queries them all.
+  function openDisclosure(id: string): HTMLDetailsElement | null {
+    if (!id) return null
+    const el = document.getElementById(id)
+    if (el instanceof HTMLDetailsElement && el.classList.contains('disclosure')) {
+      el.open = true
+      return el
+    }
+    return null
+  }
+
+  // Deep links (shared URL, in-page nav): expand + scroll to the target.
+  function syncFromHash() {
+    const opened = openDisclosure(decodeURIComponent(location.hash.slice(1)))
+    if (opened) opened.scrollIntoView({ block: 'start' })
+  }
+  syncFromHash()
+  window.addEventListener('hashchange', syncFromHash)
+
+  // Header-link click: own the interaction so the section opens rather
+  // than relying on the native <summary> toggle (which doesn't fire for
+  // a nested link). stopPropagation keeps it from toggling closed; the
+  // chevron / summary still toggles normally for collapsing.
+  for (const a of document.querySelectorAll<HTMLAnchorElement>(
+    'details.disclosure > summary > a.header-anchor',
+  )) {
+    a.addEventListener('click', (e) => {
+      e.preventDefault()
+      e.stopPropagation()
+      const details = a.closest('details')
+      if (!details) return
+      details.open = true
+      if (details.id) location.hash = details.id
+    })
+  }
+</script>

--- a/site/src/components/InteractiveDemo.tsx
+++ b/site/src/components/InteractiveDemo.tsx
@@ -35,6 +35,7 @@ import { getDemoModules } from '../../lib/sandbox/modules.ts'
 import { replaceProp, readChildren } from '../../lib/sandbox/prop-patch.ts'
 import { readProp } from '../../lib/sandbox/prop-read.ts'
 import { parseExamples, type Example } from '../../lib/sandbox/parse-examples.ts'
+import { throttle } from 'es-toolkit'
 
 /** Path served from `site/public/`. The script is a self-contained
  *  browser ESM bundle of @antadesign/anta/elements + per-element CSS;
@@ -301,33 +302,66 @@ export default function InteractiveDemo({ component, initialCode, initialCss = '
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Form edits don't rewrite `code` on every event — doing so re-synced
+  // Monaco's model and re-parsed every field on each slider tick, which
+  // is what made the inputs feel sticky. Instead each change lands
+  // instantly in the control's local state (see FormField) and is queued
+  // here, keyed by prop (+example). A throttled flush rewrites the source
+  // at most ~7×/s — leading+trailing edges keep the preview live during a
+  // drag rather than only updating on release. Keying by prop means
+  // adjusting two props in quick succession can't drop one: the map keeps
+  // the latest value per key and the flush applies them all.
+  const pendingEditsRef = useRef(
+    new Map<
+      string,
+      { prop: PropEntry; value: string | number | boolean | null; exampleId?: string }
+    >(),
+  )
+
+  const flushFormEdits = useMemo(
+    () =>
+      throttle(() => {
+        const edits = Array.from(pendingEditsRef.current.values())
+        pendingEditsRef.current.clear()
+        if (edits.length === 0) return
+        // Apply every queued edit in one functional update so we read
+        // the LATEST source (a Monaco edit or Reset may have raced) and
+        // commit a single new `code`. Per-example edits re-parse the
+        // boundaries inside the updater — they shift as the file grows.
+        setCode((prev) => {
+          let next = prev
+          for (const { prop, value, exampleId } of edits) {
+            if (!exampleId) {
+              next = replaceProp(next, component, prop.prop, value)
+              continue
+            }
+            const latest = parseExamples(next).find((e) => e.id === exampleId)
+            if (!latest || !latest.tagName) continue
+            next = replaceProp(next, latest.tagName, prop.prop, value, {
+              start: latest.jsxStart,
+              end: latest.jsxEnd,
+            })
+          }
+          return next
+        })
+      }, 150),
+    [component],
+  )
+
+  // Drop any trailing flush if the playground unmounts.
+  useEffect(() => () => flushFormEdits.cancel(), [flushFormEdits])
+
   function handleFormChange(
     prop: PropEntry,
     value: string | number | boolean | null,
     exampleId?: string,
   ) {
-    // Compute the next code from the LATEST committed state via the
-    // functional setter form. A stale closure (e.g. the user pasted
-    // into Monaco while React had not yet committed the resulting
-    // state) would otherwise resurrect an older source and wipe the
-    // paste. When an exampleId is supplied, re-parse inside the
-    // updater so the range we patch is up-to-date with whatever the
-    // latest source looks like — example boundaries shift as the
-    // file grows. The bound tag name comes from the example itself,
-    // not the global `component` prop — examples can use any tag
-    // (`Progress`, `AnimatedProgress`, …) and the form binds to
-    // whichever one the example declared.
-    setCode((prev) => {
-      if (!exampleId) {
-        return replaceProp(prev, component, prop.prop, value)
-      }
-      const latest = parseExamples(prev).find((e) => e.id === exampleId)
-      if (!latest || !latest.tagName) return prev
-      return replaceProp(prev, latest.tagName, prop.prop, value, {
-        start: latest.jsxStart,
-        end: latest.jsxEnd,
-      })
+    pendingEditsRef.current.set(`${exampleId ?? 'root'}::${prop.prop.name}`, {
+      prop,
+      value,
+      exampleId,
     })
+    flushFormEdits()
   }
 
   // ────────────────────────────────────────────────────────────────
@@ -445,7 +479,13 @@ export default function InteractiveDemo({ component, initialCode, initialCss = '
               class={s.resetBtn}
               aria-label="Reset props and code"
               title="Reset props and code"
-              onClick={() => setCode(initialCode)}
+              onClick={() => {
+                // Drop any queued form edits so a trailing flush can't
+                // re-apply them on top of the freshly reset source.
+                flushFormEdits.cancel()
+                pendingEditsRef.current.clear()
+                setCode(initialCode)
+              }}
             >
               <a-icon shape="refresh-ccw-dot" style={{ '--icon-size': '14px' } as any} />
             </button>
@@ -626,14 +666,27 @@ function FormField({
   // would do if they leave the field blank.
   const current = read?.kind === 'literal' ? read.value : undefined
 
+  // Optimistic local value: the control reflects the user's input
+  // immediately while the throttled rewrite of `code` catches up
+  // (see `flushFormEdits`). Re-sync from the parsed source whenever it
+  // changes externally — a Monaco edit, a Reset, or the throttled flush
+  // landing the value we just set (a same-value set, so Preact skips
+  // the re-render and there's no feedback loop).
+  const [value, setValue] = useState<string | number | boolean | undefined>(current)
+  useEffect(() => { setValue(current) }, [current])
+  const handle = (v: string | number | boolean | null) => {
+    setValue(v == null ? undefined : v)
+    onChange(v)
+  }
+
   if (c.kind === 'boolean') {
     return (
       <label class={s.fieldBoolean}>
         <input
           type="checkbox"
-          checked={current === true}
+          checked={value === true}
           disabled={fromExpression}
-          onChange={(e) => onChange((e.currentTarget as HTMLInputElement).checked)}
+          onChange={(e) => handle((e.currentTarget as HTMLInputElement).checked)}
         />
         <span>
           <code>{c.name}{entry.optional ? '?' : ''}</code>
@@ -653,15 +706,15 @@ function FormField({
         </span>
         {fromExpression
           ? <span class={s.fieldExpressionBadge}>set by code</span>
-          : c.kind === 'slider' && typeof current === 'number'
-            ? <span class={s.fieldValueLabel}>{current}</span>
+          : c.kind === 'slider' && typeof value === 'number'
+            ? <span class={s.fieldValueLabel}>{value}</span>
             : null}
       </div>
       <FieldControl
         control={c}
-        value={current}
+        value={value}
         disabled={fromExpression}
-        onChange={onChange}
+        onChange={handle}
       />
     </div>
   )

--- a/site/src/components/InteractiveDemo.tsx
+++ b/site/src/components/InteractiveDemo.tsx
@@ -18,6 +18,16 @@
  */
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
 import s from './InteractiveDemo.module.css'
+// Monaco ships its structural CSS as ~110 separate `import './x.css'`
+// side-effect imports inside its ESM build. Vite injects each one
+// live in dev (so the editor looks right under `pnpm dev`) but emits
+// none of them into the production bundle, since they're only reached
+// through the lazily-imported `monaco-editor` chunk. Without these
+// rules the editor's hidden <textarea> (`.inputarea`) falls back to
+// the UA default (border + resize grip) and the layout breaks. Pull
+// in Monaco's concatenated stylesheet statically so it's always part
+// of this island's CSS in both dev and prod.
+import 'monaco-editor/min/vs/editor/editor.main.css'
 
 import { controlsFor, controlsForExample, type Control, type PropEntry } from '../../lib/sandbox/props-form.ts'
 import { bundle, type BundleResult } from '../../lib/sandbox/bundler.ts'

--- a/site/src/components/Markdown.astro
+++ b/site/src/components/Markdown.astro
@@ -1,0 +1,22 @@
+---
+// Build-time markdown → HTML. Put markdown text as the children and it
+// renders to HTML inline (server-side, at build). General-purpose helper
+// for authored content; `inline` skips the wrapping <p> for inline
+// contexts. (Docs tables render their cells as inline markdown directly
+// — see PropsTable — rather than reaching for this.)
+//
+// The content is trusted (our own authored text), so `set:html` is safe;
+// don't pipe untrusted input through this.
+import { marked } from 'marked'
+
+interface Props {
+  /** Render inline — no wrapping <p>. */
+  inline?: boolean
+}
+
+const { inline = false } = Astro.props
+const source = await Astro.slots.render('default')
+const html = await (inline ? marked.parseInline(source) : marked.parse(source))
+---
+
+<Fragment set:html={html} />

--- a/site/src/components/PropsTable.astro
+++ b/site/src/components/PropsTable.astro
@@ -1,5 +1,6 @@
 ---
 import api from '../api.json'
+import { marked } from 'marked'
 
 interface Props {
   component: string
@@ -37,14 +38,15 @@ function renderType(type: any): string {
   }
 }
 
-function renderComment(comment: any): string {
+// TypeDoc splits a JSDoc summary into parts (`text` prose + `code`
+// spans whose `text` keeps its backticks), so joining the raw `text`
+// of every part reconstructs the original markdown source. Render it
+// as inline markdown (no wrapping <p>) so `` `code` ``, **bold**,
+// links, etc. in prop descriptions display formatted in the table.
+function renderDescription(comment: any): string {
   if (!comment?.summary) return ''
-  return comment.summary
-    .map((part: any) => {
-      if (part.kind === 'code') return part.text
-      return part.text
-    })
-    .join('')
+  const md = comment.summary.map((part: any) => part.text).join('')
+  return marked.parseInline(md) as string
 }
 
 const props = iface?.children
@@ -78,7 +80,7 @@ const inherited = iface?.children
               <code>{p.name}{p.flags?.isOptional ? '?' : ''}</code>
             </td>
             <td><code>{renderType(p.type)}</code></td>
-            <td>{renderComment(p.comment)}</td>
+            <td set:html={renderDescription(p.comment)} />
           </tr>
         ))}
       </tbody>
@@ -103,7 +105,7 @@ const inherited = iface?.children
             <tr>
               <td><code>{p.name}?</code></td>
               <td><code>{renderType(p.type)}</code></td>
-              <td>{renderComment(p.comment)}</td>
+              <td set:html={renderDescription(p.comment)} />
             </tr>
           ))}
         </tbody>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -253,7 +253,7 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
     width: 240px;
     flex-shrink: 0;
     background: var(--bg-pane);
-    border-right: 1px solid var(--border-5);
+    /* border-right: 1px solid var(--border-5); */
     padding: 24px 12px 24px 24px;
     position: sticky;
     top: 0;
@@ -314,7 +314,7 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
 
   .brand-links {
     display: flex;
-    gap: 6px;
+    gap: 0;
     margin: -20px 0 24px;
     flex-wrap: wrap;
   }
@@ -323,15 +323,14 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
     display: inline-flex;
     align-items: center;
     gap: 4px;
-    padding: 3px 8px;
-    border: 1px solid var(--border-5);
+    padding: 3px 8px 3px 6px;
     border-radius: 999px;
     font-size: 11px;
     font-weight: 500;
     letter-spacing: 0.03ch;
     color: var(--text-3);
     text-decoration: none;
-    transition: color 120ms ease-out, border-color 120ms ease-out, background 120ms ease-out;
+    transition: color 120ms ease-out, background 120ms ease-out;
   }
 
   .brand-links a > a-icon {
@@ -342,7 +341,6 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
   .brand-links a:hover,
   .brand-links a:focus-visible {
     color: var(--text-1);
-    border-color: var(--border-3);
     background: var(--bg-section);
     outline: none;
   }

--- a/site/src/pages/components/icon.mdx
+++ b/site/src/pages/components/icon.mdx
@@ -4,6 +4,7 @@ title: Icon
 ---
 import IconDemo from '../../components/IconDemo'
 import PropsTable from '../../components/PropsTable.astro'
+import Disclosure from '../../components/Disclosure.astro'
 
 # Icon
 
@@ -18,9 +19,11 @@ any custom icons you generate yourself.
 > way without the wrapping element. Use `<Icon>` when you need a
 > standalone icon outside of any other component.
 
-## Props
+<Disclosure title="Props">
 
 <PropsTable component="Icon" />
+
+</Disclosure>
 
 ## Built-in shapes
 

--- a/site/src/pages/components/progress.mdx
+++ b/site/src/pages/components/progress.mdx
@@ -3,6 +3,8 @@ layout: ../../layouts/DocsLayout.astro
 title: Progress
 ---
 import InteractiveDemo from '../../components/InteractiveDemo'
+import PropsTable from '../../components/PropsTable.astro'
+import Disclosure from '../../components/Disclosure.astro'
 // The demo source lives in a sibling `.ts` file rather than inline
 // here because Astro's MDX pipeline trims leading whitespace from
 // JSX-attribute template literals, which scrambles the indentation
@@ -22,7 +24,13 @@ A progress indicator for displaying task completion. Consists of a track
   initialCode={progressDemoCode}
 />
 
-## Component tokens
+<Disclosure title="Props">
+
+<PropsTable component="Progress" />
+
+</Disclosure>
+
+<Disclosure title="Component tokens">
 
 Progress exposes these CSS custom properties as its theming surface. Override any of them in consumer CSS to retint a single instance, or set them on a `[tone="…"]` selector to add a new tone variant. Tokens marked *(shadow-only API)* style elements inside the shadow DOM and can **only** be customized via these properties — consumer CSS can't reach those elements directly.
 
@@ -34,3 +42,5 @@ Progress exposes these CSS custom properties as its theming surface. Override an
 | `--progress-indicator-edge` *(shadow-only API)* | Gradient painted at the indicator's right edge. Defaults to `linear-gradient(90deg in oklch, var(--progress-indicator-bg), var(--progress-border-color))`. |
 | `--progress-text-color` | Colour of the percentage number and the label text. |
 | `--progress-hint-color` | Colour of the right-aligned hint text. |
+
+</Disclosure>

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -4,6 +4,8 @@ title: Text
 ---
 import TextDemo from '../../components/TextDemo'
 import InteractiveDemo from '../../components/InteractiveDemo'
+import PropsTable from '../../components/PropsTable.astro'
+import Disclosure from '../../components/Disclosure.astro'
 import textDemoCode from './text.demo.ts'
 
 # Text
@@ -54,7 +56,13 @@ the underline to full alpha.
 
 <TextDemo client:load />
 
-## Component tokens
+<Disclosure title="Props">
+
+<PropsTable component="Text" />
+
+</Disclosure>
+
+<Disclosure title="Component tokens">
 
 `Text` derives its colors from the global token system. Every variable
 below has a light and dark mode value defined in
@@ -76,3 +84,5 @@ resolved values into its descendant link rule:
 | `--text-link-color`            | Color used by `a-text a` at rest             |
 | `--text-link-hover`            | Color used by `a-text a:hover`               |
 | `--text-link-underline-alpha`  | Alpha applied to the underline (50% / 100%)  |
+
+</Disclosure>

--- a/site/src/pages/components/title.mdx
+++ b/site/src/pages/components/title.mdx
@@ -4,6 +4,8 @@ title: Title
 ---
 import { Title, Text, Icon } from '@antadesign/anta'
 import InteractiveDemo from '../../components/InteractiveDemo'
+import PropsTable from '../../components/PropsTable.astro'
+import Disclosure from '../../components/Disclosure.astro'
 import titleDemoCode from './title.demo.ts'
 
 # Title
@@ -188,3 +190,9 @@ announce it correctly. Search-engine crawlers, however, generally
 ignore ARIA headings — if SEO matters, write raw `<h{level}>` instead
 (it gets the same visual treatment from the reset) and skip the
 component.
+
+<Disclosure title="Props">
+
+<PropsTable component="Title" />
+
+</Disclosure>

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -221,7 +221,11 @@ code[data-copied]::after {
   scrollbar-width: thin;
   margin: 0 0 24px;
 }
-.table-wrap > table {
+/* The wrap owns the bottom margin; zero it on the inner table so a
+   wrapped table doesn't stack its own `.content table` margin on top
+   of the wrap's (which doubled the gap). Scoped to `.content` so it
+   outranks the equal-specificity-but-later `.content table` rule below. */
+.content .table-wrap > table {
   margin: 0;
 }
 


### PR DESCRIPTION
Docs-site (`site/`) fixes and improvements. No changes to the published `@antadesign/anta` package — nothing here ships to npm consumers.

## What's in here (focused commits)

### 1. Fix: Monaco editor renders broken in production
The playground's code editor lost its structural CSS in production builds — the hidden `<textarea>` showed the browser's default border + resize grip. Monaco's ESM build pulls its CSS through ~110 per-module `import './x.css'` side-effects; Vite injects those live in dev but emitted none of them into the prod bundle (they're only reached via the lazily-imported `monaco-editor` chunk). Statically importing Monaco's concatenated stylesheet into the island makes Vite always emit it. **This was a pre-existing prod bug** — invisible under `pnpm dev`, only visible on deploy.

### 2. Faster playground prop inputs
Form controls rewrote the source `code` on every event, re-syncing Monaco's model and re-parsing every field per keystroke/slider tick — inputs felt sticky. Controls now hold optimistic local state (instant feedback) and queue edits, flushed via a throttled (150 ms, leading+trailing) rewrite keyed by prop so rapid edits to different props aren't dropped. Adds `es-toolkit`.

### 3. Collapsible, anchor-linked Props / Component tokens sections
New `Disclosure.astro` — a `<details>/<summary>` styled like an `h2`, collapsed by default, using the same `header-anchor` markup as the `##` headings so sections deep-link and hover-underline. A small inline script expands a section on header-link click and when arriving via a `#slug` URL. Applied to **progress, text, icon, title** (Props above Component tokens).

### 4. Markdown in the generated props table
JSDoc prop descriptions (e.g. `` `16` ``) rendered as literal text. They're now rendered as inline markdown via `marked`. Also adds a general-purpose, children-based `Markdown.astro` build-time helper for future use. Adds `marked`.

### 5. Small fixes
- Wrapped tables no longer double their bottom margin (`.table-wrap` + `.content table` both applied 24 px).
- Sidebar tweaks: borderless brand pills, flush layout, no right border.

## Testing
- `pnpm --filter anta-site build` passes; verified the Monaco `.inputarea` reset now lands in the emitted CSS, and props-table descriptions render `<code>`/markdown in both dev and a local production preview.

## Follow-ups
- `button.mdx` lives on the `anta-button` branch; it'll want the same Disclosure treatment when that merges.