### PR TITLE
Release anta 0.2.1 / stickers 0.1.1: CSS minify, polish, docs reorg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This file only tracks what ships to npm consumers — anything under `src/`, `di
 
 Versions ending in `-dev.N` are pre-release builds published under the npm `dev` dist-tag; main releases drop the suffix. Always pin a specific version in your `package.json` (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag — the floating tag tracks the latest dev build and will silently change between installs.
 
+## 0.2.1 — June 10, 2026
+
+### Changed
+- **Secondary buttons: inset hairline edge.** The default `secondary` priority's edge is now an *inset* hairline — `box-shadow: inset 0 0 1px color-mix(in oklch, currentColor, transparent 70%)` (was a non-inset `0 0 1px color-mix(in oklch, currentColor, transparent 50%)` in 0.2.0). Softer and contained within the chip.
+- **Button loading overlay is subtler.** `--button-loading-opacity` lowered from `0.25` to `0.15`.
+- **Table borders use `--border-4`.** Raw `<table>` row separators and the `data-bordered` variant's outer frame + column dividers now use `--border-4` instead of `--border-5` — a touch stronger so the structure reads more clearly. (Both still live in `@layer anta`, overridable as before.)
+- **Monospace text carries no letter-spacing.** The reset now sets `letter-spacing: 0` on `code, kbd, samp, pre`, so a global `letter-spacing` an app applies to body prose no longer loosens code (code is metrically even by design).
+
+### Packaging
+- **Published CSS is now minified.** `build:css` runs the shipped CSS through esbuild (`--minify`), stripping comments and collapsing whitespace — smaller files in the tarball, identical rendering. Source and dev builds keep readable, commented CSS.
+
 ## 0.2.0 — June 9, 2026
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -44,10 +44,12 @@
   },
   "scripts": {
     "build": "pnpm run build:js && pnpm run build:css && pnpm run build:types",
-    "build:css": "find src -name '*.css' | while IFS= read -r f; do d=\"dist/${f#src/}\"; mkdir -p \"$(dirname \"$d\")\"; cp \"$f\" \"$d\"; done && cp scripts/generate-icons.mjs dist/",
+    "build:dev": "pnpm run build:js && pnpm run build:css:dev && pnpm run build:types",
+    "build:css": "esbuild $(find src -name '*.css') --minify --loader:.module.css=css --outdir=dist --outbase=src && cp scripts/generate-icons.mjs dist/",
+    "build:css:dev": "find src -name '*.css' | while IFS= read -r f; do d=\"dist/${f#src/}\"; mkdir -p \"$(dirname \"$d\")\"; cp \"$f\" \"$d\"; done && cp scripts/generate-icons.mjs dist/",
     "build:js": "esbuild $(find src \\( -name '*.ts' -o -name '*.tsx' \\) ! -name '*.d.ts') --outdir=dist --outbase=src --jsx=automatic --jsx-import-source=@antadesign/anta --format=esm --target=ES2022 --loader:.module.css=local-css --loader:.css=global-css",
     "build:types": "tsc -p src/tsconfig.json",
-    "dev": "echo $$ > .dev.pid; trap 'rm -f .dev.pid' EXIT; nodemon -w src -w stickers/src -e ts,tsx,css -x 'pnpm run build && pnpm --filter @antadesign/stickers run build && pnpm --filter anta-site run docs' & pnpm --filter anta-site run dev & wait",
+    "dev": "echo $$ > .dev.pid; trap 'rm -f .dev.pid' EXIT; nodemon -w src -w stickers/src -e ts,tsx,css -x 'pnpm run build:dev && pnpm --filter @antadesign/stickers run build:dev && pnpm --filter anta-site run docs' & pnpm --filter anta-site run dev & wait",
     "stop": "node scripts/dev-stop.mjs",
     "typecheck": "tsc --noEmit -p src/tsconfig.json",
     "icons": "node scripts/generate-icons.mjs --input src/elements/icons --output src/elements --name a-icon.shapes --internal",

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -47,8 +47,16 @@ export default defineConfig({
       styleOverrides: {
         borderWidth: '1px',
         borderColor: 'var(--border-5)',
+        codeFontFamily: 'var(--monospace)',
+        uiFontFamily: 'var(--sans-serif)',
+        codeFontSize: '13px',
+        codeFontWeight: '440',
+        codeLineHeight: '20px',
         codeBackground: 'var(--bg-canvas)',
-        codePaddingBlock: '0.75rem',
+        // EC renders this as `padding: <value> 0` on `pre > code`, so the
+        // 3-value form gives asymmetric block padding (10px top / 6px bottom,
+        // 0 inline) — there's no separate block-start/-end setting.
+        codePaddingBlock: '10px 0 6px',
         codePaddingInline: '1rem',
         frames: {
           frameBoxShadowCssValue: 'none',

--- a/site/src/components/Disclosure.astro
+++ b/site/src/components/Disclosure.astro
@@ -18,9 +18,13 @@ interface Props {
   id?: string
   /** Heading level for the title. Defaults to 2 (top-level section). */
   level?: 2 | 3 | 4 | 5 | 6
+  /** When false, the title renders as a plain (non-heading, non-anchor)
+   *  label — kept out of the table of contents and not deep-linkable, while
+   *  the section stays expand/collapsible. Defaults to true. */
+  anchor?: boolean
 }
 
-const { title, open = false, id, level = 2 } = Astro.props
+const { title, open = false, id, level = 2, anchor = true } = Astro.props
 const slug = (id ?? title)
   .toLowerCase()
   .replace(/[^a-z0-9]+/g, '-')
@@ -28,16 +32,22 @@ const slug = (id ?? title)
 const Heading = `h${level}` as const
 ---
 
-<details class="disclosure" open={open}>
+<details class:list={["disclosure", { plain: !anchor }]} open={open}>
   <summary class="summary">
     <a-icon shape="chevron-right" class="chevron"></a-icon>
     {/* A real heading carries the id so the TOC picks it up; the inner
         anchor mirrors rehype-autolink-headings' `behavior: 'wrap'` output
         (classes `header-anchor muted`) so the section deep-links and
-        hover-underlines like every other `##` heading. */}
-    <Heading id={slug} class="title">
-      <a class="header-anchor muted" href={`#${slug}`}>{title}</a>
-    </Heading>
+        hover-underlines like every other `##` heading. With `anchor={false}`
+        the title is a plain label instead — no heading, no id, no anchor — so
+        it stays out of the TOC and isn't deep-linkable, but still toggles. */}
+    {anchor ? (
+      <Heading id={slug} class="title">
+        <a class="header-anchor muted" href={`#${slug}`}>{title}</a>
+      </Heading>
+    ) : (
+      <span class="title plain">{title}</span>
+    )}
   </summary>
   <div class="body">
     <slot />
