### PR TITLE
Add design-systems comparison page to docs site

### DIFF
--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -1,0 +1,125 @@
+---
+// At-a-glance matrix for the /comparison page: one row per system, columns
+// for the facts that decide adoption (shape, frameworks, styling, dark mode,
+// a11y, license). The Anta row is highlighted. Full-bleed + horizontal scroll
+// so the wide table never forces the page body to scroll sideways.
+import { SYSTEMS } from './comparison-data'
+---
+
+<div class="full-bleed matrix-scroll">
+  <table class="matrix">
+    <thead>
+      <tr>
+        <th scope="col" class="sys-col">System</th>
+        <th scope="col">Shape</th>
+        <th scope="col">Frameworks</th>
+        <th scope="col">Styling</th>
+        <th scope="col">Dark mode</th>
+        <th scope="col">Accessibility</th>
+        <th scope="col">License</th>
+      </tr>
+    </thead>
+    <tbody>
+      {SYSTEMS.map((s) => (
+        <tr class:list={[{ anta: s.anta }]}>
+          <th scope="row" class="sys-col">
+            <a href={s.docs} target="_blank" rel="noopener" class="sys-name">{s.name}</a>
+            <span class="sys-ver">{s.version}</span>
+          </th>
+          <td>{s.kind}</td>
+          <td>{s.frameworks}</td>
+          <td>{s.styling}</td>
+          <td>{s.dark}</td>
+          <td>{s.a11y}</td>
+          <td>{s.license}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .matrix-scroll {
+    overflow-x: auto;
+    margin-block: 24px;
+  }
+
+  .matrix {
+    border-collapse: separate;
+    border-spacing: 0;
+    width: 100%;
+    min-width: 860px;
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  .matrix th,
+  .matrix td {
+    text-align: left;
+    vertical-align: top;
+    padding: 10px 12px;
+    border-bottom: 1px solid var(--border-5);
+  }
+
+  .matrix thead th {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-base);
+    color: var(--text-3);
+    font-weight: 550;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    border-bottom: 1px solid var(--border-4);
+    white-space: nowrap;
+  }
+
+  /* First column: the system name + version. Sticky so it stays anchored
+     while the fact columns scroll horizontally. */
+  .sys-col {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: var(--bg-canvas);
+    min-width: 168px;
+  }
+  thead .sys-col {
+    z-index: 3;
+  }
+
+  .sys-name {
+    display: block;
+    font-weight: 550;
+    color: var(--text-1);
+    text-decoration: none;
+  }
+  .sys-name:hover {
+    text-decoration: underline;
+  }
+  .sys-ver {
+    display: block;
+    margin-top: 2px;
+    font-size: 11px;
+    color: var(--text-4);
+    font-family: var(--monospace, ui-monospace, monospace);
+  }
+
+  .matrix td {
+    color: var(--text-2);
+  }
+
+  /* Anta row: brand tint across the row, including the sticky name cell,
+     so it reads as the reference point the page is written around. */
+  .matrix tbody tr.anta th,
+  .matrix tbody tr.anta td {
+    background: var(--bg-5-brand);
+    border-bottom-color: var(--border-4-brand);
+  }
+  .matrix tbody tr.anta .sys-name {
+    color: var(--text-1-brand);
+  }
+  .matrix tbody tr.anta td {
+    color: var(--text-1);
+  }
+</style>

--- a/site/src/components/CoverageMatrix.astro
+++ b/site/src/components/CoverageMatrix.astro
@@ -1,0 +1,170 @@
+---
+// Component-coverage matrix: one row per grouped component category, one
+// column per system, so you can read across a row to see who ships a Table
+// or down the Anta column to see its shape. Marks are honest and grouped by
+// job (see comparison-data.ts). Anta's column is highlighted; the category
+// column and the header row are sticky so the wide grid stays legible while
+// it scrolls horizontally.
+import { SYSTEMS, CATEGORIES, COVERAGE, type Mark } from './comparison-data'
+
+const MARK: Record<Mark | 'none', { glyph: string; label: string; cls: string }> = {
+  yes: { glyph: '✓', label: 'Included', cls: 'm-yes' },
+  partial: { glyph: '~', label: 'Basic or community-only', cls: 'm-partial' },
+  paid: { glyph: '$', label: 'Paid / commercial tier', cls: 'm-paid' },
+  no: { glyph: '·', label: 'Not shipped', cls: 'm-no' },
+  none: { glyph: '·', label: 'Not shipped', cls: 'm-no' },
+}
+
+const cell = (systemId: string, catId: string) =>
+  MARK[COVERAGE[systemId]?.[catId] ?? 'none']
+---
+
+<div class="full-bleed cov-scroll">
+  <table class="cov">
+    <thead>
+      <tr>
+        <th scope="col" class="cat-col">Component</th>
+        {SYSTEMS.map((s) => (
+          <th scope="col" class:list={['sys-head', { anta: s.anta }]}>
+            <span class="sys-head-label">{s.name}</span>
+          </th>
+        ))}
+      </tr>
+    </thead>
+    <tbody>
+      {CATEGORIES.map((c) => (
+        <tr>
+          <th scope="row" class="cat-col">
+            <span class="cat-label">{c.label}</span>
+            <span class="cat-members">{c.members}</span>
+          </th>
+          {SYSTEMS.map((s) => {
+            const m = cell(s.id, c.id)
+            return (
+              <td class:list={['mark', m.cls, { anta: s.anta }]} title={`${s.name} — ${c.label}: ${m.label}`}>
+                <span aria-hidden="true">{m.glyph}</span>
+                <span class="sr-only">{m.label}</span>
+              </td>
+            )
+          })}
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+
+<p class="cov-legend">
+  <span><b class="m-yes">✓</b> included</span>
+  <span><b class="m-partial">~</b> basic / community-only</span>
+  <span><b class="m-paid">$</b> paid tier</span>
+  <span><b class="m-no">·</b> not shipped</span>
+</p>
+
+<style>
+  .cov-scroll {
+    overflow-x: auto;
+    margin-block: 24px 8px;
+  }
+
+  .cov {
+    border-collapse: separate;
+    border-spacing: 0;
+    font-size: 13px;
+  }
+
+  .cov th,
+  .cov td {
+    padding: 8px 10px;
+    border-bottom: 1px solid var(--border-5);
+    white-space: nowrap;
+  }
+
+  /* Header row: system names, sticky to the top on vertical scroll. */
+  .cov thead .sys-head {
+    position: sticky;
+    top: 0;
+    z-index: 2;
+    background: var(--bg-base);
+    color: var(--text-2);
+    font-weight: 550;
+    text-align: center;
+    border-bottom: 1px solid var(--border-4);
+    vertical-align: bottom;
+  }
+  .sys-head-label {
+    display: inline-block;
+    font-size: 12px;
+  }
+
+  /* First column: the grouped category, sticky to the left on horizontal
+     scroll. Label on top, grouped members underneath. */
+  .cat-col {
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    background: var(--bg-canvas);
+    text-align: left;
+    min-width: 150px;
+    white-space: normal;
+  }
+  thead .cat-col {
+    z-index: 3;
+    background: var(--bg-base);
+  }
+  .cat-label {
+    display: block;
+    font-weight: 500;
+    color: var(--text-1);
+  }
+  .cat-members {
+    display: block;
+    margin-top: 1px;
+    font-size: 11px;
+    color: var(--text-4);
+  }
+
+  /* Mark cells. */
+  .mark {
+    text-align: center;
+    font-weight: 600;
+    min-width: 40px;
+  }
+  .m-yes { color: var(--text-1-success); }
+  .m-partial { color: var(--text-2-warning); }
+  .m-paid { color: var(--text-2-info); }
+  .m-no { color: var(--text-5); font-weight: 400; }
+
+  /* Anta column highlight — header + every cell down the column. */
+  .cov thead .sys-head.anta {
+    color: var(--text-1-brand);
+    background: var(--bg-5-brand);
+  }
+  .cov td.mark.anta {
+    background: var(--bg-5-brand);
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  .cov-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    font-size: 12px;
+    color: var(--text-3);
+    margin-block: 4px 0;
+  }
+  .cov-legend b {
+    font-weight: 700;
+    margin-right: 3px;
+  }
+</style>

--- a/site/src/components/SystemCards.astro
+++ b/site/src/components/SystemCards.astro
@@ -17,13 +17,13 @@ import { SYSTEMS } from './comparison-data'
       <p class="card-tagline">{s.tagline}</p>
       <div class="card-cols">
         <div class="col-pros">
-          <h4>Strengths</h4>
+          <h4><a-icon shape="circle-check" class="head-icon"></a-icon>Strengths</h4>
           <ul>
             {s.pros.map((p) => <li>{p}</li>)}
           </ul>
         </div>
         <div class="col-cons">
-          <h4>Trade-offs</h4>
+          <h4><a-icon shape="help-disk" class="head-icon"></a-icon>Trade-offs</h4>
           <ul>
             {s.cons.map((c) => <li>{c}</li>)}
           </ul>
@@ -99,11 +99,20 @@ import { SYSTEMS } from './comparison-data'
   }
 
   .card-cols h4 {
+    display: flex;
+    align-items: center;
+    gap: 5px;
     margin: 0 0 8px;
     font-size: 12px;
     text-transform: uppercase;
     letter-spacing: 0.06em;
     color: var(--text-3);
+  }
+  /* a-icon draws with currentColor, so the heading's color tints the glyph.
+     Sized a touch above the 12px label so the mark reads clearly. */
+  .head-icon {
+    --icon-size: 15px;
+    flex-shrink: 0;
   }
   .col-pros h4 { color: var(--text-1-success); }
   .col-cons h4 { color: var(--text-2-warning); }

--- a/site/src/components/SystemCards.astro
+++ b/site/src/components/SystemCards.astro
@@ -1,0 +1,139 @@
+---
+// Per-system pros/cons cards for the /comparison page. One card per system,
+// each with its name (linked to docs), version, one-line identity, and honest
+// pro/con columns. Anta's card leads and carries a brand accent.
+import { SYSTEMS } from './comparison-data'
+---
+
+<div class="cards">
+  {SYSTEMS.map((s) => (
+    <section class:list={['card', { anta: s.anta }]}>
+      <header class="card-head">
+        <h3 class="card-name" id={`sys-${s.id}`}>
+          <a href={s.docs} target="_blank" rel="noopener">{s.name}</a>
+        </h3>
+        <span class="card-ver">{s.version}</span>
+      </header>
+      <p class="card-tagline">{s.tagline}</p>
+      <div class="card-cols">
+        <div class="col-pros">
+          <h4>Strengths</h4>
+          <ul>
+            {s.pros.map((p) => <li>{p}</li>)}
+          </ul>
+        </div>
+        <div class="col-cons">
+          <h4>Trade-offs</h4>
+          <ul>
+            {s.cons.map((c) => <li>{c}</li>)}
+          </ul>
+        </div>
+      </div>
+    </section>
+  ))}
+</div>
+
+<style>
+  .cards {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    margin-block: 24px;
+  }
+
+  .card {
+    border: 1px solid var(--border-5);
+    border-radius: 10px;
+    padding: 20px 22px;
+    background: var(--bg-canvas);
+  }
+  .card.anta {
+    border-color: var(--border-3-brand);
+    background: var(--bg-5-brand);
+  }
+
+  .card-head {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 8px 12px;
+  }
+  .card-name {
+    margin: 0;
+    font-size: 18px;
+    line-height: 1.2;
+  }
+  .card-name a {
+    color: var(--text-1);
+    text-decoration: none;
+  }
+  .card.anta .card-name a {
+    color: var(--text-1-brand);
+  }
+  .card-name a:hover {
+    text-decoration: underline;
+  }
+  .card-ver {
+    font-size: 12px;
+    color: var(--text-4);
+    font-family: var(--monospace, ui-monospace, monospace);
+  }
+
+  .card-tagline {
+    margin: 8px 0 16px;
+    color: var(--text-2);
+    font-size: 14px;
+    line-height: 1.5;
+    max-width: 68ch;
+  }
+
+  .card-cols {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px 32px;
+  }
+  @container (max-width: 640px) {
+    .card-cols {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .card-cols h4 {
+    margin: 0 0 8px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--text-3);
+  }
+  .col-pros h4 { color: var(--text-1-success); }
+  .col-cons h4 { color: var(--text-2-warning); }
+
+  .card-cols ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 7px;
+  }
+  .card-cols li {
+    position: relative;
+    padding-left: 18px;
+    font-size: 13.5px;
+    line-height: 1.5;
+    color: var(--text-2);
+  }
+  .card-cols li::before {
+    position: absolute;
+    left: 0;
+    font-weight: 700;
+  }
+  .col-pros li::before {
+    content: '+';
+    color: var(--text-1-success);
+  }
+  .col-cons li::before {
+    content: '−';
+    color: var(--text-2-warning);
+  }
+</style>

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -4,7 +4,7 @@
  * cards, so the numbers can't drift between sections.
  *
  * Versions are a snapshot verified against npm / official docs in July 2026
- * (see `AS_OF`). They date quickly — re-check before quoting them elsewhere.
+ * (see `AS_OF`). They date quickly; re-check before quoting them elsewhere.
  * Coverage marks describe *shipped* components, grouping variants that cover
  * one job into a single cell (a Dialog / Modal / Drawer family is one mark).
  * Marks are honest, not generous: `partial` means "basic or community-only",
@@ -19,7 +19,7 @@ export interface System {
   /** Short key, also the coverage-column id. */
   id: string
   name: string
-  /** True for Anta — drives the highlight styling in both matrices. */
+  /** True for Anta; drives the highlight styling in both matrices. */
   anta?: boolean
   /** Package + version string, e.g. "@mui/material 9.2.0". */
   version: string
@@ -45,7 +45,7 @@ export interface System {
 
 /** Anta first (highlighted), then the framework-agnostic web-component peers,
  *  the batteries-included React libraries, the headless React primitives, and
- *  the copy-paste model — roughly grouped by how close they sit to Anta. */
+ *  the copy-paste model, roughly grouped by how close they sit to Anta. */
 export const SYSTEMS: System[] = [
   {
     id: 'anta',
@@ -56,23 +56,23 @@ export const SYSTEMS: System[] = [
     tagline:
       'Framework-agnostic web components with thin React/Preact wrappers, a tiny CSS-variable token set, and no style or animation runtime.',
     kind: 'Styled web components + JSX wrappers',
-    frameworks: 'Any — React, Preact, plain HTML',
+    frameworks: 'Any: React, Preact, plain HTML',
     styling: 'Plain CSS + CSS-variable tokens (oklch)',
     dark: '.dark ancestor class',
     a11y: 'ARIA layered in wrappers; solid',
     license: 'MIT',
     pros: [
-      'Framework-agnostic web components run in React, Preact, or plain HTML — the JSX wrappers are a thin, optional convenience.',
+      'Web components run in React, Preact, or plain HTML; the JSX wrappers are a thin, optional convenience.',
       'Declarative DOM: components never mutate their own host attributes, so they render correctly from a Worker thread or any reactive engine.',
-      'No style runtime and no animation runtime ship to consumers — styling is plain CSS in a single @layer, trivially overridable.',
-      'Deliberately tiny token vocabulary (color roles for text / background / border, plus fonts and one focus ring); everything else is a per-component CSS variable.',
-      'oklch color model throughout, so tone tuning stays perceptually stable and dark mode falls out of the same tokens.',
-      'Granular per-element imports keep bundles lean; the only animation dependency (Lottie) is isolated in the separate stickers package.',
+      'No style runtime and no animation runtime ship to consumers. Styling is plain CSS in a single @layer that any consumer rule overrides.',
+      'The token set is small: color roles for text, background, and border, plus fonts and one focus ring. Everything else is a per-component CSS variable.',
+      'oklch color throughout, so tone tuning stays perceptually stable and dark mode falls out of the same tokens.',
+      'Granular per-element imports keep bundles lean; the one animation dependency, Lottie, stays in the separate stickers package.',
     ],
     cons: [
-      'Young and small: ~17 components, no modal/dialog, toast, slider, combobox, avatar, or data grid yet.',
-      'One organization, early version (0.x) — smaller ecosystem, community, and real-world track record than the incumbents.',
-      'Table and Select are intentionally simple, not the rich data-grid / async-combobox found in enterprise kits.',
+      'Young and small: ~17 components, with no modal, toast, slider, combobox, avatar, or data grid yet.',
+      'One organization at an early version (0.x), so a smaller ecosystem, community, and track record than the incumbents.',
+      'Table and Select stay intentionally simple, short of the data grid or async combobox in enterprise kits.',
       'No first-party charts or form-management layer.',
     ],
   },
@@ -82,24 +82,24 @@ export const SYSTEMS: System[] = [
     version: 'webawesome 3.10.0 (beta)',
     docs: 'https://webawesome.com',
     tagline:
-      "Font Awesome's framework-agnostic web components and CSS framework — the commercial successor to Shoelace.",
+      "Font Awesome's framework-agnostic web components and CSS framework, the commercial successor to Shoelace.",
     kind: 'Styled web components',
-    frameworks: 'Any — web components (React/Vue/Angular/Svelte guides)',
+    frameworks: 'Any: web components (React/Vue/Angular/Svelte guides)',
     styling: 'CSS framework + ::part() + CSS variables',
     dark: 'Built-in light/dark themes',
     a11y: 'Good (inherited from Shoelace)',
     license: 'MIT core + paid Pro tier',
     pros: [
-      'True framework-agnostic web components that work in any stack or plain HTML.',
-      'Rich CSS-variable + ::part() theming plus a full utility/layout CSS framework.',
-      'Very broad component set and excellent Font Awesome icon integration.',
+      'Framework-agnostic web components that work in any stack or plain HTML.',
+      'CSS-variable and ::part() theming, plus a utility and layout CSS framework.',
+      'A broad component set and Font Awesome icon integration.',
       'Backed by an established company with commercial funding.',
     ],
     cons: [
-      'Freemium — combobox, date/file inputs, toasts, charts, and video are paid Pro components.',
-      'Still in beta, so API churn is a real risk.',
-      'Built on Lit, so it ships a runtime dependency and leans heavily on shadow DOM (SSR/hydration and form-association caveats).',
-      'Not oriented around Worker-thread / declarative-DOM rendering.',
+      'Freemium: combobox, date/file inputs, toasts, charts, and video are paid Pro components.',
+      'Still in beta, so API churn is a risk.',
+      'Built on Lit, so it ships a runtime dependency and leans on shadow DOM (SSR/hydration and form-association caveats).',
+      'Not oriented around Worker-thread or declarative-DOM rendering.',
     ],
   },
   {
@@ -110,22 +110,22 @@ export const SYSTEMS: System[] = [
     tagline:
       "Shopify's system for apps that must look native inside Shopify Admin, now shipped as CDN-delivered web components.",
     kind: 'Styled web components (CDN)',
-    frameworks: 'Any — web components',
+    frameworks: 'Any: web components',
     styling: 'Locked to the Shopify look',
     dark: 'Automatic (adopts host surface)',
     a11y: 'Strong; dev-time a11y warnings',
     license: 'Restricted (Shopify apps only)',
     pros: [
-      'Genuinely framework-agnostic web components — a rare modern first-party example.',
+      'Framework-agnostic web components, a rare modern first-party example.',
       'Zero-build CDN delivery, always up to date, small footprint.',
       'Pixel-consistent, native integration with Shopify surfaces.',
-      'Solid built-in accessibility with helpful developer warnings.',
+      'Built-in accessibility with developer warnings for missing a11y props.',
     ],
     cons: [
-      'Restrictive license: effectively only for building apps that interoperate with Shopify, not a general-purpose kit.',
-      'Deliberately not customizable — you cannot make it match your own brand.',
-      "CDN “always latest” model means components aren't version-pinned (only the types are).",
-      'Narrow component set aimed at Shopify app UIs; still churning post React→WC migration.',
+      'Restrictive license: usable mainly for apps that interoperate with Shopify, not a general-purpose kit.',
+      "Not customizable by design, so you can't make it match your own brand.",
+      "CDN “always latest” model, so components aren't version-pinned; only the types are.",
+      'Narrow component set aimed at Shopify app UIs; still churning after the React→WC migration.',
     ],
   },
   {
@@ -142,16 +142,16 @@ export const SYSTEMS: System[] = [
     a11y: 'Mature, generally strong',
     license: 'MIT core + paid MUI X',
     pros: [
-      'Huge component surface out of the box, plus MUI X for the hard ones (data grid, charts, pickers).',
-      'Enormous ecosystem, documentation, themes, and hiring pool.',
-      'Batteries-included theming with a deep, opinionated theme object.',
-      'v9 is moving to CSS variables + color-mix() and a Tailwind/Pigment path.',
+      'A large component surface out of the box, plus MUI X for data grid, charts, and pickers.',
+      'A large ecosystem, documentation, themes, and hiring pool.',
+      'Batteries-included theming with a deep theme object.',
+      'CSS-variable theming and color-mix() color, with Pigment CSS as the zero-runtime path.',
     ],
     cons: [
-      'Heavy bundle and CSS-in-JS runtime cost (the whole Pigment migration exists to fix this).',
-      'Strongly opinionated Material look is hard to fully escape.',
+      'Heavy bundle and CSS-in-JS runtime cost; the Pigment migration exists to reduce it.',
+      'The Material look is opinionated and hard to fully escape.',
       'The theme-override API has a steep learning curve; major-version migrations are frequent.',
-      'React-only, and advanced components are paywalled behind MUI X Pro/Premium.',
+      'React-only, and advanced components sit behind paid MUI X Pro/Premium.',
     ],
   },
   {
@@ -160,23 +160,23 @@ export const SYSTEMS: System[] = [
     version: 'antd 6.5.0',
     docs: 'https://ant.design',
     tagline:
-      'An enterprise-class React library, especially strong for data-dense admin and dashboard UIs.',
+      'An enterprise-class React library, strong for data-dense admin and dashboard UIs.',
     kind: 'Styled React components',
     frameworks: 'React (Angular/Vue community ports)',
     styling: 'CSS-in-JS + CSS variables (v6)',
     dark: 'darkAlgorithm token preset',
-    a11y: 'Weak — no a11y docs',
+    a11y: 'Weak; no a11y docs',
     license: 'MIT',
     pros: [
-      'One of the richest component libraries anywhere, with heavy-duty Table, Form, Transfer, and Cascader.',
-      'Excellent for enterprise/admin/data-heavy apps out of the box.',
-      'Powerful token/theme algorithm system with easy dark and compact modes.',
-      'Mature ecosystem (Pro components, charts, huge community) and first-class TypeScript.',
+      'One of the largest component libraries, with heavy-duty Table, Form, Transfer, and Cascader.',
+      'Strong for enterprise, admin, and data-heavy apps out of the box.',
+      'A token/theme algorithm system with dark and compact modes.',
+      'A mature ecosystem (Pro components, charts, large community) and first-class TypeScript.',
     ],
     cons: [
-      'Accessibility is a real weakness — no a11y docs, inconsistent keyboard and screen-reader support.',
-      'Bundle-size concerns; CSS-in-JS runtime historically added SSR overhead.',
-      'Strong, distinctive "antd look" is harder to fully rebrand.',
+      'Accessibility is a weak point: no a11y docs, inconsistent keyboard and screen-reader support.',
+      'Bundle-size concerns; the CSS-in-JS runtime historically added SSR overhead.',
+      'The antd look is distinctive and harder to fully rebrand.',
       'React-only; other frameworks are separate community projects.',
     ],
   },
@@ -186,7 +186,7 @@ export const SYSTEMS: System[] = [
     version: '@mantine/core 9.4.1',
     docs: 'https://mantine.dev',
     tagline:
-      'A full-featured React library with a large hooks package and official form/date/chart add-ons.',
+      'A React library with a large hooks package and official form, date, and chart add-ons.',
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'CSS Modules + CSS variables',
@@ -194,16 +194,16 @@ export const SYSTEMS: System[] = [
     a11y: 'Good (varies by component)',
     license: 'MIT',
     pros: [
-      'Very broad coverage out of the box — forms, dates, charts, notifications, rich text all official.',
-      'Excellent TypeScript DX and documentation.',
-      'Modern styling (CSS Modules + CSS variables) with strong theming and built-in dark mode.',
-      'Extensive @mantine/hooks utility library usable standalone.',
+      'Broad coverage out of the box: forms, dates, charts, notifications, and rich text are all official.',
+      'Strong TypeScript DX and documentation.',
+      'CSS Modules and CSS variables for styling, with theming and built-in dark mode.',
+      'The @mantine/hooks utility library is usable standalone.',
     ],
     cons: [
-      'React-only — no path to other frameworks or plain HTML.',
-      'Larger footprint than minimal or headless libraries.',
-      'A history of large breaking majors (v6→v7 rewrote styling; v9 forces React 19.2+).',
-      'Not headless — deep visual divergence can mean fighting the Styles API.',
+      'React-only, with no path to other frameworks or plain HTML.',
+      'A larger footprint than minimal or headless libraries.',
+      'A history of large breaking majors: v6→v7 rewrote styling, v9 forces React 19.2+.',
+      'Not headless, so deep visual divergence can mean fighting the Styles API.',
     ],
   },
   {
@@ -212,7 +212,7 @@ export const SYSTEMS: System[] = [
     version: '@carbon/react 1.110.0',
     docs: 'https://carbondesignsystem.com',
     tagline:
-      "IBM's enterprise-grade design system, with a first-party web-components package alongside React.",
+      "IBM's enterprise design system, with a first-party web-components package alongside React.",
     kind: 'Styled React (+ web components)',
     frameworks: 'React, web components; Angular/Vue/Svelte (community)',
     styling: 'Sass + CSS variables',
@@ -220,22 +220,22 @@ export const SYSTEMS: System[] = [
     a11y: 'Strong (IBM Equal Access program)',
     license: 'Apache-2.0',
     pros: [
-      'Enterprise-hardened, with deep data-table and app-shell components most systems lack.',
-      'Serious, well-resourced accessibility program (WCAG 2.1 AA).',
-      'Real multi-framework story, including a first-party Lit web-components package.',
-      'Comprehensive token system and Figma parity.',
+      'Hardened for enterprise, with data-table and app-shell components most systems lack.',
+      'A well-resourced accessibility program targeting WCAG 2.1 AA.',
+      'A multi-framework story, including a first-party Lit web-components package.',
+      'A token system with Figma parity.',
     ],
     cons: [
-      'Heavy and strongly IBM-branded; retheming away from the "IBM look" is nontrivial.',
-      'Sass build pipeline adds friction versus plain-CSS/CDN systems.',
-      'Large surface area and monorepo package sprawl; steep learning curve.',
-      'Non-React frameworks are community-maintained and version-lagging.',
+      'Heavy and strongly IBM-branded; retheming away from the IBM look takes work.',
+      'The Sass build pipeline adds friction versus plain-CSS or CDN systems.',
+      'A large surface area and monorepo package sprawl; steep learning curve.',
+      'Non-React frameworks are community-maintained and lag on versions.',
     ],
   },
   {
     id: 'atlassian',
     name: 'Atlassian (Atlaskit)',
-    version: '@atlaskit/* — tokens 13.0.4',
+    version: '@atlaskit/* tokens 13.0.4',
     docs: 'https://atlassian.design',
     tagline:
       'The system behind Jira, Confluence, and Trello, published as many independently versioned @atlaskit packages.',
@@ -246,14 +246,14 @@ export const SYSTEMS: System[] = [
     a11y: 'Strong (WCAG 2.1 AA)',
     license: 'Apache-2.0',
     pros: [
-      "Proven at massive scale in Atlassian's flagship products.",
-      'Mature token + theming system with a distinctive elevation model and solid dark mode.',
-      'Build-time Compiled CSS-in-JS gives near-zero style runtime.',
-      'Serious accessibility investment and first-class TypeScript.',
+      "Proven at scale in Atlassian's products.",
+      'A token and theming system with an elevation model and dark mode.',
+      'Build-time Compiled CSS-in-JS keeps the style runtime near zero.',
+      'Accessibility investment (WCAG 2.1 AA) and first-class TypeScript.',
     ],
     cons: [
-      'React-only — no web-component or multi-framework path.',
-      'Per-package versioning creates real dependency-alignment overhead.',
+      'React-only, with no web-component or multi-framework path.',
+      'Per-package versioning creates dependency-alignment overhead.',
       'Strongly Atlassian-branded; docs assume an Atlassian context.',
       'Compiled CSS-in-JS needs a specific Babel/SWC build setup.',
     ],
@@ -264,7 +264,7 @@ export const SYSTEMS: System[] = [
     version: '@blueprintjs/core 6.17.0',
     docs: 'https://blueprintjs.com',
     tagline:
-      "Palantir's React toolkit optimized for complex, data-dense desktop web interfaces.",
+      "Palantir's React toolkit for complex, data-dense desktop web interfaces.",
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'Sass-compiled CSS (bp6- classes)',
@@ -272,14 +272,14 @@ export const SYSTEMS: System[] = [
     a11y: 'Good for desktop/keyboard',
     license: 'Apache-2.0',
     pros: [
-      'Best-in-class for dense professional desktop apps — dashboards, tooling, data grids.',
-      'Strong, high-performance virtualized Table and rich Select/Omnibar/date components.',
-      'Battle-tested at Palantir scale; stable, deliberate releases.',
+      'Built for dense professional desktop apps: dashboards, tooling, and data grids.',
+      'A high-performance virtualized Table and Select/Omnibar/date components.',
+      'Battle-tested at Palantir scale, with deliberate releases.',
       'Thorough docs and consistent keyboard behavior.',
     ],
     cons: [
-      'React-only and explicitly desktop-first — weak fit for mobile/touch.',
-      'Opinionated Palantir look; heavier to restyle than token-first systems.',
+      'React-only and desktop-first, a weak fit for mobile or touch.',
+      'The Palantir look is opinionated and heavier to restyle than token-first systems.',
       'Ships global-ish compiled CSS with bp6- prefixes.',
       'Some overlay/ARIA edge cases have historically needed workarounds.',
     ],
@@ -298,16 +298,16 @@ export const SYSTEMS: System[] = [
     a11y: 'Claimed accessible (unaudited)',
     license: 'MIT',
     pros: [
-      'Backed by Meta; reportedly matured internally for years before open-sourcing.',
-      'Very large claimed component set with a coherent token-level theming model and ready themes.',
+      'Backed by Meta, reportedly matured internally for years before open-sourcing.',
+      'A large claimed component set with a token-level theming model and ready themes.',
       'StyleX scales CSS size well; consumers get precompiled CSS with no required build step.',
-      'Explicitly designed to be agent/AI-operable via a CLI — a genuinely different angle.',
+      'Designed to be agent/AI-operable via a CLI, a different angle.',
     ],
     cons: [
-      'Very new and beta (0.1.x) — API stability and real-world track record are unproven.',
-      'React-only, with internals coupled to StyleX (a Meta-specific toolchain).',
+      'New and beta (0.1.x), so API stability and track record are unproven.',
+      'React-only, with internals coupled to StyleX, a Meta-specific toolchain.',
       'Accessibility and component-count claims are largely self-reported so far.',
-      'Small public footprint; longevity outside Meta is uncertain.',
+      'A small public footprint; longevity outside Meta is uncertain.',
     ],
   },
   {
@@ -316,23 +316,23 @@ export const SYSTEMS: System[] = [
     version: 'radix-ui 1.6.2',
     docs: 'https://www.radix-ui.com/primitives',
     tagline:
-      'The reference-quality unstyled React primitives — behavior and accessibility only, you bring the CSS.',
+      'The reference unstyled React primitives: behavior and accessibility only, you bring the CSS.',
     kind: 'Headless React primitives',
     frameworks: 'React',
-    styling: 'Unstyled — bring your own',
+    styling: 'Unstyled; bring your own',
     dark: 'Bring your own (Themes adds one)',
     a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
-      'Best-in-class accessibility and interaction behavior — the de-facto reference.',
-      'Completely style-agnostic; never fights your design.',
-      'Granular per-primitive installs and excellent composition (asChild, data-* state).',
-      'The foundation under shadcn and countless design systems.',
+      'Accessibility and interaction behavior that other libraries treat as the reference.',
+      'Style-agnostic, so it never fights your design.',
+      'Granular per-primitive installs and composition (asChild, data-* state).',
+      'The foundation under shadcn and many other design systems.',
     ],
     cons: [
-      'Ships zero visuals — significant styling work before anything looks usable.',
+      'Ships no visuals, so there is styling work before anything looks usable.',
       'React-only.',
-      'Smaller component set than batteries-included libraries (no table, limited pickers).',
+      'A smaller component set than batteries-included libraries (no table, limited pickers).',
       'The Primitives-vs-Themes split can confuse newcomers.',
     ],
   },
@@ -345,20 +345,20 @@ export const SYSTEMS: System[] = [
       'A second-generation unstyled React library from the people behind Radix, Floating UI, and MUI.',
     kind: 'Headless React primitives',
     frameworks: 'React',
-    styling: 'Unstyled — bring your own',
+    styling: 'Unstyled; bring your own',
     dark: 'Bring your own',
     a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
       'Headless accessibility from the people who wrote Radix and Floating UI, with cleaner APIs.',
-      'Richer built-in components than early Radix (Combobox, Autocomplete, Number Field).',
-      'Strong MUI backing with a stated long-term maintenance commitment.',
-      'Excellent tree-shaking, no CSS baggage.',
+      'More built-in components than early Radix (Combobox, Autocomplete, Number Field).',
+      'MUI backing with a stated long-term maintenance commitment.',
+      'Tree-shaking with no CSS baggage.',
     ],
     cons: [
-      'Very young — 1.0 landed February 2026, so a smaller track record and ecosystem.',
+      'Young: 1.0 landed February 2026, so a smaller track record and ecosystem.',
       'React-only.',
-      'Unstyled: you build all the visuals, same cost as Radix.',
+      'Unstyled, so you build all the visuals, the same cost as Radix.',
       'A 1.0 package rename (@base-ui-components/react → @base-ui/react) is a live migration papercut.',
     ],
   },
@@ -368,7 +368,7 @@ export const SYSTEMS: System[] = [
     version: 'shadcn CLI 4.13.0',
     docs: 'https://ui.shadcn.com',
     tagline:
-      'Not an installed library but a copy-paste collection of Tailwind-styled components you own in your own repo.',
+      'A copy-paste collection of Tailwind-styled components you own in your repo, added by CLI rather than installed as a dependency.',
     kind: 'Copy-paste React source',
     frameworks: 'React (Vue/Svelte community ports)',
     styling: 'Tailwind + CSS variables (oklch)',
@@ -376,15 +376,15 @@ export const SYSTEMS: System[] = [
     a11y: 'Inherits Radix / Base UI',
     license: 'MIT',
     pros: [
-      'Total ownership — no black-box dependency, edit anything.',
-      'Excellent CLI and DX; rides Radix/Base UI accessibility for free.',
-      'Huge momentum and ecosystem (themes, blocks, community registries).',
+      'Total ownership: no black-box dependency, edit anything.',
+      'A CLI-driven workflow that rides Radix/Base UI accessibility for free.',
+      'Momentum and ecosystem (themes, blocks, community registries).',
       'No version-lock upgrade treadmill for the component code.',
     ],
     cons: [
-      'Hard requirement on Tailwind — not usable as-is without it.',
-      'No automatic upgrades; you manually re-sync when upstream improves.',
-      'Code sprawl — dozens of files copied into your repo, consistency is your problem.',
+      'Hard requirement on Tailwind, so not usable as-is without it.',
+      'No automatic upgrades; you re-sync manually when upstream improves.',
+      'Code sprawl: dozens of files copied into your repo, and consistency is your problem.',
       'Not a portable dependency you can pin and share; React-first.',
     ],
   },
@@ -427,7 +427,7 @@ export const CATEGORIES: Category[] = [
 
 /**
  * Coverage marks per system, keyed by category id. Absent keys default to
- * 'no'. Honest, grouped-by-job marks — see the module header. `partial` =
+ * 'no'. Honest, grouped-by-job marks; see the module header. `partial` =
  * basic, simple, or community-only; `paid` = behind a commercial tier.
  * headless primitives (Radix, Base UI) get marks only where they ship an
  * actual primitive, so their empty cells reflect "you build the visual".
@@ -448,16 +448,17 @@ export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
   },
   polaris: {
     button: 'yes', textinput: 'yes', select: 'yes', choice: 'yes',
-    datetime: 'yes', menu: 'yes', tooltip: 'yes', dialog: 'partial',
-    toast: 'partial', table: 'yes', tag: 'yes', progress: 'partial',
-    avatar: 'yes', card: 'yes', icons: 'yes', typography: 'yes',
+    datetime: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes',
+    dialog: 'partial', toast: 'partial', table: 'yes', tag: 'yes',
+    progress: 'partial', avatar: 'yes', card: 'yes', icons: 'yes',
+    typography: 'yes',
   },
   mui: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
-    choice: 'yes', slider: 'yes', datetime: 'paid', tabs: 'yes', menu: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
     tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
     table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
-    nav: 'yes', icons: 'yes', typography: 'yes', charts: 'paid',
+    nav: 'yes', icons: 'yes', typography: 'yes', charts: 'yes',
   },
   antd: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -1,0 +1,522 @@
+/**
+ * Data behind the /comparison page. One source of truth for the two
+ * matrices (at-a-glance + component coverage) and the per-system pros/cons
+ * cards, so the numbers can't drift between sections.
+ *
+ * Versions are a snapshot verified against npm / official docs in July 2026
+ * (see `AS_OF`). They date quickly — re-check before quoting them elsewhere.
+ * Coverage marks describe *shipped* components, grouping variants that cover
+ * one job into a single cell (a Dialog / Modal / Drawer family is one mark).
+ * Marks are honest, not generous: `partial` means "basic or community-only",
+ * not "counts if you squint".
+ */
+
+export const AS_OF = 'July 2026'
+
+export type Mark = 'yes' | 'partial' | 'no' | 'paid'
+
+export interface System {
+  /** Short key, also the coverage-column id. */
+  id: string
+  name: string
+  /** True for Anta — drives the highlight styling in both matrices. */
+  anta?: boolean
+  /** Package + version string, e.g. "@mui/material 9.2.0". */
+  version: string
+  /** Canonical docs URL. */
+  docs: string
+  /** One-line identity. */
+  tagline: string
+  /** Distribution / shape, e.g. "Styled web components + JSX wrappers". */
+  kind: string
+  /** Which frameworks it targets. */
+  frameworks: string
+  /** Styling mechanism. */
+  styling: string
+  /** Dark-mode story, short. */
+  dark: string
+  /** Accessibility reputation, short. */
+  a11y: string
+  /** License, short. */
+  license: string
+  pros: string[]
+  cons: string[]
+}
+
+/** Anta first (highlighted), then the framework-agnostic web-component peers,
+ *  the batteries-included React libraries, the headless React primitives, and
+ *  the copy-paste model — roughly grouped by how close they sit to Anta. */
+export const SYSTEMS: System[] = [
+  {
+    id: 'anta',
+    name: 'Anta',
+    anta: true,
+    version: '@antadesign/anta 0.3.3',
+    docs: 'https://anta.design',
+    tagline:
+      'Framework-agnostic web components with thin React/Preact wrappers, a tiny CSS-variable token set, and no style or animation runtime.',
+    kind: 'Styled web components + JSX wrappers',
+    frameworks: 'Any — React, Preact, plain HTML',
+    styling: 'Plain CSS + CSS-variable tokens (oklch)',
+    dark: '.dark ancestor class',
+    a11y: 'ARIA layered in wrappers; solid',
+    license: 'MIT',
+    pros: [
+      'Framework-agnostic web components run in React, Preact, or plain HTML — the JSX wrappers are a thin, optional convenience.',
+      'Declarative DOM: components never mutate their own host attributes, so they render correctly from a Worker thread or any reactive engine.',
+      'No style runtime and no animation runtime ship to consumers — styling is plain CSS in a single @layer, trivially overridable.',
+      'Deliberately tiny token vocabulary (color roles for text / background / border, plus fonts and one focus ring); everything else is a per-component CSS variable.',
+      'oklch color model throughout, so tone tuning stays perceptually stable and dark mode falls out of the same tokens.',
+      'Granular per-element imports keep bundles lean; the only animation dependency (Lottie) is isolated in the separate stickers package.',
+    ],
+    cons: [
+      'Young and small: ~17 components, no modal/dialog, toast, slider, combobox, avatar, or data grid yet.',
+      'One organization, early version (0.x) — smaller ecosystem, community, and real-world track record than the incumbents.',
+      'Table and Select are intentionally simple, not the rich data-grid / async-combobox found in enterprise kits.',
+      'No first-party charts or form-management layer.',
+    ],
+  },
+  {
+    id: 'webawesome',
+    name: 'Web Awesome',
+    version: 'webawesome 3.10.0 (beta)',
+    docs: 'https://webawesome.com',
+    tagline:
+      "Font Awesome's framework-agnostic web components and CSS framework — the commercial successor to Shoelace.",
+    kind: 'Styled web components',
+    frameworks: 'Any — web components (React/Vue/Angular/Svelte guides)',
+    styling: 'CSS framework + ::part() + CSS variables',
+    dark: 'Built-in light/dark themes',
+    a11y: 'Good (inherited from Shoelace)',
+    license: 'MIT core + paid Pro tier',
+    pros: [
+      'True framework-agnostic web components that work in any stack or plain HTML.',
+      'Rich CSS-variable + ::part() theming plus a full utility/layout CSS framework.',
+      'Very broad component set and excellent Font Awesome icon integration.',
+      'Backed by an established company with commercial funding.',
+    ],
+    cons: [
+      'Freemium — combobox, date/file inputs, toasts, charts, and video are paid Pro components.',
+      'Still in beta, so API churn is a real risk.',
+      'Built on Lit, so it ships a runtime dependency and leans heavily on shadow DOM (SSR/hydration and form-association caveats).',
+      'Not oriented around Worker-thread / declarative-DOM rendering.',
+    ],
+  },
+  {
+    id: 'polaris',
+    name: 'Shopify Polaris',
+    version: 'Polaris web components 2026-01',
+    docs: 'https://shopify.dev/docs/api/app-home/web-components',
+    tagline:
+      "Shopify's system for apps that must look native inside Shopify Admin, now shipped as CDN-delivered web components.",
+    kind: 'Styled web components (CDN)',
+    frameworks: 'Any — web components',
+    styling: 'Locked to the Shopify look',
+    dark: 'Automatic (adopts host surface)',
+    a11y: 'Strong; dev-time a11y warnings',
+    license: 'Restricted (Shopify apps only)',
+    pros: [
+      'Genuinely framework-agnostic web components — a rare modern first-party example.',
+      'Zero-build CDN delivery, always up to date, small footprint.',
+      'Pixel-consistent, native integration with Shopify surfaces.',
+      'Solid built-in accessibility with helpful developer warnings.',
+    ],
+    cons: [
+      'Restrictive license: effectively only for building apps that interoperate with Shopify, not a general-purpose kit.',
+      'Deliberately not customizable — you cannot make it match your own brand.',
+      "CDN “always latest” model means components aren't version-pinned (only the types are).",
+      'Narrow component set aimed at Shopify app UIs; still churning post React→WC migration.',
+    ],
+  },
+  {
+    id: 'mui',
+    name: 'MUI (Material UI)',
+    version: '@mui/material 9.2.0',
+    docs: 'https://mui.com/material-ui/',
+    tagline:
+      "The dominant React implementation of Google's Material Design, with a deep theming system.",
+    kind: 'Styled React components',
+    frameworks: 'React',
+    styling: 'CSS-in-JS (Emotion, moving to Pigment)',
+    dark: 'Color schemes / palette.mode',
+    a11y: 'Mature, generally strong',
+    license: 'MIT core + paid MUI X',
+    pros: [
+      'Huge component surface out of the box, plus MUI X for the hard ones (data grid, charts, pickers).',
+      'Enormous ecosystem, documentation, themes, and hiring pool.',
+      'Batteries-included theming with a deep, opinionated theme object.',
+      'v9 is moving to CSS variables + color-mix() and a Tailwind/Pigment path.',
+    ],
+    cons: [
+      'Heavy bundle and CSS-in-JS runtime cost (the whole Pigment migration exists to fix this).',
+      'Strongly opinionated Material look is hard to fully escape.',
+      'The theme-override API has a steep learning curve; major-version migrations are frequent.',
+      'React-only, and advanced components are paywalled behind MUI X Pro/Premium.',
+    ],
+  },
+  {
+    id: 'antd',
+    name: 'Ant Design',
+    version: 'antd 6.5.0',
+    docs: 'https://ant.design',
+    tagline:
+      'An enterprise-class React library, especially strong for data-dense admin and dashboard UIs.',
+    kind: 'Styled React components',
+    frameworks: 'React (Angular/Vue community ports)',
+    styling: 'CSS-in-JS + CSS variables (v6)',
+    dark: 'darkAlgorithm token preset',
+    a11y: 'Weak — no a11y docs',
+    license: 'MIT',
+    pros: [
+      'One of the richest component libraries anywhere, with heavy-duty Table, Form, Transfer, and Cascader.',
+      'Excellent for enterprise/admin/data-heavy apps out of the box.',
+      'Powerful token/theme algorithm system with easy dark and compact modes.',
+      'Mature ecosystem (Pro components, charts, huge community) and first-class TypeScript.',
+    ],
+    cons: [
+      'Accessibility is a real weakness — no a11y docs, inconsistent keyboard and screen-reader support.',
+      'Bundle-size concerns; CSS-in-JS runtime historically added SSR overhead.',
+      'Strong, distinctive "antd look" is harder to fully rebrand.',
+      'React-only; other frameworks are separate community projects.',
+    ],
+  },
+  {
+    id: 'mantine',
+    name: 'Mantine',
+    version: '@mantine/core 9.4.1',
+    docs: 'https://mantine.dev',
+    tagline:
+      'A full-featured React library with a large hooks package and official form/date/chart add-ons.',
+    kind: 'Styled React components',
+    frameworks: 'React',
+    styling: 'CSS Modules + CSS variables',
+    dark: 'Built-in light/dark/auto',
+    a11y: 'Good (varies by component)',
+    license: 'MIT',
+    pros: [
+      'Very broad coverage out of the box — forms, dates, charts, notifications, rich text all official.',
+      'Excellent TypeScript DX and documentation.',
+      'Modern styling (CSS Modules + CSS variables) with strong theming and built-in dark mode.',
+      'Extensive @mantine/hooks utility library usable standalone.',
+    ],
+    cons: [
+      'React-only — no path to other frameworks or plain HTML.',
+      'Larger footprint than minimal or headless libraries.',
+      'A history of large breaking majors (v6→v7 rewrote styling; v9 forces React 19.2+).',
+      'Not headless — deep visual divergence can mean fighting the Styles API.',
+    ],
+  },
+  {
+    id: 'carbon',
+    name: 'Carbon',
+    version: '@carbon/react 1.110.0',
+    docs: 'https://carbondesignsystem.com',
+    tagline:
+      "IBM's enterprise-grade design system, with a first-party web-components package alongside React.",
+    kind: 'Styled React (+ web components)',
+    frameworks: 'React, web components; Angular/Vue/Svelte (community)',
+    styling: 'Sass + CSS variables',
+    dark: 'Four built-in themes',
+    a11y: 'Strong (IBM Equal Access program)',
+    license: 'Apache-2.0',
+    pros: [
+      'Enterprise-hardened, with deep data-table and app-shell components most systems lack.',
+      'Serious, well-resourced accessibility program (WCAG 2.1 AA).',
+      'Real multi-framework story, including a first-party Lit web-components package.',
+      'Comprehensive token system and Figma parity.',
+    ],
+    cons: [
+      'Heavy and strongly IBM-branded; retheming away from the "IBM look" is nontrivial.',
+      'Sass build pipeline adds friction versus plain-CSS/CDN systems.',
+      'Large surface area and monorepo package sprawl; steep learning curve.',
+      'Non-React frameworks are community-maintained and version-lagging.',
+    ],
+  },
+  {
+    id: 'atlassian',
+    name: 'Atlassian (Atlaskit)',
+    version: '@atlaskit/* — tokens 13.0.4',
+    docs: 'https://atlassian.design',
+    tagline:
+      'The system behind Jira, Confluence, and Trello, published as many independently versioned @atlaskit packages.',
+    kind: 'Styled React components',
+    frameworks: 'React',
+    styling: 'Compiled CSS-in-JS + tokens',
+    dark: 'Token themes (light/dark)',
+    a11y: 'Strong (WCAG 2.1 AA)',
+    license: 'Apache-2.0',
+    pros: [
+      "Proven at massive scale in Atlassian's flagship products.",
+      'Mature token + theming system with a distinctive elevation model and solid dark mode.',
+      'Build-time Compiled CSS-in-JS gives near-zero style runtime.',
+      'Serious accessibility investment and first-class TypeScript.',
+    ],
+    cons: [
+      'React-only — no web-component or multi-framework path.',
+      'Per-package versioning creates real dependency-alignment overhead.',
+      'Strongly Atlassian-branded; docs assume an Atlassian context.',
+      'Compiled CSS-in-JS needs a specific Babel/SWC build setup.',
+    ],
+  },
+  {
+    id: 'blueprint',
+    name: 'Blueprint',
+    version: '@blueprintjs/core 6.17.0',
+    docs: 'https://blueprintjs.com',
+    tagline:
+      "Palantir's React toolkit optimized for complex, data-dense desktop web interfaces.",
+    kind: 'Styled React components',
+    frameworks: 'React',
+    styling: 'Sass-compiled CSS (bp6- classes)',
+    dark: '.bp6-dark container class',
+    a11y: 'Good for desktop/keyboard',
+    license: 'Apache-2.0',
+    pros: [
+      'Best-in-class for dense professional desktop apps — dashboards, tooling, data grids.',
+      'Strong, high-performance virtualized Table and rich Select/Omnibar/date components.',
+      'Battle-tested at Palantir scale; stable, deliberate releases.',
+      'Thorough docs and consistent keyboard behavior.',
+    ],
+    cons: [
+      'React-only and explicitly desktop-first — weak fit for mobile/touch.',
+      'Opinionated Palantir look; heavier to restyle than token-first systems.',
+      'Ships global-ish compiled CSS with bp6- prefixes.',
+      'Some overlay/ARIA edge cases have historically needed workarounds.',
+    ],
+  },
+  {
+    id: 'astryx',
+    name: 'Astryx',
+    version: '@astryxdesign/core 0.1.4 (beta)',
+    docs: 'https://astryx.atmeta.com',
+    tagline:
+      "Meta's new, AI-fluent design system: precompiled CSS and typed React components built on StyleX.",
+    kind: 'Styled React components',
+    frameworks: 'React',
+    styling: 'StyleX (precompiled atomic CSS)',
+    dark: 'Installable theme packages',
+    a11y: 'Claimed accessible (unaudited)',
+    license: 'MIT',
+    pros: [
+      'Backed by Meta; reportedly matured internally for years before open-sourcing.',
+      'Very large claimed component set with a coherent token-level theming model and ready themes.',
+      'StyleX scales CSS size well; consumers get precompiled CSS with no required build step.',
+      'Explicitly designed to be agent/AI-operable via a CLI — a genuinely different angle.',
+    ],
+    cons: [
+      'Very new and beta (0.1.x) — API stability and real-world track record are unproven.',
+      'React-only, with internals coupled to StyleX (a Meta-specific toolchain).',
+      'Accessibility and component-count claims are largely self-reported so far.',
+      'Small public footprint; longevity outside Meta is uncertain.',
+    ],
+  },
+  {
+    id: 'radix',
+    name: 'Radix UI',
+    version: 'radix-ui 1.6.2',
+    docs: 'https://www.radix-ui.com/primitives',
+    tagline:
+      'The reference-quality unstyled React primitives — behavior and accessibility only, you bring the CSS.',
+    kind: 'Headless React primitives',
+    frameworks: 'React',
+    styling: 'Unstyled — bring your own',
+    dark: 'Bring your own (Themes adds one)',
+    a11y: 'Reference-grade (WAI-ARIA APG)',
+    license: 'MIT',
+    pros: [
+      'Best-in-class accessibility and interaction behavior — the de-facto reference.',
+      'Completely style-agnostic; never fights your design.',
+      'Granular per-primitive installs and excellent composition (asChild, data-* state).',
+      'The foundation under shadcn and countless design systems.',
+    ],
+    cons: [
+      'Ships zero visuals — significant styling work before anything looks usable.',
+      'React-only.',
+      'Smaller component set than batteries-included libraries (no table, limited pickers).',
+      'The Primitives-vs-Themes split can confuse newcomers.',
+    ],
+  },
+  {
+    id: 'baseui',
+    name: 'Base UI',
+    version: '@base-ui/react 1.6.0',
+    docs: 'https://base-ui.com',
+    tagline:
+      'A second-generation unstyled React library from the people behind Radix, Floating UI, and MUI.',
+    kind: 'Headless React primitives',
+    frameworks: 'React',
+    styling: 'Unstyled — bring your own',
+    dark: 'Bring your own',
+    a11y: 'Reference-grade (WAI-ARIA APG)',
+    license: 'MIT',
+    pros: [
+      'Headless accessibility from the people who wrote Radix and Floating UI, with cleaner APIs.',
+      'Richer built-in components than early Radix (Combobox, Autocomplete, Number Field).',
+      'Strong MUI backing with a stated long-term maintenance commitment.',
+      'Excellent tree-shaking, no CSS baggage.',
+    ],
+    cons: [
+      'Very young — 1.0 landed February 2026, so a smaller track record and ecosystem.',
+      'React-only.',
+      'Unstyled: you build all the visuals, same cost as Radix.',
+      'A 1.0 package rename (@base-ui-components/react → @base-ui/react) is a live migration papercut.',
+    ],
+  },
+  {
+    id: 'shadcn',
+    name: 'shadcn/ui',
+    version: 'shadcn CLI 4.13.0',
+    docs: 'https://ui.shadcn.com',
+    tagline:
+      'Not an installed library but a copy-paste collection of Tailwind-styled components you own in your own repo.',
+    kind: 'Copy-paste React source',
+    frameworks: 'React (Vue/Svelte community ports)',
+    styling: 'Tailwind + CSS variables (oklch)',
+    dark: '.dark class (next-themes)',
+    a11y: 'Inherits Radix / Base UI',
+    license: 'MIT',
+    pros: [
+      'Total ownership — no black-box dependency, edit anything.',
+      'Excellent CLI and DX; rides Radix/Base UI accessibility for free.',
+      'Huge momentum and ecosystem (themes, blocks, community registries).',
+      'No version-lock upgrade treadmill for the component code.',
+    ],
+    cons: [
+      'Hard requirement on Tailwind — not usable as-is without it.',
+      'No automatic upgrades; you manually re-sync when upstream improves.',
+      'Code sprawl — dozens of files copied into your repo, consistency is your problem.',
+      'Not a portable dependency you can pin and share; React-first.',
+    ],
+  },
+]
+
+/** Component-coverage categories. Grouped by job, so a Dialog / Modal / Drawer
+ *  family is one row. Order roughly follows a typical app's control set. */
+export interface Category {
+  id: string
+  label: string
+  /** The grouped members, shown as the row's sub-label. */
+  members: string
+}
+
+export const CATEGORIES: Category[] = [
+  { id: 'button', label: 'Button', members: 'Button, icon button, group' },
+  { id: 'textinput', label: 'Text input', members: 'Text, number, password, textarea' },
+  { id: 'select', label: 'Select', members: 'Single/multi dropdown select' },
+  { id: 'combobox', label: 'Combobox', members: 'Autocomplete, searchable select' },
+  { id: 'choice', label: 'Checkbox / Radio / Switch', members: 'Toggles and choice groups' },
+  { id: 'slider', label: 'Slider', members: 'Range / value slider' },
+  { id: 'datetime', label: 'Date & time', members: 'Calendar, date/time picker' },
+  { id: 'tabs', label: 'Tabs', members: 'Tab strip + panels' },
+  { id: 'menu', label: 'Menu', members: 'Dropdown, context, menubar' },
+  { id: 'tooltip', label: 'Tooltip / Popover', members: 'Hover + click surfaces' },
+  { id: 'dialog', label: 'Dialog', members: 'Modal, drawer, sheet' },
+  { id: 'toast', label: 'Notification', members: 'Toast, banner, inline alert' },
+  { id: 'accordion', label: 'Accordion', members: 'Collapse / expander / disclosure' },
+  { id: 'table', label: 'Table', members: 'Table / data grid' },
+  { id: 'tag', label: 'Tag / Badge', members: 'Tag, badge, chip, lozenge' },
+  { id: 'progress', label: 'Progress', members: 'Bar, spinner, skeleton' },
+  { id: 'avatar', label: 'Avatar', members: 'Avatar / avatar group' },
+  { id: 'card', label: 'Card', members: 'Card / tile / surface' },
+  { id: 'nav', label: 'Nav helpers', members: 'Breadcrumb, pagination, steps' },
+  { id: 'icons', label: 'Icons', members: 'Bundled icon set' },
+  { id: 'typography', label: 'Typography', members: 'Text / title components' },
+  { id: 'charts', label: 'Charts', members: 'First-party data viz' },
+  { id: 'motion', label: 'Animated art', members: 'Stickers / illustrations' },
+]
+
+/**
+ * Coverage marks per system, keyed by category id. Absent keys default to
+ * 'no'. Honest, grouped-by-job marks — see the module header. `partial` =
+ * basic, simple, or community-only; `paid` = behind a commercial tier.
+ * headless primitives (Radix, Base UI) get marks only where they ship an
+ * actual primitive, so their empty cells reflect "you build the visual".
+ */
+export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
+  anta: {
+    button: 'yes', textinput: 'yes', select: 'yes', choice: 'partial',
+    datetime: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes',
+    accordion: 'yes', table: 'partial', tag: 'yes', progress: 'partial',
+    icons: 'yes', typography: 'yes', motion: 'yes',
+  },
+  webawesome: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'paid',
+    choice: 'yes', slider: 'yes', datetime: 'paid', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'paid', accordion: 'yes',
+    tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes', nav: 'partial',
+    icons: 'yes', typography: 'partial', charts: 'paid', motion: 'partial',
+  },
+  polaris: {
+    button: 'yes', textinput: 'yes', select: 'yes', choice: 'yes',
+    datetime: 'yes', menu: 'yes', tooltip: 'yes', dialog: 'partial',
+    toast: 'partial', table: 'yes', tag: 'yes', progress: 'partial',
+    avatar: 'yes', card: 'yes', icons: 'yes', typography: 'yes',
+  },
+  mui: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'paid', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
+    nav: 'yes', icons: 'yes', typography: 'yes', charts: 'paid',
+  },
+  antd: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
+    nav: 'yes', icons: 'yes', typography: 'yes', charts: 'partial',
+  },
+  mantine: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'partial', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
+    nav: 'yes', icons: 'partial', typography: 'yes', charts: 'yes',
+  },
+  carbon: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'partial', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', card: 'yes', nav: 'yes',
+    icons: 'yes', typography: 'partial', charts: 'yes',
+  },
+  atlassian: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'partial',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', table: 'yes', tag: 'yes',
+    progress: 'yes', avatar: 'yes', card: 'partial', nav: 'yes',
+    icons: 'yes', typography: 'partial',
+  },
+  blueprint: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', card: 'yes', nav: 'yes',
+    icons: 'yes', typography: 'partial',
+  },
+  astryx: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
+    nav: 'yes', icons: 'yes', typography: 'yes',
+  },
+  radix: {
+    select: 'yes', combobox: 'no', choice: 'yes', slider: 'yes', tabs: 'yes',
+    menu: 'yes', tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    progress: 'yes', avatar: 'yes', nav: 'partial',
+  },
+  baseui: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes',
+    dialog: 'yes', toast: 'yes', accordion: 'yes', progress: 'yes',
+    avatar: 'yes', nav: 'partial',
+  },
+  shadcn: {
+    button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
+    choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes',
+    nav: 'yes', icons: 'partial', charts: 'yes',
+  },
+}

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -93,7 +93,14 @@ if (isComponentPage && title) {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {/* viewport-fit=cover so the layout spans the whole screen on notched /
+        Dynamic-Island iPhones. Without it, Safari letterboxes the page in
+        landscape — insetting the content away from the notch and painting the
+        margins with the page background, so the UI looks like it doesn't use
+        the full width. `env(safe-area-inset-*)` padding on `.layout` keeps
+        content clear of the notch; the insets are 0 everywhere else, so this
+        is a no-op on non-notched screens. */}
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={pageUrl} />
@@ -449,6 +456,12 @@ if (isComponentPage && title) {
        scroll container, so the sticky sidebar's vertical stickiness is
        unaffected; opened panels translate back into the viewport and show. */
     overflow-x: clip;
+    /* Inset the shell out of the display's safe area. Paired with
+       viewport-fit=cover (see the head meta), this fills the whole screen on
+       notched / Dynamic-Island iPhones while keeping the sidebar and content
+       clear of the side notch in landscape. The insets are 0 on every
+       non-notched screen, so it changes nothing elsewhere. */
+    padding-inline: env(safe-area-inset-left) env(safe-area-inset-right);
   }
 
   .sidebar {

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -232,6 +232,7 @@ if (isComponentPage && title) {
           <li><a href="/colors/" aria-current={isCurrent('/colors/') ? 'page' : undefined}><Icon shape="swatch-book" size={18} /> Colors</a></li>
           <li><a href="/normalization/" aria-current={isCurrent('/normalization/') ? 'page' : undefined}><Icon shape="book-a" size={18} /> Normalization</a></li>
           <li><a href="/accessibility/" aria-current={isCurrent('/accessibility/') ? 'page' : undefined}><Icon shape="hat-glasses" size={18} /> Accessibility</a></li>
+          <li><a href="/comparison/" aria-current={isCurrent('/comparison/') ? 'page' : undefined}><Icon shape="table-2" size={18} /> Comparison</a></li>
           <li><a href="/changelog/" aria-current={isCurrent('/changelog/') ? 'page' : undefined}><Icon shape="scroll-text" size={18} /> Changelog</a></li>
           <li><a href="/credits/" aria-current={isCurrent('/credits/') ? 'page' : undefined}><Icon shape="heart-handshake" size={18} /> Credits</a></li>
         </menu>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -441,6 +441,14 @@ if (isComponentPage && title) {
   .layout {
     display: flex;
     min-height: 100vh;
+    /* Clip horizontal overflow so the off-canvas slide-out panels (the nav
+       sidebar ≤640px and the TOC rail ≤1024px, both fixed + translated past
+       the right edge when closed) can't create a pannable region. Without it
+       a wide page — the comparison matrices in landscape especially — scrolls
+       sideways into empty space. `clip` (not `hidden`) doesn't establish a
+       scroll container, so the sticky sidebar's vertical stickiness is
+       unaffected; opened panels translate back into the viewport and show. */
+    overflow-x: clip;
   }
 
   .sidebar {

--- a/site/src/pages/comparison.mdx
+++ b/site/src/pages/comparison.mdx
@@ -12,9 +12,9 @@ import { AS_OF } from '../components/comparison-data'
 
 How Anta relates to the design systems it takes cues from. This page is written
 from Anta's point of view, so it says plainly where Anta is smaller or younger
-than the incumbents — a comparison that only flattered would not be useful.
+than the incumbents. A comparison that only flattered wouldn't be useful.
 
-Every system here solves a real problem well. They cluster into a few shapes:
+Every system here is a serious tool. They cluster into a few shapes:
 **styled React libraries** you install and theme (MUI, Ant Design, Mantine,
 Carbon, Atlaskit, Blueprint, Astryx), **headless React primitives** you style
 yourself (Radix, Base UI), a **copy-paste-and-own** model (shadcn/ui), and
@@ -29,32 +29,31 @@ system's link for the current release.
 
 <ComparisonMatrix />
 
-The row that sets Anta apart is **Shape** and **Styling**. Most systems here are
-React-only and reach for a styling engine — CSS-in-JS (MUI, Ant Design,
+The rows that set Anta apart are **Shape** and **Styling**. Most systems here are
+React-only and reach for a styling engine: CSS-in-JS (MUI, Ant Design,
 Atlaskit), Sass (Carbon, Blueprint), StyleX (Astryx), or Tailwind (shadcn). Anta
 ships framework-agnostic web components styled with plain CSS in a single
-`@layer`, so there is no style runtime to load and any consumer rule overrides a
-default without a specificity fight. The two other web-component systems are the
-closest cousins: Polaris is locked to the Shopify look under a restricted
-license, and Web Awesome bundles a Lit runtime with a paid tier.
+`@layer`, so there's no style runtime to load and any consumer rule overrides a
+default without a specificity fight. The two other web-component systems sit
+closest: Polaris is locked to the Shopify look under a restricted license, and
+Web Awesome bundles a Lit runtime with a paid tier.
 
 ## What Anta adds
 
-A few things in the table are Anta-specific enough to spell out.
+A few of these are Anta-specific enough to spell out.
 
 - **Runs anywhere, including a Worker.** The web components never mutate their
-  own host attributes; internal state changes stay inside shadow DOM. That
-  keeps them in sync when the UI is driven from a Worker thread or a non-React
-  reactive engine — the constraint Anta was built around — and it means the
-  React and Preact wrappers are a thin convenience, not a requirement.
+  own host attributes; internal state changes stay inside shadow DOM. That keeps
+  them in sync when the UI is driven from a Worker thread or a non-React reactive
+  engine. Anta was built around that constraint, so the React and Preact wrappers
+  stay a thin convenience.
 - **No style runtime, no animation runtime.** Nothing ships to parse styles at
   runtime. The one animation dependency, Lottie, lives in the separate
   `@antadesign/stickers` package, so the core carries no animation engine.
-- **A deliberately tiny token set.** The only global tokens are color *roles* —
-  text, background, and border, each with tones that already pair light and
-  dark — plus fonts and a single focus ring. Everything else is a
-  per-component CSS variable with a literal value, kept local on purpose so
-  each part stays independently tunable.
+- **A tiny token set.** The only global tokens are color roles for text,
+  background, and border, each with tones that pair light and dark, plus fonts
+  and a single focus ring. Everything else is a per-component CSS variable with a
+  literal value, kept local so each part stays independently tunable.
 - **oklch color throughout.** Tone tuning and alpha happen in oklch via
   `color-mix`, so lightness and hue stay perceptually stable. The wider drift
   toward CSS variables and `color-mix()` (MUI v9) and oklch tokens (shadcn)
@@ -66,15 +65,15 @@ Grouped by job, so a Dialog / Modal / Drawer family counts as one row. This is
 the honest view of Anta's size: it covers the common controls but is younger and
 narrower than the batteries-included kits, with no dialog, toast, slider,
 combobox, avatar, or data grid yet. The headless primitives (Radix, Base UI)
-leave most cells to you by design — they ship behavior, not a finished look.
+leave most cells to you by design; they ship behavior and leave the look to you.
 
 <CoverageMatrix />
 
-Two rows are worth reading closely. Anta's **Table** and **Select** are marked
-basic on purpose — they are not the async data grid or virtualized combobox that
-enterprise kits like Ant Design, Carbon, and Blueprint are known for. And
-**Animated art** is Anta's alone here: the stickers package ships Lottie-backed
-`<a-sticker>` elements, a piece none of the general-purpose systems carry.
+Anta's **Table** and **Select** are marked basic on purpose: they aren't the
+async data grid or virtualized combobox that enterprise kits like Ant Design,
+Carbon, and Blueprint are known for. **Animated art** is Anta's alone here: the
+stickers package ships Lottie-backed `<a-sticker>` elements, a piece none of the
+general-purpose systems carry.
 
 ## The systems
 
@@ -84,17 +83,17 @@ Honest strengths and trade-offs for each, Anta first.
 
 ## Choosing between them
 
-- **Building a React app and want everything now** — Ant Design or Mantine for
+- **Building a React app and want everything now.** Ant Design or Mantine for
   breadth, MUI for ecosystem and hiring, Carbon or Atlaskit for enterprise
   rigor, Blueprint for dense desktop tools.
-- **You want full control of the markup and styling** — Radix or Base UI for
+- **You want full control of the markup and styling.** Radix or Base UI for
   headless primitives, shadcn/ui if you'd rather own the code outright (and
   already use Tailwind).
-- **You need components outside React — plain HTML, Preact, or multiple
-  frameworks** — a web-component system: Web Awesome for breadth (mind the paid
-  tier), Polaris only inside Shopify, and **Anta** when you want an open,
-  plainly-styled, runtime-free set with a tiny token surface — especially if any
-  of your UI renders off the main thread.
+- **You need components outside React, in plain HTML, Preact, or several
+  frameworks.** A web-component system: Web Awesome for breadth (mind the paid
+  tier), Polaris only inside Shopify, and **Anta** for an open, plainly-styled,
+  runtime-free set with a tiny token surface, especially when some of your UI
+  renders off the main thread.
 
 Anta is the youngest and smallest system on this page. It is the right pick when
 its constraints are yours: framework portability, a declarative worker-safe DOM,

--- a/site/src/pages/comparison.mdx
+++ b/site/src/pages/comparison.mdx
@@ -1,0 +1,103 @@
+---
+layout: ../layouts/DocsLayout.astro
+title: Comparison
+---
+
+import ComparisonMatrix from '../components/ComparisonMatrix.astro'
+import CoverageMatrix from '../components/CoverageMatrix.astro'
+import SystemCards from '../components/SystemCards.astro'
+import { AS_OF } from '../components/comparison-data'
+
+# Comparison
+
+How Anta relates to the design systems it takes cues from. This page is written
+from Anta's point of view, so it says plainly where Anta is smaller or younger
+than the incumbents — a comparison that only flattered would not be useful.
+
+Every system here solves a real problem well. They cluster into a few shapes:
+**styled React libraries** you install and theme (MUI, Ant Design, Mantine,
+Carbon, Atlaskit, Blueprint, Astryx), **headless React primitives** you style
+yourself (Radix, Base UI), a **copy-paste-and-own** model (shadcn/ui), and
+**framework-agnostic web components** (Web Awesome, Shopify Polaris, and Anta).
+Anta sits in that last group, with an extra constraint the others don't carry:
+its DOM is declarative enough to render from a Worker thread.
+
+Versions are a snapshot verified in {AS_OF} and move quickly; follow each
+system's link for the current release.
+
+## At a glance
+
+<ComparisonMatrix />
+
+The row that sets Anta apart is **Shape** and **Styling**. Most systems here are
+React-only and reach for a styling engine — CSS-in-JS (MUI, Ant Design,
+Atlaskit), Sass (Carbon, Blueprint), StyleX (Astryx), or Tailwind (shadcn). Anta
+ships framework-agnostic web components styled with plain CSS in a single
+`@layer`, so there is no style runtime to load and any consumer rule overrides a
+default without a specificity fight. The two other web-component systems are the
+closest cousins: Polaris is locked to the Shopify look under a restricted
+license, and Web Awesome bundles a Lit runtime with a paid tier.
+
+## What Anta adds
+
+A few things in the table are Anta-specific enough to spell out.
+
+- **Runs anywhere, including a Worker.** The web components never mutate their
+  own host attributes; internal state changes stay inside shadow DOM. That
+  keeps them in sync when the UI is driven from a Worker thread or a non-React
+  reactive engine — the constraint Anta was built around — and it means the
+  React and Preact wrappers are a thin convenience, not a requirement.
+- **No style runtime, no animation runtime.** Nothing ships to parse styles at
+  runtime. The one animation dependency, Lottie, lives in the separate
+  `@antadesign/stickers` package, so the core carries no animation engine.
+- **A deliberately tiny token set.** The only global tokens are color *roles* —
+  text, background, and border, each with tones that already pair light and
+  dark — plus fonts and a single focus ring. Everything else is a
+  per-component CSS variable with a literal value, kept local on purpose so
+  each part stays independently tunable.
+- **oklch color throughout.** Tone tuning and alpha happen in oklch via
+  `color-mix`, so lightness and hue stay perceptually stable. The wider drift
+  toward CSS variables and `color-mix()` (MUI v9) and oklch tokens (shadcn)
+  lands where Anta already is.
+
+## Component coverage
+
+Grouped by job, so a Dialog / Modal / Drawer family counts as one row. This is
+the honest view of Anta's size: it covers the common controls but is younger and
+narrower than the batteries-included kits, with no dialog, toast, slider,
+combobox, avatar, or data grid yet. The headless primitives (Radix, Base UI)
+leave most cells to you by design — they ship behavior, not a finished look.
+
+<CoverageMatrix />
+
+Two rows are worth reading closely. Anta's **Table** and **Select** are marked
+basic on purpose — they are not the async data grid or virtualized combobox that
+enterprise kits like Ant Design, Carbon, and Blueprint are known for. And
+**Animated art** is Anta's alone here: the stickers package ships Lottie-backed
+`<a-sticker>` elements, a piece none of the general-purpose systems carry.
+
+## The systems
+
+Honest strengths and trade-offs for each, Anta first.
+
+<SystemCards />
+
+## Choosing between them
+
+- **Building a React app and want everything now** — Ant Design or Mantine for
+  breadth, MUI for ecosystem and hiring, Carbon or Atlaskit for enterprise
+  rigor, Blueprint for dense desktop tools.
+- **You want full control of the markup and styling** — Radix or Base UI for
+  headless primitives, shadcn/ui if you'd rather own the code outright (and
+  already use Tailwind).
+- **You need components outside React — plain HTML, Preact, or multiple
+  frameworks** — a web-component system: Web Awesome for breadth (mind the paid
+  tier), Polaris only inside Shopify, and **Anta** when you want an open,
+  plainly-styled, runtime-free set with a tiny token surface — especially if any
+  of your UI renders off the main thread.
+
+Anta is the youngest and smallest system on this page. It is the right pick when
+its constraints are yours: framework portability, a declarative worker-safe DOM,
+no styling runtime, and a color model tuned in oklch. When you need a data grid,
+a date-range picker, or a decade of ecosystem tomorrow, one of the incumbents
+above will serve you better today.


### PR DESCRIPTION
## What

A new **`/comparison`** page on the docs site that positions Anta against the design systems referenced in `CLAUDE.md`: MUI (Material UI), shadcn/ui, Radix UI, Base UI, Carbon, Shopify Polaris, Ant Design, Atlassian (Atlaskit), Mantine, Blueprint, Web Awesome, and Astryx.

It's written from Anta's point of view but stays honest — it says plainly where Anta is smaller or younger than the incumbents (no dialog, toast, slider, combobox, avatar, or data grid yet; Table and Select are intentionally basic).

## Sections

- **At a glance** — one row per system with version, docs link, shape, frameworks, styling, dark mode, accessibility, and license. Anta's row is highlighted.
- **What Anta adds** — worker-safe declarative DOM, no style/animation runtime, a deliberately tiny token set, and oklch color.
- **Component coverage** — a matrix grouped by job (e.g. Dialog / Modal / Drawer is one cell). Anta's column is highlighted; marks are `✓` included, `~` basic/community-only, `$` paid tier, `·` not shipped. "Animated art" (stickers) is Anta's alone here.
- **The systems** — per-system strengths and trade-offs, Anta first.
- **Choosing between them** — a short honest guide to when each system (including Anta) is the right pick.

## Implementation

- `site/src/components/comparison-data.ts` — single source of truth for all facts, so the matrices and cards can't drift. Versions are a snapshot **verified against npm / official docs in July 2026** and flagged as such on the page.
- `ComparisonMatrix.astro`, `CoverageMatrix.astro`, `SystemCards.astro` — static Astro renderers (no hydration), with sticky headers/first-column and horizontal scroll so the wide tables never scroll the page body sideways.
- `comparison.mdx` — the page.
- Sidebar nav link added in `DocsLayout.astro` (not registered as a component page).

## Verification

- `pnpm --filter anta-site build` passes; the page renders 13 systems across all three sections.
- `pnpm --filter anta-site lint:css` passes.
- Spot-checked rendering in both light and dark themes.

Preview the page at `/comparison/` once the branch deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HYx9WMkti513xX9yUAScUA

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYx9WMkti513xX9yUAScUA)_