### PR TITLE
fix(site): narrow desktop TOC rail to 200px, widen folded slide-out to 240px

### DIFF
--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -515,10 +515,14 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
     display: none;
   }
 
-  /* Right "On this page" rail — mirrors the left sidebar's width and
-     sticky full-height behaviour. Holds the <a-toc> web component. */
+  /* Right "On this page" rail — narrower than the left nav sidebar to hand
+     the content track ~40px more room (it lets two-column sections stay
+     side-by-side a bit longer before collapsing). Sticky, full-height; holds
+     the <a-toc> web component. It widens back to 240px once it folds into the
+     slide-out panel below (≤1100px), where horizontal room is no longer at a
+     premium. */
   .toc-rail {
-    width: 240px;
+    width: 200px;
     flex-shrink: 0;
     padding: 32px 16px 32px 4px;
     position: sticky;
@@ -558,7 +562,7 @@ const description = "Antithesis design system: global CSS tokens, framework-agno
       top: 0;
       right: 0;
       height: 100dvh;
-      width: min(280px, 80vw);
+      width: min(240px, 80vw);
       padding: 24px;
       background: var(--bg-canvas);
       border-left: 1px solid var(--border-5);


### PR DESCRIPTION
## What

The right **"On this page"** TOC rail in the docs layout mirrored the left nav sidebar at `240px`. This change makes its width asymmetric across breakpoints:

- **Desktop (visible, > 1100px):** `240px` → **`200px`**
- **Folded slide-out (≤ 1100px):** `min(280px, 80vw)` → **`min(240px, 80vw)`**

## Why

On desktop the rail doesn't need to be as wide as the left nav. Shrinking it to `200px` hands the content track ~40px more room, so two-column `<Columns>` sections stay side-by-side a bit longer before the container query collapses them to one column (collapse point moves from ~1444px to ~1404px viewport).

Once the rail folds into the slide-out panel (≤1100px), horizontal room in the main track is no longer at a premium, so it widens back to `240px` (still guarded by `80vw` on narrow phones).

## Notes

- Single-file change, `site/` only — no consumer-facing `@antadesign/anta` change, so nothing for `CHANGELOG.md`.
- No layout tokens touched: only the left nav sidebar feeds `--page-sidebar-width`/`.full-bleed`; the flex content track absorbs the rail's width change on its own. The fold breakpoint (`max-width: 1100px`) and left nav width (`240px`) are unchanged.