@@ -47,6 +57,12 @@ const Heading = `h${level}` as const
 <style>
   .disclosure {
     margin-block: 32px 0;
+  }
+
+  /* Plain (non-anchor) variant — e.g. the top-of-page Playground. Tighter
+     top margin since it isn't a full section heading. */
+  .disclosure.plain {
+    margin-block-start: 16px;
   }
 
   .summary {
@@ -68,6 +84,15 @@ const Heading = `h${level}` as const
      chevron in the summary row. */
   .title {
     margin: 0;
+  }
+
+  /* Plain (non-anchor) title — a label, not a heading. Sized close to h5. */
+  .title.plain {
+    font-size: 15px;
+    line-height: 20px;
+    font-weight: 584.62;
+    letter-spacing: 0;
+    color: var(--text-1);
   }
 
   .chevron {

--- a/site/src/components/Playground.module.css
+++ b/site/src/components/Playground.module.css
@@ -128,7 +128,14 @@
   min-height: 64px;
   border: none;
   background: var(--bg-base);
+  /* Backstop: color-scheme on the iframe *element* (the canvas itself is fixed
+     by the srcdoc's inline theme script in Playground.tsx). Switched by the
+     docs `.dark` class so the element's own box matches the theme. */
+  color-scheme: light;
   transition: height 200ms ease-out;
+}
+:global(.dark) .previewFrame {
+  color-scheme: dark;
 }
 
 .panel {
@@ -401,6 +408,7 @@
 
 .fieldValueLabel {
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 12px;
   color: var(--text-3);
 }
@@ -409,6 +417,7 @@
    style, ReactNode, …). Renders the type in monospace; no input. */
 .docType {
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 12px;
   color: var(--text-3);
 }
@@ -461,6 +470,7 @@
 /* Prop name — plain monospace value, not a copyable code pill. */
 .fieldName {
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 12px;
   color: var(--text-1);
 }
@@ -560,6 +570,7 @@
   padding: 8px 12px;
   border-radius: 6px;
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 12px;
   white-space: pre-wrap;
 }

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -1068,10 +1068,25 @@ function ExampleAccordion({
 // Iframe lifecycle helpers
 
 // Transparent iframe body so the playground's surrounding panel
-// background shows through. The html class="dark" + cloned-stylesheet
-// pipeline still applies anta tokens for typography and colors;
-// removing the body background just lets the host card paint behind.
-const IFRAME_SRCDOC = `<!DOCTYPE html><html class="dark"><head><meta charset="utf-8"><style>
+// background shows through. The cloned-stylesheet pipeline applies anta
+// tokens for typography and colors; removing the body background just lets
+// the host card paint behind.
+//
+// The inline <script> below seeds the theme synchronously *during parse*,
+// before first paint: it reads the parent docs theme (srcdoc iframes are
+// same-origin, so parent.document is reachable) and sets the iframe's own
+// `.dark` class + `color-scheme`. Setting color-scheme ON THE EMBEDDED
+// DOCUMENT is what makes its blank UA canvas paint the right shade — an iframe
+// element's color-scheme does NOT propagate into the document (its canvas
+// defaults to light), which is why a white flash appeared on expand in dark
+// mode. The setupIframe mirror keeps the `.dark` class in sync on later toggles.
+const IFRAME_SRCDOC = `<!DOCTYPE html><html><head><meta charset="utf-8"><script>
+  try {
+    var d = parent.document.documentElement.classList.contains('dark');
+    document.documentElement.classList.toggle('dark', d);
+    document.documentElement.style.colorScheme = d ? 'dark' : 'light';
+  } catch (e) {}
+</script><style>
   /* Pin the Antithesis-sans variable font's slnt / ital axes to 0.
      Safari leaves variable-font axes at the font file's internal
      defaults unless they're explicitly set — and our font ships
@@ -1143,13 +1158,13 @@ function setupIframe(iframe: HTMLIFrameElement) {
   `
   doc.head.appendChild(reg)
 
-  // 4) Mirror the parent's .dark class.
+  // 4) Mirror the parent's .dark class (and color-scheme, so a light docs
+  //    theme flips the iframe canvas back to light — the srcdoc defaults to
+  //    dark to avoid the white expand-flash in dark mode).
   const apply = () => {
-    if (document.documentElement.classList.contains('dark')) {
-      doc.documentElement.classList.add('dark')
-    } else {
-      doc.documentElement.classList.remove('dark')
-    }
+    const dark = document.documentElement.classList.contains('dark')
+    doc.documentElement.classList.toggle('dark', dark)
+    doc.documentElement.style.colorScheme = dark ? 'dark' : 'light'
   }
   apply()
   const obs = new MutationObserver(apply)

--- a/site/src/components/PropsTable.astro
+++ b/site/src/components/PropsTable.astro
@@ -251,6 +251,7 @@ const inherited = all.filter((p) => p.fromBase).sort((a, b) => a.name.localeComp
     font-family: var(--monospace);
     font-size: 0.9em;
     font-weight: 475;
+    letter-spacing: 0;
   }
   /* The optional `?` is its own element (text-3, not selectable) so a
      double-click selects just the name and copying omits the `?`. */
@@ -263,11 +264,19 @@ const inherited = all.filter((p) => p.fromBase).sort((a, b) => a.name.localeComp
   .type-name {
     font-family: var(--monospace);
     font-size: 0.9em;
+    letter-spacing: 0;
     color: var(--text-3);
   }
   /* "No value" em-dash placeholders (Type / Default columns). */
   .empty {
     color: var(--text-5);
+  }
+  /* Note under the inherited table: data-*/aria-* are accepted via index
+     signatures on BaseProps, which TypeDoc can't surface as named rows. */
+  .inherited-note {
+    margin: 8px 0 0;
+    font-size: 0.85em;
+    color: var(--text-4);
   }
 </style>
 
@@ -309,5 +318,9 @@ const inherited = all.filter((p) => p.fromBase).sort((a, b) => a.name.localeComp
         </tbody>
       </table>
     </div>
+    <p class="inherited-note">
+      Plus any <code>data-*</code> or <code>aria-*</code> attribute — forwarded
+      as-is to the underlying <code>&lt;a-*&gt;</code> element.
+    </p>
   </details>
 )}

--- a/site/src/components/Swatches.module.css
+++ b/site/src/components/Swatches.module.css
@@ -209,6 +209,7 @@
   align-items: center;
   justify-content: center;
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 1.6rem;
   font-weight: 600;
   background: var(--bg-pane);
@@ -236,6 +237,7 @@
 
 .tokenName {
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 0.85rem;
   color: var(--text-1);
   align-self: flex-start;
@@ -316,6 +318,7 @@
   bottom: 10px;
   right: 14px;
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 0.7rem;
   color: var(--text-4);
 }
@@ -351,6 +354,7 @@
   align-items: center;
   justify-content: center;
   font-family: var(--monospace);
+  letter-spacing: 0;
   font-size: 0.8rem;
   color: var(--text-3);
   border-width: 1px;
@@ -395,6 +399,7 @@
 .a11yHeadCell {
   font-size: 0.7rem;
   font-family: var(--monospace);
+  letter-spacing: 0;
   color: var(--text-4);
   padding: 4px 8px;
   line-height: 1.3;

--- a/site/src/pages/components/button.mdx
+++ b/site/src/pages/components/button.mdx
@@ -18,7 +18,19 @@ component (or `<a role="button">` when `href` is set). Tone, priority,
 size, and state are all plain attributes, so the styling is identical
 whether you use the wrapper or author the element by hand.
 
-Play with it in [playground](#playground).
+<Disclosure title="Playground" anchor={false}>
+
+<Playground
+  client:visible
+  component="Button"
+  layout="side"
+  panelHeight={400}
+  initialCode={buttonDemoCode}
+  initialCss={`html, body { height: 100%; }
+.preview { min-height: 100%; align-items: center; justify-content: center; }`}
+/>
+
+</Disclosure>
 
 ## Priorities
 
@@ -453,7 +465,7 @@ other routing library.
 
 </Disclosure>
 
-## Special events
+<Disclosure title="Special events">
 
 Beyond a plain click, a `Button` can drive a native form or emit your own
 event:
@@ -509,27 +521,15 @@ without taking ownership of `onClick`.
 </Col>
 </Columns>
 
-<Disclosure title="Playground">
-
-<Playground
-  client:visible
-  component="Button"
-  layout="side"
-  panelHeight={400}
-  initialCode={buttonDemoCode}
-  initialCss={`html, body { height: 100%; }
-.preview { min-height: 100%; align-items: center; justify-content: center; }`}
-/>
-
 </Disclosure>
 
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Button" />
 
 </Disclosure>
 
-<Disclosure title="Component tokens">
+<Disclosure title="Component tokens" open>
 
 Override any of these on a single instance
 (`style={{ '--button-padding-x': '12px' }}`) or on a selector wrapping
@@ -548,7 +548,7 @@ with a hex8 fallback first.
 | `--button-loading-angle` | Stripe angle (default `125deg`). |
 | `--button-loading-period` | Stripe + gap along the gradient axis (default `30px`). |
 | `--button-loading-stripe`<br />`--button-loading-stripe-gap` | Stripe geometry (default `14px` / `16px`). |
-| `--button-loading-opacity` | Overlay opacity (default `0.25`). |
+| `--button-loading-opacity` | Overlay opacity (default `0.15`). |
 | `--button-loading-blur` | Stripe-edge softening (default `2.5px`). |
 
 </Disclosure>

--- a/site/src/pages/components/icon.mdx
+++ b/site/src/pages/components/icon.mdx
@@ -19,15 +19,15 @@ any custom icons you generate yourself.
 > way without the wrapping element. Use `<Icon>` when you need a
 > standalone icon outside of any other component.
 
+## Built-in shapes
+
+<IconDemo client:load />
+
 <Disclosure title="Component props">
 
 <PropsTable component="Icon" />
 
 </Disclosure>
-
-## Built-in shapes
-
-<IconDemo client:load />
 
 ## Sizing and color
 

--- a/site/src/pages/components/progress.mdx
+++ b/site/src/pages/components/progress.mdx
@@ -20,6 +20,19 @@ import progressDemoCode from './progress.demo.ts'
 A progress indicator for displaying task completion. Consists of a track
 (background bar), an indicator (filled portion), and an optional label area.
 
+<Disclosure title="Playground" anchor={false}>
+
+<Playground
+  client:visible
+  component="Progress"
+  layout="side"
+  initialCode={progressDemoCode}
+/>
+
+</Disclosure>
+
+## Examples
+
 <Preview>
   <div style={{ display: 'flex', flexDirection: 'column', gap: '20px', width: '100%' }}>
     <Progress value={60} />
@@ -55,24 +68,13 @@ function AnimatedProgress({ speed = 1 }) {
 }
 ```
 
-<Disclosure title="Playground">
-
-<Playground
-  client:visible
-  component="Progress"
-  layout="side"
-  initialCode={progressDemoCode}
-/>
-
-</Disclosure>
-
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Progress" />
 
 </Disclosure>
 
-<Disclosure title="Component tokens">
+<Disclosure title="Component tokens" open>
 
 Progress exposes these CSS custom properties as its theming surface. Override any of them in consumer CSS to retint a single instance, or set them on a `[tone="…"]` selector to add a new tone variant. Tokens marked *(shadow-only API)* style elements inside the shadow DOM and can **only** be customized via these properties — consumer CSS can't reach those elements directly.
 

--- a/site/src/pages/components/table.mdx
+++ b/site/src/pages/components/table.mdx
@@ -32,7 +32,7 @@ While the `<Table>` component is in design, Anta's `reset.css` ships a
 polite baseline for the native `<table>` element so plain HTML tables
 look intentional out of the box. The defaults are deliberately minimal:
 top-left aligned cells with 5 × 10 px padding, hairline row separators
-in `--border-5`, semibold `<thead>` cells, and no outer frame or
+in `--border-4`, semibold `<thead>` cells, and no outer frame or
 column dividers. Set `font-variant-numeric: tabular-nums` so numeric
 columns line up.
 

--- a/site/src/pages/components/tag.mdx
+++ b/site/src/pages/components/tag.mdx
@@ -20,7 +20,19 @@ you use the wrapper or author the element by hand. Content is composed
 from `icon`, `label`, `value`, and `iconTrailing` props, the same way
 `Button` works.
 
-Play with it in [playground](#playground).
+<Disclosure title="Playground" anchor={false}>
+
+<Playground
+  client:visible
+  component="Tag"
+  layout="side"
+  panelHeight={400}
+  initialCode={tagDemoCode}
+  initialCss={`html, body { height: 100%; }
+.preview { min-height: 100%; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; }`}
+/>
+
+</Disclosure>
 
 ## Tones
 
@@ -173,27 +185,13 @@ keeps it as `GitHub`.
 <Tag icon="github-logo" nocaps label="GitHub" value="v1.6.9" />
 ```
 
-<Disclosure title="Playground">
-
-<Playground
-  client:visible
-  component="Tag"
-  layout="side"
-  panelHeight={400}
-  initialCode={tagDemoCode}
-  initialCss={`html, body { height: 100%; }
-.preview { min-height: 100%; align-items: center; justify-content: center; gap: 8px; flex-wrap: wrap; }`}
-/>
-
-</Disclosure>
-
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Tag" />
 
 </Disclosure>
 
-<Disclosure title="Component tokens">
+<Disclosure title="Component tokens" open>
 
 Override any of these on a single instance
 (`style={{ '--tag-bg': 'var(--bg-5)' }}`) or on a selector wrapping the

--- a/site/src/pages/components/text.mdx
+++ b/site/src/pages/components/text.mdx
@@ -27,6 +27,18 @@ want emphasis. Pair with `tone` to apply a tinted palette (`brand`,
 `<Text>` are styled by the design system — there are no per-page
 overrides to maintain.
 
+<Disclosure title="Playground" anchor={false}>
+
+<Playground
+  client:visible
+  component="Text"
+  layout="side"
+  initialCode={textDemoCode}
+  initialCss={`.preview { align-items: center; justify-content: center; min-height: 100%; }`}
+/>
+
+</Disclosure>
+
 ## Link behavior
 
 Links inside `<Text>` follow a priority-aware hierarchy that keeps
@@ -53,18 +65,6 @@ the underline to full alpha.
 ## Demo
 
 <TextDemo client:load />
-
-<Disclosure title="Playground">
-
-<Playground
-  client:visible
-  component="Text"
-  layout="side"
-  initialCode={textDemoCode}
-  initialCss={`.preview { align-items: center; justify-content: center; min-height: 100%; }`}
-/>
-
-</Disclosure>
 
 ## Truncation & expansion
 
@@ -111,13 +111,13 @@ full text. `expandable` only takes effect together with `truncate`.
 </Col>
 </Columns>
 
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Text" />
 
 </Disclosure>
 
-<Disclosure title="Component tokens">
+<Disclosure title="Component tokens" open>
 
 `Text` derives its colors from the global token system. Every variable
 below has a light and dark mode value defined in

--- a/site/src/pages/components/title.mdx
+++ b/site/src/pages/components/title.mdx
@@ -21,6 +21,18 @@ Raw `<h1>`–`<h6>` get the same default styling via anta's reset, so
 reach for a real heading tag when SEO matters and you don't need the
 `tone` / `priority` props. Use `<Title>` when you do.
 
+<Disclosure title="Playground" anchor={false}>
+
+<Playground
+  client:visible
+  component="Title"
+  layout="side"
+  initialCode={titleDemoCode}
+  initialCss={`.preview { align-items: center; justify-content: center; min-height: 100%; }`}
+/>
+
+</Disclosure>
+
 ## Levels in context
 
 Six levels interleaved with paragraphs of `<Text>`, all rendered with
@@ -183,19 +195,7 @@ ignore ARIA headings — if SEO matters, write raw `<h{level}>` instead
 (it gets the same visual treatment from the reset) and skip the
 component.
 
-<Disclosure title="Playground">
-
-<Playground
-  client:visible
-  component="Title"
-  layout="side"
-  initialCode={titleDemoCode}
-  initialCss={`.preview { align-items: center; justify-content: center; min-height: 100%; }`}
-/>
-
-</Disclosure>
-
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Title" />
 

--- a/site/src/pages/components/tooltip.mdx
+++ b/site/src/pages/components/tooltip.mdx
@@ -22,6 +22,41 @@ devices — where there's no hover and a tap shouldn't surface it — it opens o
 default the bubble follows the cursor; pass `static` to pin it under the anchor,
 or `interactive` to make it hoverable and clickable (for content like links).
 
+<Disclosure title="Playground" anchor={false}>
+
+A single tooltip on a button — tweak its props (or edit the code) and hover the
+button. The props panel is generated from the `Tooltip` API and edits the
+`<Tooltip>` element, not the `<Button>` it's attached to.
+
+<Playground
+  client:visible
+  component="Tooltip"
+  layout="side"
+  initialCode={tooltipDemoCode}
+  initialCss={`.container {
+  min-height: 220px;
+  display: grid;
+
+  /* Where to park the trigger — test how the tooltip flips / clamps near an
+     edge. Comment out the active line and uncomment one below.
+     1st value = vertical (start=top, center=middle, end=bottom);
+     2nd value = horizontal (start=left, center=middle, end=right). */
+  place-items: center;
+  /* place-items: start start; */
+  /* place-items: start center; */
+  /* place-items: start end; */
+  /* place-items: center start; */
+  /* place-items: center end; */
+  /* place-items: end start; */
+  /* place-items: end center; */
+  /* place-items: end end; */
+}`}
+/>
+
+</Disclosure>
+
+## Examples
+
 <Preview>
   <div style={{ display: 'flex', gap: '16px', alignItems: 'center', flexWrap: 'wrap' }}>
     <Button label="Save">
@@ -87,7 +122,7 @@ The underlying `<a-tooltip>` works in plain HTML too, as a child of any element:
 </button>
 ```
 
-## Adjacent and nested tooltips
+### Adjacent and nested tooltips
 
 Only one tooltip shows at a time. Moving between **adjacent** anchors hands off
 cleanly — the outgoing bubble lingers briefly and keeps following the cursor,
@@ -125,44 +160,13 @@ when you leave. Hover the examples to feel it.
 </div>
 ```
 
-## Playground
-
-A single tooltip on a button — tweak its props (or edit the code) and hover the
-button. The props panel is generated from the `Tooltip` API and edits the
-`<Tooltip>` element, not the `<Button>` it's attached to.
-
-<Playground
-  client:visible
-  component="Tooltip"
-  layout="side"
-  initialCode={tooltipDemoCode}
-  initialCss={`.container {
-  min-height: 220px;
-  display: grid;
-
-  /* Where to park the trigger — test how the tooltip flips / clamps near an
-     edge. Comment out the active line and uncomment one below.
-     1st value = vertical (start=top, center=middle, end=bottom);
-     2nd value = horizontal (start=left, center=middle, end=right). */
-  place-items: center;
-  /* place-items: start start; */
-  /* place-items: start center; */
-  /* place-items: start end; */
-  /* place-items: center start; */
-  /* place-items: center end; */
-  /* place-items: end start; */
-  /* place-items: end center; */
-  /* place-items: end end; */
-}`}
-/>
-
-<Disclosure title="Component props">
+<Disclosure title="Component props" open>
 
 <PropsTable component="Tooltip" />
 
 </Disclosure>
 
-<Disclosure title="Component tokens">
+<Disclosure title="Component tokens" open>
 
 Tooltip exposes only the box "chrome" that lives inside the shadow popover and
 is therefore impossible to reach with plain consumer CSS. Every token below is a

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -235,6 +235,12 @@ code {
 
 pre code { background: none; padding: 0; }
 
+/* Font, size, line-height, weight and padding are set via Expressive Code's
+   styleOverrides (astro.config.mjs). letter-spacing has no EC setting, and EC's
+   `pre > code` rule uses `all: unset` (which resets letter-spacing too), so the
+   extra `.content` ancestor here out-specifies it. */
+.content .expressive-code pre > code { letter-spacing: 0; }
+
 :not(pre) > code {
   cursor: copy;
   position: relative;
@@ -750,6 +756,7 @@ code[data-copied]::after {
 .demoLabel {
   font-size: 0.75rem;
   font-family: var(--monospace);
+  letter-spacing: 0;
   color: var(--text-4);
 }
 .demoLabel.upper {

--- a/src/elements/a-button.css
+++ b/src/elements/a-button.css
@@ -23,7 +23,7 @@
     --button-loading-x-period: calc(
       var(--button-loading-period) / cos(var(--button-loading-angle) - 90deg)
     );
-    --button-loading-opacity: 0.25;
+    --button-loading-opacity: 0.15;
     --button-loading-blur: 2.5px;
 
     --button-bg-primary-rest: #635b65;
@@ -330,10 +330,7 @@
     background-color: var(--button-bg);
     border-radius: 4px;
     text-decoration: none;
-    /* Secondary is the default priority — a 1px hairline in the current
-       fg tone (at 50% alpha) gives the chip a subtle edge. Primary,
-       tertiary, and quaternary cancel it in their own blocks below. */
-    box-shadow: 0 0 1px color-mix(in oklch, currentColor, transparent 50%);
+    box-shadow: inset 0 0 1px color-mix(in oklch, currentColor, transparent 70%);
 
     font-size: 15px;
     font-family: var(--sans-serif);

--- a/src/reset.css
+++ b/src/reset.css
@@ -78,6 +78,14 @@
     line-height: 1em;
   }
 
+  /* Monospace text carries no letter tracking. Code is metrically even
+     by design, so a global `letter-spacing` an app sets on body prose
+     must not bleed into it. Targets the monospace elements directly so
+     the declaration beats the inherited tracking. */
+  code, kbd, samp, pre {
+    letter-spacing: 0;
+  }
+
   /* Prose lists (ul, ol) get a tight 3ch left padding so markers
      hug the text, and items get a small bottom margin so
      consecutive ones breathe. Markers are toned all the way down
@@ -169,7 +177,7 @@
     padding: 5px 10px;
     text-align: left;
     vertical-align: top;
-    border-bottom: 1px solid var(--border-5);
+    border-bottom: 1px solid var(--border-4);
   }
 
   thead th {
@@ -195,12 +203,12 @@
   table[data-bordered] {
     border-collapse: separate;
     border-spacing: 0;
-    border: 1px solid var(--border-5);
+    border: 1px solid var(--border-4);
     border-radius: 3px;
   }
 
   table[data-bordered] :is(th, td) {
-    border-right: 1px solid var(--border-5);
+    border-right: 1px solid var(--border-4);
   }
 
   table[data-bordered] tr > :is(th, td):last-child {

--- a/stickers/README.md
+++ b/stickers/README.md
@@ -1,0 +1,34 @@
+# @antadesign/stickers
+
+Part of [Antithesis](https://antithesis.com)' design system, **Anta** — the sticker pack companion to [`@antadesign/anta`](https://www.npmjs.com/package/@antadesign/anta).
+
+Square illustrated stickers, two flavors per name: a lightweight static SVG (`Sticker{Name}`) and a Lottie-driven animated version (`Sticker{Name}Animated`). Each one is its own named export, so your bundler ships only the stickers you actually use.
+
+Kept as a separate package so that core anta carries **no `lottie-web`** — apps that don't use stickers never install the animation runtime. Installing this package pulls `@antadesign/anta` (for the JSX runtime and shared helpers) and `lottie-web` transitively.
+
+📖 **Full documentation, the complete sticker gallery, and live demos: [anta.design/components/sticker](https://anta.design/components/sticker/)**
+
+## Installation
+
+```sh
+npm install @antadesign/stickers   # pulls @antadesign/anta + lottie-web
+```
+
+`react` is a peer dependency (or alias `react` → `preact/compat`). As with anta, **pin an exact version** rather than a floating tag.
+
+## Usage
+
+```tsx
+import '@antadesign/stickers/elements'   // register <a-sticker> / <a-sticker-animated> (client-side)
+import { StickerCoding, StickerCodingAnimated } from '@antadesign/stickers'
+
+<StickerCoding size={128} label="Writing code" />
+<StickerCodingAnimated size={128} />
+```
+
+The element registration must run on the UI thread of a real browser (it needs `HTMLElement`). In SSR contexts (Astro, Next.js) import `@antadesign/stickers/elements` client-side only — same rule as `@antadesign/anta/elements`.
+
+## See also
+
+- [`@antadesign/anta`](https://www.npmjs.com/package/@antadesign/anta) — the core design system.
+- [anta.design/components/sticker](https://anta.design/components/sticker/) — props, sizing, animation control, and bringing your own stickers.

--- a/stickers/package.json
+++ b/stickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/stickers",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -29,7 +29,9 @@
   },
   "scripts": {
     "build": "pnpm run build:js && pnpm run build:css && pnpm run build:types",
-    "build:css": "find src -name '*.css' | while IFS= read -r f; do d=\"dist/${f#src/}\"; mkdir -p \"$(dirname \"$d\")\"; cp \"$f\" \"$d\"; done && cp scripts/generate-stickers.mjs dist/",
+    "build:dev": "pnpm run build:js && pnpm run build:css:dev && pnpm run build:types",
+    "build:css": "esbuild $(find src -name '*.css') --minify --loader:.module.css=css --outdir=dist --outbase=src && cp scripts/generate-stickers.mjs dist/",
+    "build:css:dev": "find src -name '*.css' | while IFS= read -r f; do d=\"dist/${f#src/}\"; mkdir -p \"$(dirname \"$d\")\"; cp \"$f\" \"$d\"; done && cp scripts/generate-stickers.mjs dist/",
     "build:js": "esbuild $(find src \\( -name '*.ts' -o -name '*.tsx' \\) ! -name '*.d.ts') --outdir=dist --outbase=src --jsx=automatic --jsx-import-source=@antadesign/anta --format=esm --target=ES2022 --loader:.module.css=local-css --loader:.css=global-css",
     "build:types": "tsc -p src/tsconfig.json",
     "typecheck": "tsc --noEmit -p src/tsconfig.json",


### PR DESCRIPTION
## Summary

Prepares **anta `0.2.1`** and **stickers `0.1.1`** (versions bumped in this PR; publish to `latest` after merge), plus a docs-site pass.

### `@antadesign/anta` → 0.2.1 (consumer-facing — see CHANGELOG)
- **Secondary button** edge is now an *inset* hairline: `box-shadow: inset 0 0 1px color-mix(in oklch, currentColor, transparent 70%)` (was non-inset `… 50%`).
- **Button loading overlay** subtler: `--button-loading-opacity` 0.25 → 0.15.
- **Table borders** use `--border-4` (was `--border-5`) — raw `<table>` row separators and the `data-bordered` frame/dividers.
- **Monospace** (`code, kbd, samp, pre`) gets `letter-spacing: 0` in the reset, so an app's global body tracking no longer loosens code.
- **Packaging:** published CSS is now minified via esbuild (`build:css`); dev builds keep readable, commented CSS (`build:css:dev`).

### `@antadesign/stickers` → 0.1.1
- Add `README.md` (identifies it as part of Anta, links to `anta.design/components/sticker/`).
- CSS minify in build.

### Docs site (not consumer-facing)
- Move the Playground to the top of Button/Progress/Tag/Text/Title/Tooltip as a **collapsed, non-anchor** (`anchor={false}`) Disclosure styled like h5 — kept out of the TOC; **Component props + tokens expanded by default**.
- Expressive Code: code blocks use `--monospace` (+ tuned font-size/line-height/weight/padding); UI chrome uses `--sans-serif`.
- Fix the preview-iframe **theme flash on expand** — the srcdoc now reads the parent theme and sets `color-scheme` synchronously during parse (before first paint), fixing both the white (dark-mode) and black (light-mode) flashes.
- Document `data-*` / `aria-*` pass-through under Inherited props; Icon page Component-props move; Progress/Tooltip "Examples" headings.

## Test plan
- `pnpm run build`, `pnpm run typecheck`, `pnpm --filter anta-site build` — all green locally (mirrors CI).
- Manually verified the playground theme-flash fix in both light and dark mode.