### PR TITLE
fix(reset): prose links in <Text> take currentColor, not global blue

### DIFF
--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -3,6 +3,8 @@ layout: ../../layouts/DocsLayout.astro
 title: Text
 ---
 import TextDemo from '../../components/TextDemo'
+import TruncateDemo from '../../components/TruncateDemo'
+import ExpandableDemo from '../../components/ExpandableDemo'
 import Playground from '../../components/Playground'
 import PropsTable from '../../components/PropsTable.astro'
 import Disclosure from '../../components/Disclosure.astro'
@@ -59,6 +61,46 @@ the underline to full alpha.
 />
 
 </Disclosure>
+
+## Truncation
+
+```tsx
+{/* Single line */}
+<Text truncate>
+  This very long sentence will be cut off with an ellipsis…
+</Text>
+
+{/* Multi-line — pass the line count */}
+<Text truncate={3}>
+  Long paragraph that wraps across many lines but stops at three…
+</Text>
+```
+
+<TruncateDemo client:load />
+
+`truncate` accepts either `true` (or `1`) for a single-line ellipsis or
+any integer ≥ 2 for multi-line clamping. Both modes use
+`-webkit-line-clamp` inside `display: -webkit-box`. Despite the
+`-webkit-` prefix, every major browser supports it (Firefox 68+,
+Chrome, Safari, Edge). The host gets `min-width: 0` so truncation
+works correctly inside flex and grid containers.
+
+## Expandable
+
+```tsx
+<Text truncate expandable>…</Text>
+<Text truncate={3} expandable>…</Text>
+```
+
+Pair `expandable` with `truncate` to let the user reveal the full
+text. Single-line truncation gets a horizontal fade on the right edge;
+multi-line gets a vertical fade over the last line. A chevron-down
+hint appears in the bottom-right corner on hover or keyboard focus.
+The chevron is a real `<button>` carrying `aria-expanded` — clicking it
+(or focusing it and pressing Enter) drops the clamp and reveals the
+full text. `expandable` only takes effect together with `truncate`.
+
+<ExpandableDemo client:load />
 
 <Disclosure title="Component props">
 

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -69,8 +69,6 @@ the underline to full alpha.
 <Columns>
 <Col>
 
-### Truncate
-
 <TruncateDemo client:load />
 
 `truncate` accepts either `true` (or `1`) for a single-line ellipsis or
@@ -91,8 +89,6 @@ works correctly inside flex and grid containers.
 
 </Col>
 <Col>
-
-### Expandable
 
 <ExpandableDemo client:load />
 

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -8,6 +8,8 @@ import ExpandableDemo from '../../components/ExpandableDemo'
 import Playground from '../../components/Playground'
 import PropsTable from '../../components/PropsTable.astro'
 import Disclosure from '../../components/Disclosure.astro'
+import Columns from '../../components/Columns.astro'
+import Col from '../../components/Col.astro'
 import textDemoCode from './text.demo.ts'
 
 # Text
@@ -62,19 +64,12 @@ the underline to full alpha.
 
 </Disclosure>
 
-## Truncation
+## Truncation & expansion
 
-```tsx
-{/* Single line */}
-<Text truncate>
-  This very long sentence will be cut off with an ellipsis…
-</Text>
+<Columns>
+<Col>
 
-{/* Multi-line — pass the line count */}
-<Text truncate={3}>
-  Long paragraph that wraps across many lines but stops at three…
-</Text>
-```
+### Truncate
 
 <TruncateDemo client:load />
 
@@ -85,12 +80,21 @@ any integer ≥ 2 for multi-line clamping. Both modes use
 Chrome, Safari, Edge). The host gets `min-width: 0` so truncation
 works correctly inside flex and grid containers.
 
