### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
-## Unreleased
+## 0.3.3 — July 8, 2026
 
 ### Added
 - **`InputDate`** — a date (and date-time, with `time`) field, composed from `Input` + `Menu` + `Calendar`. Type freely; it resolves on blur or Enter with a locale-aware parser (field order, month names, run-together digits) and rewrites the entry to the canonical format. An unrecognized entry marks the field `critical` and keeps the text. The trailing button opens the calendar. `time` makes the value `YYYY-MM-DDTHH:mm` and adds a time row with a 12- or 24-hour clock (locale-driven, `hour12` to override; a 24-hour hour typed into a 12-hour field auto-converts). Controlled or uncontrolled, submits ISO under `name`. Exports `InputDateProps` / `InputDateChangeAttrs`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/components/ChangelogNav.astro
+++ b/site/src/components/ChangelogNav.astro
@@ -1,63 +1,36 @@
 ---
 /**
- * ChangelogNav.astro — two-link nav strip between the two changelog pages:
+ * ChangelogNav.astro — nav between the two changelog pages:
  *   • /changelog/      — Main releases (stable, summarised)
  *   • /changelog/dev/  — Dev releases (prereleases, full detail)
  *
- * The changelog used to be a single page with a client-side stream filter;
- * it's now physically split into two pages (so each page's "On this page"
- * rail lists only its own versions). This strip is plain links — the active
- * page is marked with aria-current="page". No JS.
+ * Rendered as an Anta <Tabs> strip (via the NavTabs island) that navigates to
+ * the picked URL on the client. Hydrated (`client:load`) since the tabs are
+ * buttons, not links.
  */
+import NavTabs from './NavTabs'
+
 interface Props {
   active: 'main' | 'dev'
 }
 const { active } = Astro.props
+const activeUrl = active === 'dev' ? '/changelog/dev/' : '/changelog/'
 ---
 
-<nav class="changelog-tabs" aria-label="Changelog releases">
-  <a href="/changelog/" aria-current={active === 'main' ? 'page' : undefined}>
-    Main releases
-  </a>
-  <a href="/changelog/dev/" aria-current={active === 'dev' ? 'page' : undefined}>
-    Dev releases
-  </a>
-</nav>
+<div class="changelog-nav">
+  <NavTabs
+    client:load
+    label="Changelog releases"
+    active={activeUrl}
+    tabs={[
+      { value: '/changelog/', label: 'Main releases' },
+      { value: '/changelog/dev/', label: 'Dev releases' },
+    ]}
+  />
+</div>
 
