### PR TITLE
Release anta 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file only tracks what ships to npm consumers — anything under `src/`, `di
 
 Versions ending in `-dev.N` are pre-release builds published under the npm `dev` dist-tag; main releases drop the suffix. Always pin a specific version in your `package.json` (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag — the floating tag tracks the latest dev build and will silently change between installs.
 
-## 0.2.2 — Unreleased
+## 0.2.2 — June 13, 2026
 
 ### Breaking
 - **`list-detail-view` icon renamed to `list-collapse` (and restyled to lucide `list-collapse`).** The old filled detail-view glyph is gone; `shape="list-collapse"` is the lucide three-lines-with-chevrons glyph. Migration: rename `shape="list-detail-view"` → `shape="list-collapse"`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bumps **`@antadesign/anta` `0.2.1` → `0.2.2`** and dates the CHANGELOG. Stickers is unchanged (stays `0.1.1` — its README already shipped in 0.1.1).

Just the version bump + changelog date; all the actual changes already landed on `main` (merged in #58). After merge, publish with `npm publish --access public --tag latest` from the repo root.

### What 0.2.2 contains (see CHANGELOG)
- **Breaking:** Tooltip is pinned by default; cursor-following is opt-in via `follow` (`static` removed). `list-detail-view` icon renamed to `list-collapse`.
- **Added:** `::part(bubble)` + `--tooltip-padding` token on Tooltip.
- **Changed:** Tooltip distance-fade (follow mode); quaternary buttons `font-weight: 400` + `letter-spacing: 0.06ch` + full-opacity rest; `Button`/`Text`/`Title` pin `ss02`/`ss05`; `copy` icon rotated 90°; `filter` icon restyled to lucide `list-filter`.
- **Fixed:** Button drops empty/whitespace/`NaN` children; button icon padding discounts `<Tooltip>`.

### Test plan
- `pnpm run build`, `pnpm run typecheck`, `pnpm --filter anta-site build` — green locally.