### PR TITLE
fix(checkbox): align hint colour with radio

### DIFF
--- a/site/src/pages/checkbox.mdx
+++ b/site/src/pages/checkbox.mdx
@@ -84,7 +84,7 @@ to tint the whole control.
   <Checkbox className="toned-text" defaultChecked tone="critical" hint="Deletes everything">Critical</Checkbox>
   <style is:inline>{`
     a-checkbox.toned-text { color: var(--text-1-critical); }
-    a-checkbox.toned-text a-checkbox-hint { color: var(--text-4-critical); }
+    a-checkbox.toned-text a-checkbox-hint { color: var(--text-3-critical); }
   `}</style>
 </Preview>
 
@@ -93,7 +93,7 @@ to tint the whole control.
    colour, the hint is targeted directly. The class is just for the demo — swap
    your own selector. */
 a-checkbox.toned-text { color: var(--text-1-critical); }
-a-checkbox.toned-text a-checkbox-hint { color: var(--text-4-critical); }
+a-checkbox.toned-text a-checkbox-hint { color: var(--text-3-critical); }
 ```
 
 ## Size

--- a/src/elements/a-checkbox.css
+++ b/src/elements/a-checkbox.css
@@ -36,7 +36,9 @@
 
     --checkbox-label-color: var(--text-2);
     --checkbox-label-color-disabled: var(--text-4);
-    --checkbox-hint-color: var(--text-4);
+    /* Hint uses --text-3 to match <a-radio>'s hint (one step less muted than the
+       disabled label). */
+    --checkbox-hint-color: var(--text-3);
 
     /* Type scales with `size` (like <a-radio>): label tracks the body size, hint
        a step down. Tokens so the size variants set them in one place. */


### PR DESCRIPTION
## What

The secondary **hint** line under a `Checkbox` label was one step more muted than `Radio`'s. This aligns them.

| | Before | After |
|---|---|---|
| **Checkbox** hint | `--text-4` | `--text-3` |
| **Radio** hint | `--text-3` | `--text-3` (unchanged) |
| Labels (`--text-2`) | — | unchanged |

<img width="739" height="86" alt="img-1" src="https://github.com/user-attachments/assets/ea0c8b74-1cc0-439f-93c6-f39ee168a345" />


## Scope

Pure **consistency** fix. **Radio was already correct** (`--text-3`) — nothing in radio changed. All we do is move the checkbox neutral hint to `--text-3` so the two controls read identically.

> Rebased onto latest `main`: PR #85 (checkbox/radio recolour + top-alignment) had already removed the old `toneText` hint variants, so this branch reduces to the single neutral-hint line. Marks top-align to the label's first line (from #85) and tones colour only the mark — the hint stays neutral, so this token is the only hint-colour left to align.

<img width="750" height="1003" alt="img-2" src="https://github.com/user-attachments/assets/80155f2c-e401-466a-9a93-c8f845055bf7" />


## Files
- `src/elements/a-checkbox.css` — `--checkbox-hint-color: var(--text-4)` → `var(--text-3)`
- `site/src/pages/checkbox.mdx` — updated the presentation example on the site so it matches the implementation: its recolour demo's hint now uses `--text-3-critical` (docs-site only, nothing recoloured — just the demo tracking the component).

## Visual reference
Checkbox vs radio, neutral + toned marks + a tinted-text section, label + hint, light & dark:
https://claude.ai/code/artifact/28b955a2-70b0-4836-9706-d87d396a42d5

🤖 Generated with [Claude Code](https://claude.com/claude-code)