### PR TITLE
Fix sticky link :hover on touch devices (reset.css)

### DIFF
--- a/src/reset.css
+++ b/src/reset.css
@@ -118,11 +118,15 @@
     text-decoration-thickness: 0.5px;
     text-underline-offset: 3px;
   }
-  a:hover {
-    color: var(--link-color-hover);
-    /* Underline color is left as the resting hairline (the base rule's
-       `currentColor` mix) — only the thickness grows on hover. */
-    text-decoration-thickness: 1px;
+  /* Hover only on real-pointer devices — gating avoids the sticky hover
+     color that lingers after a tap on touch screens. */
+  @media (hover: hover) and (pointer: fine) {
+    a:hover {
+      color: var(--link-color-hover);
+      /* Underline color is left as the resting hairline (the base rule's
+         `currentColor` mix) — only the thickness grows on hover. */
+      text-decoration-thickness: 1px;
+    }
   }
   a:active {
     text-decoration-color: color-mix(in srgb, currentColor 75%, transparent);


### PR DESCRIPTION
## What

Gates the global `a:hover` rule in `src/reset.css` behind `@media (hover: hover) and (pointer: fine)`, so the link hover color only applies on real-pointer devices.

## Why

The Unreleased → Fixed entry in `CHANGELOG.md` already documents this fix and lists `reset.css` among the affected files:

> Hover-only appearance changes (… and the global `a` / `a-text a` link hover) are now gated behind `@media (hover: hover) and (pointer: fine)` …

But `reset.css` never actually received the gating — `a-button.css` and `a-text.css` did. This change brings `reset.css` in line with what's already documented, so tapped links return to their rest state on touch devices instead of keeping the hover color until the next tap. `:active` press feedback is unchanged.

No CHANGELOG edit needed — the entry already covers this.