### PR TITLE
site: add "none" option to playground segmented controls

### DIFF
--- a/site/lib/sandbox/props-form.ts
+++ b/site/lib/sandbox/props-form.ts
@@ -58,7 +58,11 @@ export type Control =
   | { kind: 'number'; name: string; defaultValue?: number; description?: string }
   | { kind: 'text'; name: string; defaultValue?: string; description?: string }
   | { kind: 'boolean'; name: string; defaultValue?: boolean; description?: string }
-  | { kind: 'segmented'; name: string; options: string[]; defaultValue?: string; description?: string }
+  /** `clearable` adds a leading "none" button that removes the
+   *  attribute entirely. Set for optional props with no `@defaultValue`,
+   *  where omitting the attribute is a meaningful state the radiogroup
+   *  otherwise can't express (e.g. Button's `underline`). */
+  | { kind: 'segmented'; name: string; options: string[]; defaultValue?: string; clearable?: boolean; description?: string }
   /** Named-tone tabs + a "Custom" tab that reveals a color input. `options`
    *  are the named literals; a value outside them is treated as a custom
    *  color. Serialized as a plain string attribute (`tone="…"`). */
@@ -340,8 +344,12 @@ function controlFor(p: any): PropEntry | null {
       // attribute when the user picks the default, hiding the
       // selection from the rendered output.
       const defaultValue = readDefaultValueTag(p.comment)
+      // An optional prop with no documented default can be omitted
+      // entirely — surface that as a leading "none" button rather than
+      // leaving the radiogroup with no active selection.
+      const clearable = optional && defaultValue === undefined
       return wrap(
-        { kind: 'segmented', name, options, defaultValue, description },
+        { kind: 'segmented', name, options, defaultValue, clearable, description },
         { name, kind: 'literal-union' },
       )
     }

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -891,6 +891,22 @@ function FieldControl({
       const selected = value !== undefined ? value : control.defaultValue
       return (
         <div class={`${s.segment} ${cls}`} role="radiogroup" aria-label={control.name}>
+          {control.clearable && (
+            // Optional prop with no default — "none" clears the attribute
+            // so the omitted state is selectable, and stays lit while
+            // nothing else is chosen.
+            <button
+              key="__none"
+              type="button"
+              role="radio"
+              aria-checked={selected === undefined}
+              class={selected === undefined ? `${s.segBtn} ${s.segBtnActive}` : s.segBtn}
+              onClick={() => onChange(null)}
+              disabled={disabled}
+            >
+              none
+            </button>
+          )}
           {control.options.map((opt) => (
             <button
               key={opt}


### PR DESCRIPTION
## What

Adds a **none** option to the docs-site playground's segmented controls so an optional prop can be returned to its omitted state.

On the Button page, the `underline` control previously rendered as `solid | dashed | dotted` with **no way to express "no underline"** — when the attribute was absent, no button was lit, and a radiogroup can't be deselected. Since `underline` is optional, "none" now leads the group and clears the attribute.

## How

- **`props-form.ts`** — adds a `clearable` flag to the `segmented` control, set when a literal-union prop is **optional and has no `@defaultValue`**. This is a general rule: today it matches only `underline` (priority/size carry defaults; tone is its own control), and any future optional-without-default segmented prop inherits it automatically.
- **`Playground.tsx`** — renders a leading **none** button when `clearable`; clicking it passes `null` to remove the attribute, and it stays lit while nothing else is selected.

"none" means *omit the attribute* (no underline rendered) — not a new `underline="none"` literal. Text/number controls already express "absent" via an empty field, so they needed nothing.

## Scope

Docs-site only — **no change to the `@antadesign/anta` package or its API**, so no `CHANGELOG.md` entry.

## Verification

- `pnpm --filter anta-site build` — green (17 pages).
- Drove the live playground: with `priority: tertiary`, the underline control reads `none | solid | dashed | dotted` with **none** active by default; clicking `solid` sets the attribute and clicking `none` removes it (round-trip confirmed against the parsed source).