-<style is:global>
-  .changelog-tabs {
-    display: inline-flex;
-    flex-wrap: nowrap;
-    align-items: stretch;
-    gap: 4px;
-    border: 0.5px solid var(--border-4);
-    background: var(--bg-pane);
-    padding: 4px;
-    border-radius: 6px;
+<style>
+  .changelog-nav {
     margin: 0 0 24px;
-    max-width: 100%;
-    overflow-x: auto;
-    scrollbar-width: thin;
-  }
-  .changelog-tabs > a {
-    font: inherit;
-    font-size: 0.85rem;
-    line-height: 1.2;
-    color: var(--text-3);
-    padding: 4px 8px 5px;
-    border-radius: 4px;
-    text-decoration: none;
-    white-space: nowrap;
-    transition: background 150ms ease-out, color 150ms ease-out;
-  }
-  .changelog-tabs > a:hover,
-  .changelog-tabs > a:focus-visible {
-    color: var(--text-2);
-    outline: none;
-  }
-  .changelog-tabs > a[aria-current='page'] {
-    background: var(--bg-canvas);
-    color: var(--text-1);
-    box-shadow: 0 0 2px var(--border-3);
   }
 </style>

--- a/site/src/components/NavTabs.tsx
+++ b/site/src/components/NavTabs.tsx
@@ -1,0 +1,39 @@
+import { Tabs } from '@antadesign/anta'
+
+interface NavTab {
+  /** Destination URL — doubles as the tab's `value`. */
+  value: string
+  label: string
+}
+
+interface Props {
+  tabs: NavTab[]
+  /** The current page's URL (must match one tab's `value`). */
+  active: string
+  /** Accessible name for the tablist. */
+  label: string
+}
+
+/**
+ * Anta `<Tabs>` used as page navigation: each tab's `value` is a URL, and
+ * picking a tab navigates there. The strip is controlled to the current page's
+ * URL, so it never flickers to the clicked tab before the load fires. Used for
+ * the changelog (main / dev) and the Colors tone sub-pages.
+ *
+ * Navigation runs on `onStateChange` (the pre-apply pick), not `onValueChange`:
+ * in controlled mode we deliberately don't update `value`, so the post-apply
+ * `onValueChange` wouldn't fire. Needs `client:load` — the tabs are buttons, so
+ * the handler must be hydrated to navigate.
+ */
+export default function NavTabs({ tabs, active, label }: Props) {
+  return (
+    <Tabs
+      value={active}
+      label={label}
+      options={tabs}
+      onStateChange={(_event, { next }) => {
+        if (next && next !== active) window.location.href = next
+      }}
+    />
+  )
+}

--- a/site/src/components/Swatches.astro
+++ b/site/src/components/Swatches.astro
@@ -6,6 +6,7 @@
 // read live from the rendered colours. One island per theme example.
 import s from './Swatches.module.css'
 import SwatchGrid from './SwatchGrid.tsx'
+import NavTabs from './NavTabs'
 
 type Tone = 'neutral' | 'brand' | 'info' | 'success' | 'critical' | 'warning'
 type Kind = 'bg' | 'text' | 'border'
@@ -45,18 +46,13 @@ const slug = (k: Kind) => TITLES[k].toLowerCase()
 ---
 
 <div class:list={[s.page, 'full-bleed']}>
-  <div class={s.toneTabs} role="tablist">
-    {TONES.map((t) => (
-      <a
-        href={toneHref(t.id)}
-        role="tab"
-        aria-selected={t.id === tone ? 'true' : 'false'}
-        data-preserve-scroll
-        class:list={[s.toneTab, { [s.toneTabActive]: t.id === tone }]}
-      >
-        {t.label}
-      </a>
-    ))}
+  <div class={s.toneTabs}>
+    <NavTabs
+      client:load
+      label="Colour tones"
+      active={toneHref(tone)}
+      tabs={TONES.map((t) => ({ value: toneHref(t.id), label: t.label }))}
+    />
   </div>
 
   {KINDS.map((kind) => (

--- a/site/src/components/Swatches.module.css
+++ b/site/src/components/Swatches.module.css
@@ -18,20 +18,11 @@
 /* ─── Segmented control ──────────────────────────────────────────────────
    Style for the documentation tone tabs (Colors). Surface is bg-block.
    (The Accessibility matrix controls are Anta <Tabs> — see AccessibilityMatrix.) */
+/* The tone nav is an Anta <Tabs> strip (the NavTabs island) that navigates on
+   pick; this wrapper only positions it (sticky page-nav below) and caps its
+   width. The strip's own chrome comes from <Tabs>. */
 .toneTabs {
-  display: inline-flex;
-  flex-wrap: nowrap;
-  align-items: stretch;
-  gap: 3px;
-  padding: 3px;
-  background: var(--bg-block);
-  border: 0.5px solid var(--border-4);
-  border-radius: 6px;
-  /* Cap at parent width so a long control list scrolls horizontally instead
-     of pushing the page wider than the content column. */
   max-width: 100%;
-  overflow-x: auto;
-  scrollbar-width: thin;
 }
 
 /* Tone tabs are also sticky page-nav, nudged in to the 960 prose left edge
@@ -61,51 +52,6 @@
 }
 .page .themeRows {
   max-width: none;
-}
-
-/* Items. Tone tabs are <a> (per-tone navigation) so the selector list strips
-   every facet of the global `<a>` styling across all link pseudos. */
-.toneTab,
-.toneTab:link,
-.toneTab:visited,
-.toneTab:hover,
-.toneTab:focus,
-.toneTab:active {
-  appearance: none;
-  border: none;
-  background: transparent;
-  font: inherit;
-  font-size: 0.8rem;
-  line-height: 1.2;
-  color: var(--text-3);
-  padding: 4px 8px 5px;
-  border-radius: 4px;
-  cursor: pointer;
-  text-decoration: none;
-  text-decoration-line: none;
-  text-decoration-color: transparent;
-  text-decoration-thickness: 0;
-  text-underline-offset: 0;
-  transition: background 150ms ease-out, color 150ms ease-out;
-}
-
-.toneTab:hover,
-.toneTab:focus {
-  color: var(--text-1);
-}
-
-/* Active state. The `:link` / `:visited` / `:hover` / `:focus` coverage keeps
-   the active styling winning over the base group at every link state (so the
-   active tab doesn't fall back to the inactive look on hover). */
-.toneTabActive,
-.toneTabActive:link,
-.toneTabActive:visited,
-.toneTabActive:hover,
-.toneTabActive:focus,
-.toneTabActive:active {
-  background: var(--bg-canvas);
-  color: var(--text-1);
-  box-shadow: 0 0 2px var(--border-3);
 }
 
 .block {

--- a/site/src/components/TabsDemo.tsx
+++ b/site/src/components/TabsDemo.tsx
@@ -265,7 +265,7 @@ export function OptionsTabs() {
       options={[
         { value: 'overview', label: 'Overview', icon: 'home' },
         { value: 'activity', label: 'Activity', icon: 'history' },
-        { value: 'settings', label: 'Settings', icon: 'list' },
+        { value: 'settings', label: 'Settings', icon: 'columns-3-cog' },
       ]}
     />
   )

--- a/site/src/components/a-toc.ts
+++ b/site/src/components/a-toc.ts
@@ -42,10 +42,13 @@ export class ATocElement extends HTMLElement {
   }
 
   connectedCallback() {
-    // Build after layout settles so all headings exist and have their ids.
-    const idle =
-      (window as any).requestIdleCallback ?? ((cb: () => void) => setTimeout(cb, 1))
-    idle(() => this.build())
+    // Build on the next frame, not requestIdleCallback: the headings (and their
+    // rehype-slug ids) are already in the server-rendered HTML by the time this
+    // upgrades, so waiting for idle only left the reserved-width rail blank for
+    // a beat after load. rAF runs after the current layout pass and before
+    // paint, so the TOC fills in right away; scroll positions self-correct on
+    // the scroll / resize listeners build() attaches.
+    requestAnimationFrame(() => this.build())
   }
 
   disconnectedCallback() {

--- a/site/src/pages/tabs.mdx
+++ b/site/src/pages/tabs.mdx
@@ -372,7 +372,7 @@ config or a `.map()`. `<TabPanel>` children still supply panel bodies (matched b
   options={[
     { value: 'overview', label: 'Overview', icon: 'home' },
     { value: 'activity', label: 'Activity', icon: 'history' },
-    { value: 'settings', label: 'Settings', icon: 'list' },
+    { value: 'settings', label: 'Settings', icon: 'columns-3-cog' },
   ]}
 />
 ```


### PR DESCRIPTION
Release prep for **0.3.3** (July 8, 2026), plus a few docs-site changes bundled in at request.

## Release (consumer-facing)
- `package.json`: `0.3.2` → `0.3.3`.
- `CHANGELOG.md`: promote `Unreleased` → `## 0.3.3 — July 8, 2026` (no content changes; Added / Fixed / Changed carry over — Fixed was already a single block).

## Docs site (not in the changelog — `anta.design` only)
- **Changelog + Colors navs → Anta `<Tabs>`.** Both hand-rolled tab-strip link navs replaced by a reusable `NavTabs` island: an Anta `<Tabs>` where each tab's `value` is its destination URL, controlled to the current page, navigating via JS on pick (`client:load`). Dogfoods Tabs; matches the documented "tabs that drive navigation" pattern.
- **"On this page" TOC appears right away.** `a-toc` built in `requestIdleCallback`, leaving the reserved-width (214px) rail blank for a beat; now builds on `requestAnimationFrame` so it fills in immediately (headings/ids are already in the SSR'd HTML). No layout shift; scroll positions self-correct.
- **Tabs data-driven demo icon** `list` → `columns-3-cog`.

### Remaining release steps (not in this PR)
- Tag `v0.3.3` if tagging.
- Publish anta (`npm publish` — confirm `latest` vs `dev` dist-tag; `prepublishOnly` rebuilds `dist`).
- Republish `@antadesign/stickers` afterward only if it should pin anta 0.3.3.

Note: the changelog/colors tabs are `client:load`, so navigation needs JS (the old `<a>` links worked without). And the tabs pattern emits `role="tablist"/tab` for what is page navigation — works, matches intent, flagging for awareness.