### PR TITLE
JSX run time export 

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,45 @@ import { h, Fragment } from 'preact'
 configure(h, Fragment)
 ```
 
+### TypeScript: typing raw `<a-*>` tags in JSX
+
+If you only use the JSX wrappers (`<Button>`, `<Progress>`, …) you need no setup — they're typed like any React component. This section is only for writing the raw `<a-*>` tags directly in JSX.
+
+**Option A (preferred)** — point your JSX types at anta in `tsconfig.json`:
+
+```jsonc
+{ "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "@antadesign/anta" } }
+```
+
+Every `a-*` tag type-checks, all standard HTML tags keep working, and importing anything from `@antadesign/stickers` adds the sticker tags automatically.
+
+**Option B** — if you can't change `jsxImportSource` (a shared tsconfig, Emotion's `@emotion/react` source, an older `@types/react` without the `React.JSX` namespace), merge anta's tag map into your JSX namespace yourself. Anta exports it as a standalone interface, `AntaIntrinsicElements` — and `@antadesign/stickers` exports the matching `StickerIntrinsicElements` — so it's a single `extends` in any `.d.ts` covered by your tsconfig:
+
+```ts
+import type { AntaIntrinsicElements } from '@antadesign/anta'
+import type { StickerIntrinsicElements } from '@antadesign/stickers' // only if you use stickers
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements extends AntaIntrinsicElements, StickerIntrinsicElements {}
+  }
+}
+```
+
+On modern `@types/react` (≥18) with `jsx: "react-jsx"`, the JSX namespace is module-scoped and the global declaration above is silently ignored — target the `react` module instead:
+
+```ts
+import type { AntaIntrinsicElements } from '@antadesign/anta'
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements extends AntaIntrinsicElements {}
+  }
+}
+```
+
+Either way the tags stay fully typed — unknown `a-*` tags and wrong prop types are still errors. New tags arrive automatically when you upgrade anta; there's no per-tag list to maintain.
+
 ### Raw web components (no JSX)
 
 ```html

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export { Tooltip } from './components/Tooltip'
 export type { TooltipProps } from './components/Tooltip'
 export type { BaseProps, BaseAttributes } from './general_types'
 export { configure } from './jsx-runtime'
