### PR TITLE
feat(expander)!: migrate open-state to the state contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file only tracks what ships to npm consumers — anything under `src/`, `di
 
 Versions ending in `-dev.N` are pre-release builds published under the npm `dev` dist-tag; main releases drop the suffix. Always pin a specific version in your `package.json` (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag — the floating tag tracks the latest dev build and will silently change between installs.
 
+## Unreleased
+
+### Breaking
+- **`Expander` open-state API moved to the shared `state` contract** (see `STATEFUL-COMPONENTS.md`). The controlled/uncontrolled behaviour is unchanged; the attribute, event, and one callback are renamed.
+  - **Element** — the `open` / `defaultopen` attributes become `state` / `default-state`, a string enum (`"open"` / `"closed"`) rather than value-based booleans. The `toggle` event becomes **`statechange`** — now `cancelable` and fired *before* the state is applied — with `detail: { next, prev }` (the `'open'|'closed'` vocabulary) replacing `detail.open`.
+  - **Wrapper (`<Expander>`)** — the `open` and `defaultOpen` props are unchanged. The `onToggle?: (open: boolean) => void` callback becomes **`onStateChange?: (event, { next, prev }) => void`** (event-first; `next`/`prev` are booleans). Migration: `onToggle={setOpen}` → `onStateChange={(e, { next }) => setOpen(next)}`.
+  - **New capability** — because `statechange` is cancelable and fires before applying, an *uncontrolled* expander can now veto a toggle synchronously via `event.preventDefault()` (e.g. confirm-before-close) without switching to controlled mode.
+
 ## 0.2.3 — June 18, 2026
 
 ### Added

--- a/site/src/pages/components/expander.mdx
+++ b/site/src/pages/components/expander.mdx
@@ -212,7 +212,7 @@ string. The node owns its own type scale, so set the level on it, not on
 them in the header:
 
 <Preview direction="column" gap="8px">
-  <a-expander class="heading-title" defaultopen>
+  <a-expander class="heading-title" default-state="open">
     <Title slot="title" level={2}>Title level 2 example</Title>
     <a-expander-details><Text>A level-2 <code>{'<Title>'}</code> as the header — a real heading node in the page outline.</Text></a-expander-details>
   </a-expander>
@@ -350,19 +350,29 @@ state stays as-is — disabling an open expander keeps it open. Header
 
 Leave it uncontrolled and pass `defaultOpen` for the initial state — the
 element owns open/close from there. To drive it yourself, pass `open`
-and handle `onToggle(open)` (controlled): the expander then only follows
-the prop, and clicking the summary just *requests* a change through
-`onToggle` — apply it to your state to accept, or ignore it to reject
-(e.g. a section that needs confirmation before closing). If you pass
+and handle `onStateChange` (controlled): the expander then only follows
+the prop, and clicking the summary just *requests* a change — apply
+`detail.next` to your state to accept, or ignore it to reject. If you pass
 `open`, you own it.
+
+`onStateChange` is event-first: `(event, { next, prev })`, where `next`/`prev`
+are booleans (the requested / previous open state). `statechange` fires
+**before** the element applies anything and is **cancelable**, so even
+uncontrolled you can veto a toggle synchronously with `event.preventDefault()`
+(e.g. a section that confirms before closing) — no need to lift state.
 
 ```tsx
 // uncontrolled
 <Expander title="Details" defaultOpen>…</Expander>
 
+// uncontrolled, with a veto
+<Expander title="Details" onStateChange={(e, { next }) => {
+  if (!next && unsaved) e.preventDefault()   // refuse to close
+}}>…</Expander>
+
 // controlled
 const [open, setOpen] = useState(false)