-## Expandable
+```tsx folded
+{/* Single line */}
+<Text truncate>{longSentence}</Text>
 
-```tsx
-<Text truncate expandable>…</Text>
-<Text truncate={3} expandable>…</Text>
+{/* Multi-line — pass the line count */}
+<Text truncate={2}>{longSentence}</Text>
+<Text truncate={3}>{longSentence}</Text>
 ```
+
+</Col>
+<Col>
+
+### Expandable
+
+<ExpandableDemo client:load />
 
 Pair `expandable` with `truncate` to let the user reveal the full
 text. Single-line truncation gets a horizontal fade on the right edge;
@@ -100,7 +104,14 @@ The chevron is a real `<button>` carrying `aria-expanded` — clicking it
 (or focusing it and pressing Enter) drops the clamp and reveals the
 full text. `expandable` only takes effect together with `truncate`.
 
-<ExpandableDemo client:load />
+```tsx folded
+<Text truncate expandable>{longSentence}</Text>
+<Text truncate={3} expandable>{longSentence}</Text>
+<Text truncate={5} expandable>{longSentence}</Text>
+```
+
+</Col>
+</Columns>
 
 <Disclosure title="Component props">
 

--- a/src/reset.css
+++ b/src/reset.css
@@ -108,14 +108,18 @@
   /* Global link defaults. Hairline underline at 75% alpha;
      underline goes to currentColor (100%) and 1px on hover. Color
      comes from --link-color tokens, which auto-flip in dark mode.
-     `:not([role="button"])` excludes anchor-buttons (`<a role="button">`,
+     `:not(:where([role="button"]))` excludes anchor-buttons (`<a role="button">`,
      e.g. `<Button href>`): `a:link`/`a:visited` are pseudo-classes with the
      same (0,1,1) specificity as `a[role="button"]`, so without the exclusion
      they'd tie and win on source order, giving buttons link colour +
-     underline. Other contexts (nav, headings) still override as needed. */
-  a:not([role="button"]),
-  a:not([role="button"]):link,
-  a:not([role="button"]):visited {
+     underline. The `:where()` keeps the exclusion specificity-neutral so this
+     base rule stays at (0,0,1)/(0,1,1) — a bare `:not([role="button"])` would
+     add an attribute selector's weight and out-specify prose-link overrides
+     like `a-text a` / the <Button> prose-link rule, leaving their links stuck
+     on the global blue. Other contexts (nav, headings) still override as needed. */
+  a:not(:where([role="button"])),
+  a:not(:where([role="button"])):link,
+  a:not(:where([role="button"])):visited {
     color: var(--link-color);
     text-decoration: underline;
     text-decoration-style: solid;
@@ -126,14 +130,14 @@
   /* Hover only on real-pointer devices — gating avoids the sticky hover
      color that lingers after a tap on touch screens. */
   @media (hover: hover) and (pointer: fine) {
-    a:not([role="button"]):hover {
+    a:not(:where([role="button"])):hover {
       color: var(--link-color-hover);
       /* Underline color is left as the resting hairline (the base rule's
          `currentColor` mix) — only the thickness grows on hover. */
       text-decoration-thickness: 1px;
     }
   }
-  a:not([role="button"]):active {
+  a:not(:where([role="button"])):active {
     text-decoration-color: color-mix(in srgb, currentColor 75%, transparent);
   }
 


### PR DESCRIPTION
## What

Links inside `<Text>` were all rendering in the global brand-blue `--link-color`, ignoring the priority/tone-aware prose-link hierarchy (tertiary+ priorities and all tinted tones should mute the link to `currentColor`).

## Why it happened

Commit `f891e9e` (*"fix(reset): don't apply link styling to anchor-buttons"*) added `:not([role="button"])` to the global `a` rule in `src/reset.css` to exclude anchor-buttons. That was correct in intent, but `:not()` inherits the specificity of its argument, and `[role="button"]` is an attribute selector — so the global link rule's specificity jumped from `(0,1,1)` to `(0,2,1)`.

Both `reset.css` and `a-text.css` live in `@layer anta`, so specificity alone decides the winner. The bumped global rule now out-specifies the `<Text>` overrides:

| Rule | Selector | Specificity |
|---|---|---|
| Global (reset.css) | `a:not([role="button"]):link` | `(0,2,1)` ← won |
| Text override (a-text.css) | `a-text a:link` | `(0,1,2)` |

So `--text-link-color: currentColor` became dead code for real anchors.

## Fix

Wrap the exclusion argument in `:where()` — `a:not(:where([role="button"]))` — which is specificity-neutral. The global rule returns to `(0,0,1)/(0,1,1)`, the `a-text` overrides win again, and anchor-buttons stay excluded exactly as before. Applied to the base, `:hover`, and `:active` rules.

## Scope / consequences

- `src/reset.css` only.
- No docs change needed — `site/src/pages/components/text.mdx` already documents the intended behavior; this just makes the CSS match it again.
- `<Button href>` / `<a role="button">` remain excluded from link coloring + underline.

## Review

Preview deploy (Cloudflare): check the **Text** component page — links under `priority="tertiary"`+ and any `tone="brand|success|critical|warning|info"` should take the text color, not blue. Primary/secondary neutral links stay `--link-color`.