### PR TITLE
Make Interface Kit dev-only; fix code-block header width

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,9 +67,6 @@ importers:
       esbuild-wasm:
         specifier: 0.25.12
         version: 0.25.12
-      interface-kit:
-        specifier: ^0.1.3
-        version: 0.1.3(react-dom@19.2.6)(react@19.2.5)
       marked:
         specifier: ^18.0.4
         version: 18.0.4
@@ -110,6 +107,9 @@ importers:
         specifier: 3.23.0
         version: 3.23.0
     devDependencies:
+      interface-kit:
+        specifier: ^0.1.3
+        version: 0.1.3(react-dom@19.2.6)(react@19.2.5)
       pixelmatch:
         specifier: 7.1.1
         version: 7.1.1
@@ -2366,7 +2366,7 @@ packages:
       react: 19.2.5
       react-dom: 19.2.6(react@19.2.5)
       tslib: 2.8.1
-    dev: false
+    dev: true
 
   /fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -2715,7 +2715,7 @@ packages:
       react-dom: 19.2.6(react@19.2.5)
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
-    dev: false
+    dev: true
 
   /iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -3826,11 +3826,11 @@ packages:
     resolution: {integrity: sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==}
     dependencies:
       motion-utils: 12.39.0
-    dev: false
+    dev: true
 
   /motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
-    dev: false
+    dev: true
 
   /motion@12.40.0(react-dom@19.2.6)(react@19.2.5):
     resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
@@ -3850,7 +3850,7 @@ packages:
       react: 19.2.5
       react-dom: 19.2.6(react@19.2.5)
       tslib: 2.8.1
-    dev: false
+    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4126,12 +4126,10 @@ packages:
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
-    dev: false
 
   /react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -4480,7 +4478,6 @@ packages:
 
   /scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-    dev: false
 
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -4726,7 +4723,6 @@ packages:
 
   /tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-    dev: false
 
   /type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,6 @@
     "astro-expressive-code": "0.41.7",
     "es-toolkit": "^1.47.0",
     "esbuild-wasm": "0.25.12",
-    "interface-kit": "^0.1.3",
     "marked": "^18.0.4",
     "monaco-editor": "0.52.2",
     "preact": "10.29.1",