+export type { AntaIntrinsicElements } from './jsx-runtime'
 
 /**
  * Seed interface for the icon shape registry. The generated

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -50,6 +50,9 @@ export { _Fragment as Fragment }
 
 import type { AProgressAttributes, ATextAttributes, ATitleAttributes, ATagAttributes, AIconAttributes, AButtonAttributes, ATooltipAttributes, BaseAttributes } from './general_types'
 
+// Declared as an `interface` (not a type alias) so downstream companion
+// packages — e.g. `@antadesign/stickers` — can augment it with their own
+// custom-element tags via `declare module '@antadesign/anta/jsx-runtime'`.
 export namespace JSX {
   export interface IntrinsicElements extends React.JSX.IntrinsicElements, AntaIntrinsicElements {}
 }

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -50,24 +50,23 @@ export { _Fragment as Fragment }
 
 import type { AProgressAttributes, ATextAttributes, ATitleAttributes, ATagAttributes, AIconAttributes, AButtonAttributes, ATooltipAttributes, BaseAttributes } from './general_types'
 
-// Declared as an `interface` (not a type alias) so downstream companion
-// packages — e.g. `@antadesign/stickers` — can augment it with their own
-// custom-element tags via `declare module '@antadesign/anta/jsx-runtime'`.
 export namespace JSX {
-  export interface IntrinsicElements extends React.JSX.IntrinsicElements {
-    'a-progress': AProgressAttributes
-    'a-progress-label': BaseAttributes
-    'a-progress-number': BaseAttributes
-    'a-progress-text': BaseAttributes
-    'a-progress-hint': BaseAttributes
-    'a-text': ATextAttributes
-    'a-title': ATitleAttributes
-    'a-tag': ATagAttributes
-    'a-tag-label': BaseAttributes
-    'a-tag-value': BaseAttributes
-    'a-icon': AIconAttributes
-    'a-button': AButtonAttributes
-    'a-button-label': BaseAttributes
-    'a-tooltip': ATooltipAttributes
-  }
+  export interface IntrinsicElements extends React.JSX.IntrinsicElements, AntaIntrinsicElements {}
+}
+
+export interface AntaIntrinsicElements {
+  'a-progress': AProgressAttributes
+  'a-progress-label': BaseAttributes
+  'a-progress-number': BaseAttributes
+  'a-progress-text': BaseAttributes
+  'a-progress-hint': BaseAttributes
+  'a-text': ATextAttributes
+  'a-title': ATitleAttributes
+  'a-tag': ATagAttributes
+  'a-tag-label': BaseAttributes
+  'a-tag-value': BaseAttributes
+  'a-icon': AIconAttributes
+  'a-button': AButtonAttributes
+  'a-button-label': BaseAttributes
+  'a-tooltip': ATooltipAttributes
 }

--- a/stickers/src/index.ts
+++ b/stickers/src/index.ts
@@ -22,6 +22,11 @@ export { Sticker } from './Sticker'
 export type { StickerProps } from './Sticker'
 export { StickerAnimated } from './StickerAnimated'
 export type { StickerAnimatedProps } from './StickerAnimated'
+export type {
+  AStickerAttributes,
+  AStickerAnimatedAttributes,
+  StickerIntrinsicElements,
+} from './jsx'
 
 // Generated per-sticker components (Sticker{Name} / Sticker{Name}Animated).
 export * from './generated'

--- a/stickers/src/jsx.ts
+++ b/stickers/src/jsx.ts
@@ -41,14 +41,33 @@ export interface AStickerAnimatedAttributes extends BaseAttributes {
   'aria-hidden'?: 'true' | 'false' | boolean
 }
 
+/**
+ * The two sticker `<a-*>` tags. Companion to anta's
+ * `AntaIntrinsicElements` — consumers using the global-merge pattern
+ * extend both to get a complete set of intrinsic elements:
+ *
+ * ```ts
+ * import type { AntaIntrinsicElements } from '@antadesign/anta'
+ * import type { StickerIntrinsicElements } from '@antadesign/stickers'
+ * declare global {
+ *   namespace JSX {
+ *     interface IntrinsicElements extends AntaIntrinsicElements, StickerIntrinsicElements {}
+ *   }
+ * }
+ * ```
+ */
+export interface StickerIntrinsicElements {
+  'a-sticker': AStickerAttributes
+  'a-sticker-animated': AStickerAnimatedAttributes
+}
+
 // Teach anta's JSX runtime about this package's two custom-element tags.
-// anta itself ships no sticker code; these intrinsics live here so the
-// wrappers (and consumers authoring raw `<a-sticker>` JSX) type-check.
+// `<a-sticker>` / `<a-sticker-animated>` written directly in JSX type-check
+// for consumers using `jsxImportSource: "@antadesign/anta"` — anta's
+// module-scoped `JSX.IntrinsicElements` picks up these members via
+// interface merging.
 declare module '@antadesign/anta/jsx-runtime' {
   namespace JSX {
-    interface IntrinsicElements {
-      'a-sticker': AStickerAttributes
-      'a-sticker-animated': AStickerAnimatedAttributes
-    }
+    interface IntrinsicElements extends StickerIntrinsicElements {}
   }
 }


### PR DESCRIPTION
## Problem

  Consumers that can't set `jsxImportSource: "@antadesign/anta"` (e.g.
  projects on older `@types/react`) couldn't merge anta's `<a-*>` tags
  into their global JSX with a single `extends`.

  Anta's `JSX.IntrinsicElements` internally extended
  `React.JSX.IntrinsicElements`, which doesn't exist on `@types/react ≤17`
   — that collapses the intersection to `any` and the augmentation
  silently contributes nothing. The workaround was enumerating every tag
  by hand (8+ lines).

  ## Fix

  Extract anta's `a-*` tag map into a standalone `AntaIntrinsicElements`
  interface, re-exported from the package root, so consumers can extend it
   directly with no `React.JSX` dependency. Same treatment for
  `@antadesign/stickers` (`StickerIntrinsicElements`).

  ## Consumer migration

  Before — 8-line per-element list:

  ```ts
  declare global {
    namespace JSX {
      interface IntrinsicElements {
        'a-button': AButtonAttributes
        'a-icon': AIconAttributes
        'a-progress': AProgressAttributes
        // …one line per tag
      }
    }
  }

  After:

  import type { AntaIntrinsicElements } from "@antadesign/anta"
  import type { StickerIntrinsicElements } from "@antadesign/stickers"

  declare global {
    namespace JSX {
      interface IntrinsicElements extends AntaIntrinsicElements,
  StickerIntrinsicElements {}
    }
  }