-<Expander title="Details" open={open} onToggle={setOpen}>…</Expander>
+<Expander title="Details" open={open} onStateChange={(e, { next }) => setOpen(next)}>…</Expander>
 ```
 
 ## Styling the chevron & header
@@ -439,7 +449,7 @@ mode alike) — no JS. Two worked examples:
 **Custom expandable code block**
 
 <Preview direction="column" gap="8px">
-  <a-expander class="code-like" defaultopen>
+  <a-expander class="code-like" default-state="open">
     <a-expander-summary slot="title">Example.tsx</a-expander-summary>
     <Button priority="tertiary" slot="actions"><Icon shape="copy" /></Button>
     <a-expander-details>
@@ -537,7 +547,7 @@ still toggles; the indicator only reflects state, rotating via
 equivalent element composition because these docs render statically):
 
 <Preview direction="column" gap="8px">
-  <a-expander class="indicator" defaultopen>
+  <a-expander class="indicator" default-state="open">
     <a-expander-summary slot="title">Build log</a-expander-summary>
     <Icon slot="actions" shape="chevron-down" />
     <a-expander-details><Text>The header is the trigger; the actions chevron is an indicator only.</Text></a-expander-details>

--- a/site/src/pages/components/expander.mdx
+++ b/site/src/pages/components/expander.mdx
@@ -581,6 +581,25 @@ equivalent element composition because these docs render statically):
 `}</style>
 ```
 
+## Controlled vs Uncontrolled
+
+Open state follows Anta's shared **state contract**. Leave it *uncontrolled* and
+the expander owns open/close; pass the controlled prop and *you* own it. The two
+layers speak different idioms — the `<Expander>` wrapper takes booleans, the
+`<a-expander>` element takes a `state` string enum — and the wrapper maps between
+them:
+
+| | `<Expander>` (JSX) | `<a-expander>` (element) |
+|---|---|---|
+| **Uncontrolled** — element owns it | `defaultOpen` | `default-state="open" \| "closed"` |
+| **Controlled** — you own it | `open` + `onStateChange` | `state="open" \| "closed"` + `statechange` |
+| **Change event** | `onStateChange(event, { next, prev })` — `next` / `prev` are **booleans** | `statechange`, a `CustomEvent<{ next, prev }>` — `'open'` / `'closed'` |
+
+`statechange` is **cancelable** and fires *before* the element applies the
+change. Uncontrolled, call `event.preventDefault()` to veto a toggle (e.g.
+confirm before closing). Controlled, the element never self-applies — apply
+`detail.next` to `open` to accept, or do nothing to reject.
+
 <Disclosure title="Component props" open>
 
 <PropsTable component="Expander" />

--- a/src/components/Expander.tsx
+++ b/src/components/Expander.tsx
@@ -57,27 +57,39 @@ export interface ExpanderProps extends Omit<BaseProps, "title"> {
   disabled?: boolean;
   /** Controlled open state. When provided, the consumer owns open/close:
    *  the expander only follows this prop, and clicking the summary just
-   *  requests a change via `onToggle` (so a toggle can be rejected by not
-   *  updating). Leave undefined for uncontrolled. */
+   *  requests a change via `onStateChange` (so a toggle can be rejected by
+   *  not updating). Leave undefined for uncontrolled. */
   open?: boolean;
   /** Initial open state for the uncontrolled case. */
   defaultOpen?: boolean;
-  /** Fired whenever the summary is toggled, with the requested open
-   *  state (in controlled mode, apply it to `open` to accept). */
-  onToggle?: (open: boolean) => void;
+  /** Fired before the open state changes. `event` is the cancelable
+   *  `statechange` — call `event.preventDefault()` to veto an *uncontrolled*
+   *  toggle (e.g. confirm before closing). `detail.next` is the requested
+   *  open state, `detail.prev` the current one (booleans). In controlled
+   *  mode, apply `detail.next` to `open` to accept, or do nothing to reject. */
+  onStateChange?: (
+    event: CustomEvent,
+    detail: { next: boolean; prev: boolean },
+  ) => void;
 }
 
-/** The element's `toggle` event payload. */
-type ToggleEvent = CustomEvent<{ open: boolean }>;
+/** The element's `statechange` payload, in the `'open'|'closed'` vocabulary. */
+type StateChangeDetail = { next: "open" | "closed"; prev: "open" | "closed" };
+type StateChangeEvent =
+  | CustomEvent<StateChangeDetail>
+  | { nativeEvent: CustomEvent<StateChangeDetail> };
 
-/** Pull the requested open state out of the element's `toggle` event,
- *  across renderers: a raw `CustomEvent` carries `detail` directly; a
- *  synthetic wrapper carries it on `nativeEvent.detail`. */
-function toggledOpen(e: ToggleEvent | { nativeEvent: ToggleEvent }): boolean {
-  const detail =
-    ("nativeEvent" in e ? e.nativeEvent?.detail : undefined) ??
-    ("detail" in e ? e.detail : undefined);
-  return !!detail?.open;
+/** Resolve the *native* `statechange` event across renderers: it's `e`
+ *  directly (vanilla / React 19 / Preact all bind a native listener for
+ *  custom events) or `e.nativeEvent` behind a synthetic wrapper. Returning the
+ *  native event is what lets a consumer's `preventDefault()` reach the
+ *  element's `dispatchEvent` return and actually veto the transition. */
+function nativeStateChange(e: StateChangeEvent): {
+  event: CustomEvent<StateChangeDetail>;
+  detail?: StateChangeDetail;
+} {
+  const event = ("nativeEvent" in e ? e.nativeEvent : e) as CustomEvent<StateChangeDetail>;
+  return { event, detail: event?.detail };
 }
 
 /**
@@ -88,12 +100,13 @@ function toggledOpen(e: ToggleEvent | { nativeEvent: ToggleEvent }): boolean {
  * no state and grabs no ref — it only maps props to attributes (safe
  * wherever the host DOM is reconciled, incl. off the UI thread).
  *
- * Uncontrolled (`defaultOpen`): the element owns its open state. The
- * wrapper emits `defaultopen` — never `open` — so the DOM carries no
- * stale state attribute. Controlled (`open` + `onToggle`): the wrapper
- * emits `open="" | "false"`; the element treats the attribute as the
- * source of truth and clicks only dispatch the `toggle` event, giving
- * real controlled semantics (a consumer can reject a toggle).
+ * Uncontrolled (`defaultOpen`): the element owns its open state. The wrapper
+ * emits `default-state="open"` — never `state` — so the DOM carries no stale
+ * controlled attribute. Controlled (`open` + `onStateChange`): the wrapper
+ * emits `state="open" | "closed"`; the element treats the attribute as the
+ * source of truth and clicks only dispatch the cancelable `statechange` event,
+ * giving real controlled semantics (a consumer can reject a toggle). See
+ * STATEFUL-COMPONENTS.md.
  */
 export const Expander = ({
   title,
@@ -105,7 +118,7 @@ export const Expander = ({
   disabled,
   open,
   defaultOpen,
-  onToggle,
+  onStateChange,
   className,
   style,
   children,
@@ -140,18 +153,29 @@ export const Expander = ({
 
   return (
     <a-expander
-      open={controlled ? (open ? "" : "false") : undefined}
-      defaultopen={!controlled && defaultOpen ? "" : undefined}
+      state={controlled ? (open ? "open" : "closed") : undefined}
+      default-state={!controlled && defaultOpen ? "open" : undefined}
       level={level != null ? (String(level) as `${typeof level}`) : undefined}
       tone={tone && tone !== "neutral" ? tone : undefined}
       priority={priority && priority !== "secondary" ? priority : undefined}
       outdent={outdent ? "" : undefined}
       disabled={disabled ? "" : undefined}
-      // All-lowercase `ontoggle` is the one event-prop spelling both
-      // renderers bind to our `toggle` event: React 19 keeps the case of
-      // whatever follows `on` (so `onToggle` would listen for "Toggle"),
+      // All-lowercase `onstatechange` is the one event-prop spelling both
+      // renderers bind to our `statechange` event: React 19 keeps the case of
+      // whatever follows `on` (so `onStateChange` would listen for "StateChange"),
       // Preact lowercases. Verified against real React 19 + Preact.
-      ontoggle={onToggle ? (e: ToggleEvent) => onToggle(toggledOpen(e)) : undefined}
+      onstatechange={
+        onStateChange
+          ? (e: StateChangeEvent) => {
+              const { event, detail } = nativeStateChange(e);
+              if (detail)
+                onStateChange(event, {
+                  next: detail.next === "open",
+                  prev: detail.prev === "open",
+                });
+            }
+          : undefined
+      }
       class={className}
       style={computedStyle}
       {...rest}

--- a/src/elements/a-expander.css
+++ b/src/elements/a-expander.css
@@ -8,17 +8,14 @@
     --expander-bg-primary: var(--bg-4);
     --expander-border-primary: var(--border-4);
 
-    /* Closed-only hover lightens the surface by 50/50-mixing the current bg with
-       its next-lighter neutral neighbour. The bg scale inverts in dark mode
-       (bg-1 is darkest there), so the lift targets are overridden under `.dark`;
-       toned variants lift within their own hue via oklch (see below). */
-    --expander-bg-secondary-lift: var(--bg-1);
-    --expander-bg-primary-lift: var(--bg-3);
-
     --expander-bg: var(--expander-bg-secondary);
     --expander-border: var(--expander-border-secondary);
-    --expander-bg-lift: var(--expander-bg-secondary-lift);
-    --expander-bg-hover: color-mix(in oklch, var(--expander-bg) 50%, var(--expander-bg-lift));
+    /* Closed-only hover lightens the current surface in place: an oklch lightness
+       bump that keeps hue + chroma, so it works for every priority and tone, in
+       light and dark, with no precomputed targets (lighten = higher L in both
+       modes; a transparent surface keeps zero alpha). Tune the amount here. */
+    --expander-bg-hover-lift: 0.03;
+    --expander-bg-hover: oklch(from var(--expander-bg) calc(l + var(--expander-bg-hover-lift)) c h);
 
     /* The single gutter that the title inset, the body inset, AND the chevron
        position all derive from (see a-expander.ts). The chevron sits absolutely
@@ -75,30 +72,21 @@
   a-expander[priority="primary"] {
     --expander-bg: var(--expander-bg-primary);
     --expander-border: var(--expander-border-primary);
-    --expander-bg-lift: var(--expander-bg-primary-lift);
   }
   a-expander[priority="tertiary"] {
     --expander-bg: transparent;
     --expander-border: transparent;
-    /* Transparent surface → no hover fill (the bare disclosure). */
-    --expander-bg-lift: transparent;
   }
 
   /* Closed + enabled: lighten on hover, then snap back to the base surface while
      pressed so the background is already correct as the region expands. Gated on
-     `:not(:state(open))` so an open expander has no surface hover. */
+     `:not(:state(open))` so an open expander has no surface hover. (A transparent
+     tertiary surface stays transparent — the oklch bump preserves zero alpha.) */
   a-expander:not([disabled]):not(:state(open)):hover {
     background: var(--expander-bg-hover);
   }
   a-expander:not([disabled]):not(:state(open)):active {
     background: var(--expander-bg);
-  }
-
-  /* Dark mode neutral: the bg scale inverts (bg-1 is darkest), so the
-     next-lighter neighbour is the higher index. */
-  .dark a-expander {
-    --expander-bg-secondary-lift: var(--bg-3);
-    --expander-bg-primary-lift: var(--bg-5);
   }
 
   /* Outdent: zero the gutter so the title + body go flush with the surrounding
@@ -184,15 +172,6 @@
     --expander-border-secondary: oklch(from var(--expander-tone-source) 0.22 0.05 h);
     --expander-bg-primary:       oklch(from var(--expander-tone-source) 0.19 0.04 h);
     --expander-border-primary:   oklch(from var(--expander-tone-source) 0.26 0.07 h);
-  }
-
-  /* Toned variants have no neutral-white neighbour (and `--bg-1-{tone}` doesn't
-     exist), so they lift within their own hue: a small oklch lightness bump of
-     the resolved surface, the same in light and dark. Higher specificity than
-     the priority lift above, so it wins for both secondary and primary tones
-     (transparent surfaces stay transparent — the bump preserves zero alpha). */
-  a-expander[tone]:not([tone="neutral"]) {
-    --expander-bg-lift: oklch(from var(--expander-bg) calc(l + 0.02) c h);
   }
 
   a-expander[disabled],

--- a/src/elements/a-expander.css
+++ b/src/elements/a-expander.css
@@ -8,8 +8,17 @@
     --expander-bg-primary: var(--bg-4);
     --expander-border-primary: var(--border-4);
 
+    /* Closed-only hover lightens the surface by 50/50-mixing the current bg with
+       its next-lighter neutral neighbour. The bg scale inverts in dark mode
+       (bg-1 is darkest there), so the lift targets are overridden under `.dark`;
+       toned variants lift within their own hue via oklch (see below). */
+    --expander-bg-secondary-lift: var(--bg-1);
+    --expander-bg-primary-lift: var(--bg-3);
+
     --expander-bg: var(--expander-bg-secondary);
     --expander-border: var(--expander-border-secondary);
+    --expander-bg-lift: var(--expander-bg-secondary-lift);
+    --expander-bg-hover: color-mix(in oklch, var(--expander-bg) 50%, var(--expander-bg-lift));
 
     /* The single gutter that the title inset, the body inset, AND the chevron
        position all derive from (see a-expander.ts). The chevron sits absolutely
@@ -32,6 +41,8 @@
 
     color: var(--expander-text);
     background: var(--expander-bg);
+    /* Smooth the closed-state hover/active surface change. */
+    transition: background-color 150ms ease;
   }
 
   a-expander-summary {
@@ -64,10 +75,30 @@
   a-expander[priority="primary"] {
     --expander-bg: var(--expander-bg-primary);
     --expander-border: var(--expander-border-primary);
+    --expander-bg-lift: var(--expander-bg-primary-lift);
   }
   a-expander[priority="tertiary"] {
     --expander-bg: transparent;
     --expander-border: transparent;
+    /* Transparent surface → no hover fill (the bare disclosure). */
+    --expander-bg-lift: transparent;
+  }
+
+  /* Closed + enabled: lighten on hover, then snap back to the base surface while
+     pressed so the background is already correct as the region expands. Gated on
+     `:not(:state(open))` so an open expander has no surface hover. */
+  a-expander:not([disabled]):not(:state(open)):hover {
+    background: var(--expander-bg-hover);
+  }
+  a-expander:not([disabled]):not(:state(open)):active {
+    background: var(--expander-bg);
+  }
+
+  /* Dark mode neutral: the bg scale inverts (bg-1 is darkest), so the
+     next-lighter neighbour is the higher index. */
+  .dark a-expander {
+    --expander-bg-secondary-lift: var(--bg-3);
+    --expander-bg-primary-lift: var(--bg-5);
   }
 
   /* Outdent: zero the gutter so the title + body go flush with the surrounding
@@ -153,6 +184,15 @@
     --expander-border-secondary: oklch(from var(--expander-tone-source) 0.22 0.05 h);
     --expander-bg-primary:       oklch(from var(--expander-tone-source) 0.19 0.04 h);
     --expander-border-primary:   oklch(from var(--expander-tone-source) 0.26 0.07 h);
+  }
+
+  /* Toned variants have no neutral-white neighbour (and `--bg-1-{tone}` doesn't
+     exist), so they lift within their own hue: a small oklch lightness bump of
+     the resolved surface, the same in light and dark. Higher specificity than
+     the priority lift above, so it wins for both secondary and primary tones
+     (transparent surfaces stay transparent — the bump preserves zero alpha). */
+  a-expander[tone]:not([tone="neutral"]) {
+    --expander-bg-lift: oklch(from var(--expander-bg) calc(l + 0.02) c h);
   }
 
   a-expander[disabled],

--- a/src/elements/a-expander.css
+++ b/src/elements/a-expander.css
@@ -14,7 +14,7 @@
        bump that keeps hue + chroma, so it works for every priority and tone, in
        light and dark, with no precomputed targets (lighten = higher L in both
        modes; a transparent surface keeps zero alpha). Tune the amount here. */
-    --expander-bg-hover-lift: 0.03;
+    --expander-bg-hover-lift: 0.01;
     --expander-bg-hover: oklch(from var(--expander-bg) calc(l + var(--expander-bg-hover-lift)) c h);
 
     /* The single gutter that the title inset, the body inset, AND the chevron
@@ -39,7 +39,7 @@
     color: var(--expander-text);
     background: var(--expander-bg);
     /* Smooth the closed-state hover/active surface change. */
-    transition: background-color 150ms ease;
+    transition: background-color 100ms ease;
   }
 
   a-expander-summary {

--- a/src/elements/a-expander.ts
+++ b/src/elements/a-expander.ts
@@ -40,19 +40,23 @@ import './a-expander.css'
  *                              clips while animating; it projects the body
  *                              directly, no wrapper div
  *
- * ## Open state — controlled vs. uncontrolled
+ * ## Open state — the `state` contract (see STATEFUL-COMPONENTS.md)
  *
- * - **Uncontrolled** (no `open` attribute): the element owns its state.
- *   Clicking the summary toggles it; `defaultopen` (presence) sets the
- *   initial state. This is the hand-authored-HTML mode.
- * - **Controlled** (`open` attribute present — `""`/`"true"` open,
- *   `"false"` closed): the attribute is the single source of truth.
- *   Clicks do NOT self-toggle; they only dispatch the `toggle` event
- *   (`detail.open` = the *requested* state) and the consumer answers by
- *   updating the attribute. This gives real controlled semantics — a
- *   consumer can reject a toggle by simply not updating. If you set
- *   `open`, you own it. The attribute is value-based (like ARIA), not
- *   presence-based, because absence must keep meaning "uncontrolled".
+ * - **Uncontrolled** (no `state` attribute): the element owns its state.
+ *   Clicking the summary toggles it; `default-state="open"` seeds the
+ *   initial state (read once at connect). This is the hand-authored mode.
+ * - **Controlled** (`state="open"`/`"closed"` present): the attribute is the
+ *   single source of truth. Clicks do NOT self-toggle; they only dispatch the
+ *   cancelable `statechange` event and the consumer answers by updating
+ *   `state`. A consumer can reject by simply not updating. If you set `state`,
+ *   you own it; absence keeps meaning "uncontrolled".
+ *
+ * Either way the element fires **`statechange`** — `cancelable`, *before* it
+ * applies anything — with `detail: { next, prev }` in the `'open'|'closed'`
+ * vocabulary. Uncontrolled, a handler can veto the transition synchronously
+ * with `preventDefault()` (the element gates its own apply on the dispatch
+ * result); controlled, `preventDefault()` is moot (the element never
+ * self-applies) and not-updating-`state` is the reject.
  *
  * The internal open state lives in the shadow: `aria-expanded` on the
  * button (BOTH the a11y signal and the CSS state hook — no extra class)
@@ -319,8 +323,11 @@ const SHADOW_STYLE = `
   }
 `
 
+type ExpanderState = 'open' | 'closed'
+const parseState = (v: string | null): ExpanderState => (v === 'open' ? 'open' : 'closed')
+
 export class AExpanderElement extends HTMLElementBase {
-  static observedAttributes = ['open', 'disabled']
+  static observedAttributes = ['state', 'disabled']
 
   private summary: HTMLButtonElement
   private region: HTMLDivElement
@@ -379,41 +386,41 @@ export class AExpanderElement extends HTMLElementBase {
     shadow.append(style, header, this.region)
   }
 
-  /** Controlled mode: the `open` attribute is present and owns the state. */
+  /** Controlled mode: the `state` attribute is present and owns the state. */
   private get controlled(): boolean {
-    return this.hasAttribute('open')
+    return this.hasAttribute('state')
   }
 
-  private get isOpen(): boolean {
-    return this.summary.getAttribute('aria-expanded') === 'true'
+  /** The currently *applied* state (read from the shadow, the source of truth
+   *  for what's painted). */
+  private get current(): ExpanderState {
+    return this.summary.getAttribute('aria-expanded') === 'true' ? 'open' : 'closed'
   }
 
   connectedCallback() {
     this.syncDisabled()
-    if (this.controlled) this.syncFromAttribute()
-    else this.setOpen(this.hasAttribute('defaultopen'))
+    // Controlled → reflect `state`; uncontrolled → seed once from `default-state`.
+    this.applyState(parseState(this.getAttribute(this.controlled ? 'state' : 'default-state')))
   }
 
   attributeChangedCallback(name: string) {
     if (name === 'disabled') this.syncDisabled()
-    // When `open` is removed (controlled → uncontrolled hand-off) the
-    // current state is kept, not reset.
-    else if (this.controlled) this.syncFromAttribute()
-  }
-
-  private syncFromAttribute() {
-    this.setOpen(this.getAttribute('open') !== 'false')
+    // `state` is the controlled lever — reflect changes. When it's *removed*
+    // (controlled → uncontrolled hand-off) `controlled` is false, so we skip and
+    // the current applied state is kept, not reset.
+    else if (name === 'state' && this.controlled) this.applyState(parseState(this.getAttribute('state')))
   }
 
   private syncDisabled() {
     this.summary.disabled = this.hasAttribute('disabled')
   }
 
-  /** Apply open state to the shadow internals (idempotent; reads the host,
-   *  writes only the shadow). `aria-expanded` is both the a11y signal and
-   *  the CSS state hook; `inert` keeps collapsed content out of the tab
-   *  order and the accessibility tree. */
-  private setOpen(open: boolean) {
+  /** Apply state to the shadow internals (idempotent; reads the host, writes
+   *  only the shadow). `aria-expanded` is both the a11y signal and the CSS
+   *  state hook; `inert` keeps collapsed content out of the tab order and the
+   *  accessibility tree. */
+  private applyState(state: ExpanderState) {
+    const open = state === 'open'
     this.summary.setAttribute('aria-expanded', open ? 'true' : 'false')
     this.region.inert = !open
     // Mirror to the `:state(open)` custom state for external CSS hooks.
@@ -423,12 +430,18 @@ export class AExpanderElement extends HTMLElementBase {
     } catch {}
   }
 
-  /** Uncontrolled: toggle, then announce. Controlled: only announce the
-   *  requested state — the consumer answers via the `open` attribute. */
+  /** Compute the requested next state, announce it (cancelable, *before*
+   *  applying), then — uncontrolled only, and only if not vetoed — apply it.
+   *  Controlled: never self-apply; the consumer answers via the `state`
+   *  attribute. See STATEFUL-COMPONENTS.md. */
   private onSummaryClick = () => {
-    const requested = !this.isOpen
-    if (!this.controlled) this.setOpen(requested)
-    this.dispatchEvent(new CustomEvent('toggle', { detail: { open: requested } }))
+    const prev = this.current
+    const next: ExpanderState = prev === 'open' ? 'closed' : 'open'
+    const ok = this.dispatchEvent(
+      new CustomEvent('statechange', { cancelable: true, detail: { next, prev } }),
+    )
+    if (this.controlled) return
+    if (ok) this.applyState(next)
   }
 }
 

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -146,16 +146,14 @@ export interface ATagAttributes extends BaseAttributes {
  * use `Expander` from `@antadesign/anta`.
  */
 export interface AExpanderAttributes extends BaseAttributes {
-  /** Controlled open state — value-based, like ARIA, because absence
-   *  must keep meaning "uncontrolled". When present, the attribute is
-   *  the source of truth (`''`/`'true'` open, `'false'` closed): clicks
-   *  only dispatch `toggle` with the requested state, and the consumer
-   *  answers by updating the attribute. Omit it (use `defaultopen`) for
-   *  the self-toggling uncontrolled mode. */
-  open?: '' | 'true' | 'false'
-  /** Initial open state for the uncontrolled mode. Presence-based
-   *  (`''`/bare = initially open); read once when the element connects. */
-  defaultopen?: boolean | ''
+  /** Controlled open state (`'open'` / `'closed'`). Present → controlled: the
+   *  attribute is the source of truth, clicks only dispatch the cancelable
+   *  `statechange` event, and the consumer answers by updating it. Absent →
+   *  uncontrolled (use `default-state`). See STATEFUL-COMPONENTS.md. */
+  state?: 'open' | 'closed'
+  /** Initial open state for the uncontrolled mode (`'open'` / `'closed'`);
+   *  read once when the element connects. */
+  'default-state'?: 'open' | 'closed'
   /** Surface emphasis. `secondary` (default) is a subtle fill; `primary`
    *  is a stronger raised fill; `tertiary` is transparent. */
   priority?: 'primary' | 'secondary' | 'tertiary'
@@ -175,13 +173,16 @@ export interface AExpanderAttributes extends BaseAttributes {
   /** Heading type scale for the summary, `'1'`–`'6'` (mirrors `<a-title>`
    *  levels). Default (omitted) ≈ level 5. */
   level?: '1' | '2' | '3' | '4' | '5' | '6'
-  /** Fires when the summary is toggled. The element dispatches a `toggle`
-   *  `CustomEvent` whose `detail.open` carries the requested state. The
-   *  all-lowercase spelling is deliberate — it's the one form both
-   *  renderers bind to the `toggle` event (React 19 keeps the case of
-   *  whatever follows `on`, so `onToggle` would listen for "Toggle";
-   *  Preact lowercases). */
-  ontoggle?: (e: CustomEvent<{ open: boolean }>) => void
+  /** Fires before the open state changes — the element dispatches a
+   *  `cancelable` `statechange` `CustomEvent` whose `detail` is
+   *  `{ next, prev }` in the `'open'|'closed'` vocabulary. Uncontrolled,
+   *  `preventDefault()` vetoes the transition. The all-lowercase spelling is
+   *  deliberate — it's the one form both renderers bind to the `statechange`
+   *  event (React 19 keeps the case after `on`, so `onStateChange` would
+   *  listen for "StateChange"; Preact lowercases). */
+  onstatechange?: (
+    e: CustomEvent<{ next: 'open' | 'closed'; prev: 'open' | 'closed' }>,
+  ) => void
 }
 
 /**


### PR DESCRIPTION
Brings the published `Expander` (0.2.3) onto the shared `STATEFUL-COMPONENTS.md` contract (now on main). **Breaking** — it's published, so the attribute/event/callback renames are consumer-facing.

## Changes
- **Element `<a-expander>`**
  - `open` / `defaultopen` attributes → **`state`** / **`default-state`**, a string enum (`"open"` / `"closed"`) instead of value-based booleans. Present `state` → controlled; absent → uncontrolled; `default-state` seeds the uncontrolled initial state once.
  - `toggle` event → **`statechange`** — `cancelable`, fired **before** applying, `detail: { next, prev }` in the `'open'|'closed'` vocabulary (was `detail.open`).
  - Control algorithm is the contract's canonical one: `dispatch → if (controlled) return → if (ok) apply`.
  - `:state(open)` styling hook unchanged.
- **Wrapper `<Expander>`**
  - `open` / `defaultOpen` props unchanged (boolean, the React idiom).
  - `onToggle?: (open) => void` → **`onStateChange?: (event, { next, prev }) => void`** — event-first so `event.preventDefault()` is reachable; `next`/`prev` are booleans; detail is normalized across React/Preact.
- **New capability** — uncontrolled expanders can now veto a toggle synchronously via `event.preventDefault()` (e.g. confirm-before-close) without going controlled.
- Types (`general_types.ts`), docs (`expander.mdx` Open-state section + raw-element examples), and a `CHANGELOG` **Breaking** entry updated in lockstep.

## Migration
`onToggle={setOpen}` → `onStateChange={(e, { next }) => setOpen(next)}`. Hand-authored `<a-expander open>` → `<a-expander state="open">`; `defaultopen` → `default-state="open"`.

Typecheck + full build pass.