@@ -38,6 +37,7 @@
     "shiki": "3.23.0"
   },
   "devDependencies": {
+    "interface-kit": "^0.1.3",
     "pixelmatch": "7.1.1",
     "playwright": "1.59.1",
     "pngjs": "7.0.0",

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -216,62 +216,26 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
     <div class="backdrop" aria-hidden="true"></div>
 
     <script>
-      // Interface Kit — visual styling tool, mounted on every docs page (in
-      // every build, including production). It's tucked just off the top-right
-      // corner of the viewport and slides into view only when the pointer
-      // enters a 96×96px hotspot in that corner — or while its editor is
-      // active. interface-kit is a React 19 tool run under preact/compat via
-      // the `useEffectEvent` shim wired up in astro.config.mjs; it renders
-      // nothing inline and injects its own floating paintbrush bubble + editor
-      // panel into a shadow DOM under the host it appends to `mountTarget`.
+      // Interface Kit — DEV-ONLY visual styling tool, mounted on every docs page
+      // during local development as a plain paintbrush bubble in the top-right
+      // corner. interface-kit is a React 19 tool run under preact/compat via the
+      // `useEffectEvent` shim wired up in astro.config.mjs; it renders nothing
+      // inline and injects its own floating bubble + editor panel into the page.
       //
-      // `enabled: true` is passed explicitly so the kit stays on regardless of
-      // NODE_ENV — its own auto-disable only kicks in when `enabled` is unset.
-      // `mountTarget` lands the kit's shadow host inside our `.ik-mount`
-      // element; a transform on `.ik-mount` becomes the containing block for
-      // the kit's `position: fixed` bubble, which is how we slide it off-screen
-      // and back via CSS (see the `.ik-mount` rules below).
-      const HOTSPOT = 96
-      const [{ render, createElement }, { InterfaceKit }] = await Promise.all([
-        import('preact/compat'),
-        import('interface-kit/react'),
-      ])
-
-      const mount = document.createElement('div')
-      mount.className = 'ik-mount'
-      document.body.appendChild(mount)
-
-      render(
-        createElement(InterfaceKit, {
-          enabled: true,
-          mountTarget: mount,
-          // Pin the bubble in view while the editor is active so it doesn't
-          // slide away mid-edit when the pointer leaves the hotspot.
-          onStateChange: (payload: { snapshot: { isActive: boolean } } | null) => {
-            document.body.dataset.ikActive = payload?.snapshot.isActive ? 'true' : 'false'
-          },
-        }),
-        mount,
-      )
-
-      // Reveal when the pointer is inside the top-right 96×96 corner. We sniff
-      // the region with a `pointermove` listener rather than an overlay element
-      // so we never block clicks on whatever sits in that corner (e.g. the TOC
-      // rail). The kit's bubble lives within the hotspot, so moving onto it
-      // keeps the reveal latched; the active-state flag covers the rest.
-      let revealed = false
-      const setReveal = (on: boolean) => {
-        if (on === revealed) return
-        revealed = on
-        document.body.dataset.ikReveal = on ? 'true' : 'false'
+      // The `import.meta.env.DEV` guard is statically `false` in the production
+      // build, so Vite dead-code-eliminates this whole block — interface-kit (and
+      // its ~420 KB React→preact chunk) never enters the deployed bundle, and the
+      // public site can't summon the editor. (That's also why `interface-kit` is
+      // a devDependency.) `enabled: true` keeps the kit on regardless of NODE_ENV.
+      if (import.meta.env.DEV) {
+        const [{ render, createElement }, { InterfaceKit }] = await Promise.all([
+          import('preact/compat'),
+          import('interface-kit/react'),
+        ])
+        const mount = document.createElement('div')
+        document.body.appendChild(mount)
+        render(createElement(InterfaceKit, { enabled: true }), mount)
       }
-      window.addEventListener(
-        'pointermove',
-        (e) => setReveal(e.clientX >= window.innerWidth - HOTSPOT && e.clientY <= HOTSPOT),
-        { passive: true },
-      )
-      // Pointer left the window entirely — tuck it back.
-      document.addEventListener('pointerleave', () => setReveal(false))
     </script>
 
     <script>
@@ -693,31 +657,6 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
       margin-inline: 6px;
       color: var(--text-4);
       font-weight: 400;
-    }
-  }
-</style>
-
-<style is:global>
-  /* Interface Kit launcher — tucked off the top-right corner, revealed when
-     the pointer enters the top-right hotspot or while the editor is active.
-     `.ik-mount` is created at runtime (so it's outside Astro's scoped styles,
-     hence `is:global`) and hosts the kit's shadow DOM. The transform makes it
-     the containing block for the kit's `position: fixed` bubble, so translating
-     it slides the bubble off-screen; the 96px/-96px offset clears the 44px
-     bubble at its 16px top/right inset. Revealed/active state uses
-     `transform: none` so the kit's viewport-relative overlay math stays exact
-     while it's in use. */
-  .ik-mount {
-    transform: translate(96px, -96px);
-    transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
-  }
-  body[data-ik-reveal='true'] .ik-mount,
-  body[data-ik-active='true'] .ik-mount {
-    transform: none;
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .ik-mount {
-      transition: none;
     }
   }
 </style>

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -326,6 +326,13 @@ pre code { background: none; padding: 0; }
 .content .expressive-code .frame.is-terminal,
 .content .expressive-code .frame[data-foldable] {
   display: grid;
+  /* Clamp the single column to the figure width. Without this the implicit
+     `auto` column grows to the `<pre>`'s longest line (grid items default to
+     `min-width: auto`), and the `<figcaption>` header stretches to that
+     over-wide track — pushing its right border outside the `overflow: hidden`
+     figure (most visible when folded). `minmax(0, 1fr)` pins the column to the
+     container; wide code scrolls inside the `<pre>` (its own `overflow: auto`). */
+  grid-template-columns: minmax(0, 1fr);
   grid-template-rows: var(--fold-header-h) 1fr;
   overflow: hidden;
 }


### PR DESCRIPTION
Two docs-site (`site/`) changes. No consumer-facing package change.

## 1. Interface Kit → dev-only (remove from production)
The Interface Kit had been mounted on every build (incl. the deployed site), tucked off-screen behind a top-right hover hotspot. That shipped its ~420 KB React→preact chunk to production and let any visitor summon the styling editor. This reverts that:

- Re-gate the mount behind `import.meta.env.DEV`, so Vite dead-code-eliminates it from the production build (interface-kit never enters the deployed bundle, public site can't open the editor).
- Move `interface-kit` back to `devDependencies`.
- In dev it's now a plain paintbrush bubble in the top-right corner — dropped the `mountTarget`/`pointermove`/`onStateChange` hotspot machinery and the `.ik-mount` global CSS, which only existed to hide it discreetly on the public site.

**Verified:** prod build (18 pages) ships no `interface-kit`/`data-interface-kit`/`ik-mount`/etc.; dev server mounts the bubble; `pnpm run typecheck` clean.

## 2. Fix: keep code-block header within the figure width
Foldable/titled code-block frames are `display: grid` with `overflow: hidden` but no `grid-template-columns`, so the implicit `auto` column grew to the `<pre>`'s longest line (grid items default to `min-width: auto`). The `<figcaption>` header stretched to that over-wide track, pushing its right border outside the clipped figure — most visible when folded.

Fix: `grid-template-columns: minmax(0, 1fr)` clamps the column to the figure width; wide code scrolls inside the `<pre>` instead.

**Verified live (measured):** on `/components/button/`, every folded frame's header = figure width with 0px overflow; a frame whose code is 818px wide (vs a 736px figure) now clamps the header to 736px and scrolls the `<pre>` internally — pre-fix it overflowed ~82px past the clipped figure.