### PR TITLE
Remove Dark mode column from comparison

### DIFF
--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -99,7 +99,8 @@ import { SYSTEMS } from './comparison-data'
     display: block;
     margin-top: 2px;
     font-size: 11px;
-    color: var(--text-4);
+    font-weight: 400;
+    color: var(--text-3);
     font-family: var(--monospace, ui-monospace, monospace);
   }
 

--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -26,7 +26,10 @@ import { SYSTEMS } from './comparison-data'
             <span class="sys-ver">{s.version}</span>
           </th>
           <td>{s.kind}</td>
-          <td>{s.frameworks}</td>
+          <td>
+            {s.frameworks}
+            {s.frameworksNote && <span class="fw-note">({s.frameworksNote})</span>}
+          </td>
           <td>{s.styling}</td>
           <td>{s.a11y}</td>
           <td>{s.license}</td>
@@ -106,6 +109,14 @@ import { SYSTEMS } from './comparison-data'
 
   .matrix td {
     color: var(--text-2);
+  }
+
+  /* Secondary framework reach on its own muted line under the primary. */
+  .fw-note {
+    display: block;
+    margin-top: 2px;
+    color: var(--text-4);
+    font-size: 12px;
   }
 
   /* Anta row: brand tint across the row, including the sticky name cell,

--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -1,7 +1,7 @@
 ---
 // At-a-glance matrix for the /comparison page: one row per system, columns
-// for the facts that decide adoption (shape, frameworks, styling, dark mode,
-// a11y, license). The Anta row is highlighted. Full-bleed + horizontal scroll
+// for the facts that decide adoption (shape, frameworks, styling, a11y,
+// license). The Anta row is highlighted. Full-bleed + horizontal scroll
 // so the wide table never forces the page body to scroll sideways.
 import { SYSTEMS } from './comparison-data'
 ---
@@ -14,7 +14,6 @@ import { SYSTEMS } from './comparison-data'
         <th scope="col">Shape</th>
         <th scope="col">Frameworks</th>
         <th scope="col">Styling</th>
-        <th scope="col">Dark mode</th>
         <th scope="col">Accessibility</th>
         <th scope="col">License</th>
       </tr>
@@ -29,7 +28,6 @@ import { SYSTEMS } from './comparison-data'
           <td>{s.kind}</td>
           <td>{s.frameworks}</td>
           <td>{s.styling}</td>
-          <td>{s.dark}</td>
           <td>{s.a11y}</td>
           <td>{s.license}</td>
         </tr>

--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -1,6 +1,6 @@
 ---
 // At-a-glance matrix for the /comparison page: one row per system, columns
-// for the facts that decide adoption (shape, frameworks, styling, a11y,
+// for the facts that decide adoption (shape, frameworks, styling,
 // license). The Anta row is highlighted. Full-bleed + horizontal scroll
 // so the wide table never forces the page body to scroll sideways.
 import { SYSTEMS } from './comparison-data'
@@ -14,7 +14,6 @@ import { SYSTEMS } from './comparison-data'
         <th scope="col">Shape</th>
         <th scope="col">Frameworks</th>
         <th scope="col">Styling</th>
-        <th scope="col">Accessibility</th>
         <th scope="col">License</th>
       </tr>
     </thead>
@@ -31,7 +30,6 @@ import { SYSTEMS } from './comparison-data'
             {s.frameworksNote && <span class="fw-note">({s.frameworksNote})</span>}
           </td>
           <td>{s.styling}</td>
-          <td>{s.a11y}</td>
           <td>{s.license}</td>
         </tr>
       ))}

--- a/site/src/components/CoverageMatrix.astro
+++ b/site/src/components/CoverageMatrix.astro
@@ -17,6 +17,15 @@ const MARK: Record<Mark | 'none', { glyph: string; label: string; cls: string }>
 
 const cell = (systemId: string, catId: string) =>
   MARK[COVERAGE[systemId]?.[catId] ?? 'none']
+
+// Category → Anta's own component doc page, for the row-label link. Only
+// categories Anta ships a page for; the rest render as plain, unlinked labels.
+const ANTA_SLUG: Record<string, string> = {
+  button: 'button', textinput: 'input', select: 'select', choice: 'checkbox',
+  datetime: 'input-date', tabs: 'tabs', menu: 'menu', tooltip: 'tooltip',
+  accordion: 'expander', table: 'table', tag: 'tag', progress: 'progress',
+  icons: 'icon', typography: 'text',
+}
 ---
 
 <div class="full-bleed cov-scroll">
@@ -26,7 +35,7 @@ const cell = (systemId: string, catId: string) =>
         <th scope="col" class="cat-col">Component</th>
         {SYSTEMS.map((s) => (
           <th scope="col" class:list={['sys-head', { anta: s.anta }]}>
-            <span class="sys-head-label">{s.name}</span>
+            <a href={s.docs} target="_blank" rel="noopener" class="sys-head-label">{s.name}</a>
           </th>
         ))}
       </tr>
@@ -35,7 +44,9 @@ const cell = (systemId: string, catId: string) =>
       {CATEGORIES.map((c) => (
         <tr>
           <th scope="row" class="cat-col">
-            <span class="cat-label">{c.label}</span>
+            {ANTA_SLUG[c.id]
+              ? <a href={`/${ANTA_SLUG[c.id]}`} class="cat-label cat-link">{c.label}</a>
+              : <span class="cat-label">{c.label}</span>}
             <span class="cat-members">{c.members}</span>
           </th>
           {SYSTEMS.map((s) => {
@@ -94,6 +105,11 @@ const cell = (systemId: string, catId: string) =>
   .sys-head-label {
     display: inline-block;
     font-size: 12px;
+    color: inherit;
+    text-decoration: none;
+  }
+  .sys-head-label:hover {
+    text-decoration: underline;
   }
 
   /* First column: the grouped category, sticky to the left on horizontal
@@ -115,6 +131,12 @@ const cell = (systemId: string, catId: string) =>
     display: block;
     font-weight: 500;
     color: var(--text-1);
+  }
+  a.cat-label {
+    text-decoration: none;
+  }
+  a.cat-label:hover {
+    text-decoration: underline;
   }
   .cat-members {
     display: block;

--- a/site/src/components/SystemCards.astro
+++ b/site/src/components/SystemCards.astro
@@ -75,7 +75,8 @@ import { SYSTEMS } from './comparison-data'
   }
   .card-ver {
     font-size: 12px;
-    color: var(--text-4);
+    font-weight: 400;
+    color: var(--text-3);
     font-family: var(--monospace, ui-monospace, monospace);
   }
 

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -33,8 +33,6 @@ export interface System {
   frameworks: string
   /** Styling mechanism. */
   styling: string
-  /** Dark-mode story, short. */
-  dark: string
   /** Accessibility reputation, short. */
   a11y: string
   /** License, short. */
@@ -58,7 +56,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled web components + JSX wrappers',
     frameworks: 'Any: React, Preact, plain HTML',
     styling: 'Plain CSS + CSS-variable tokens (oklch)',
-    dark: '.dark ancestor class',
     a11y: 'ARIA layered in wrappers; solid',
     license: 'MIT',
     pros: [
@@ -86,7 +83,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled web components',
     frameworks: 'Any: web components (React/Vue/Angular/Svelte guides)',
     styling: 'CSS framework + ::part() + CSS variables',
-    dark: 'Built-in light/dark themes',
     a11y: 'Good (inherited from Shoelace)',
     license: 'MIT core + paid Pro tier',
     pros: [
@@ -112,7 +108,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled web components (CDN)',
     frameworks: 'Any: web components',
     styling: 'Locked to the Shopify look',
-    dark: 'Automatic (adopts host surface)',
     a11y: 'Strong; dev-time a11y warnings',
     license: 'Restricted (Shopify apps only)',
     pros: [
@@ -138,7 +133,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'CSS-in-JS (Emotion, moving to Pigment)',
-    dark: 'Color schemes / palette.mode',
     a11y: 'Mature, generally strong',
     license: 'MIT core + paid MUI X',
     pros: [
@@ -164,7 +158,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React (Angular/Vue community ports)',
     styling: 'CSS-in-JS + CSS variables (v6)',
-    dark: 'darkAlgorithm token preset',
     a11y: 'Weak; no a11y docs',
     license: 'MIT',
     pros: [
@@ -190,7 +183,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'CSS Modules + CSS variables',
-    dark: 'Built-in light/dark/auto',
     a11y: 'Good (varies by component)',
     license: 'MIT',
     pros: [
@@ -216,7 +208,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React (+ web components)',
     frameworks: 'React, web components; Angular/Vue/Svelte (community)',
     styling: 'Sass + CSS variables',
-    dark: 'Four built-in themes',
     a11y: 'Strong (IBM Equal Access program)',
     license: 'Apache-2.0',
     pros: [
@@ -242,7 +233,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'Compiled CSS-in-JS + tokens',
-    dark: 'Token themes (light/dark)',
     a11y: 'Strong (WCAG 2.1 AA)',
     license: 'Apache-2.0',
     pros: [
@@ -268,7 +258,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'Sass-compiled CSS (bp6- classes)',
-    dark: '.bp6-dark container class',
     a11y: 'Good for desktop/keyboard',
     license: 'Apache-2.0',
     pros: [
@@ -294,7 +283,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'StyleX (precompiled atomic CSS)',
-    dark: 'Installable theme packages',
     a11y: 'Claimed accessible (unaudited)',
     license: 'MIT',
     pros: [
@@ -320,7 +308,6 @@ export const SYSTEMS: System[] = [
     kind: 'Headless React primitives',
     frameworks: 'React',
     styling: 'Unstyled; bring your own',
-    dark: 'Bring your own (Themes adds one)',
     a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
@@ -346,7 +333,6 @@ export const SYSTEMS: System[] = [
     kind: 'Headless React primitives',
     frameworks: 'React',
     styling: 'Unstyled; bring your own',
-    dark: 'Bring your own',
     a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
@@ -372,7 +358,6 @@ export const SYSTEMS: System[] = [
     kind: 'Copy-paste React source',
     frameworks: 'React (Vue/Svelte community ports)',
     styling: 'Tailwind + CSS variables (oklch)',
-    dark: '.dark class (next-themes)',
     a11y: 'Inherits Radix / Base UI',
     license: 'MIT',
     pros: [

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -101,7 +101,7 @@ export const SYSTEMS: System[] = [
   {
     id: 'polaris',
     name: 'Shopify Polaris',
-    version: 'Polaris web components 2026-01',
+    version: 'Web components 2026-01',
     docs: 'https://shopify.dev/docs/api/app-home/web-components',
     tagline:
       "Shopify's system for apps that must look native inside Shopify Admin, now shipped as CDN-delivered web components.",

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -83,7 +83,7 @@ export const SYSTEMS: System[] = [
     tagline:
       "Font Awesome's framework-agnostic web components and CSS framework, the commercial successor to Shoelace.",
     kind: 'Styled web components',
-    frameworks: 'Any: web components',
+    frameworks: 'Web components',
     frameworksNote: 'React, Vue, Angular, Svelte guides',
     styling: 'CSS framework + ::part() + CSS variables',
     a11y: 'Good (inherited from Shoelace)',
@@ -109,7 +109,7 @@ export const SYSTEMS: System[] = [
     tagline:
       "Shopify's system for apps that must look native inside Shopify Admin, now shipped as CDN-delivered web components.",
     kind: 'Styled web components (CDN)',
-    frameworks: 'Any: web components',
+    frameworks: 'Web components',
     styling: 'Locked to the Shopify look',
     a11y: 'Strong; dev-time a11y warnings',
     license: 'Restricted (Shopify apps only)',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -29,8 +29,10 @@ export interface System {
   tagline: string
   /** Distribution / shape, e.g. "Styled web components + JSX wrappers". */
   kind: string
-  /** Which frameworks it targets. */
+  /** Primary framework(s) it targets, shown on the first line. */
   frameworks: string
+  /** Secondary / community reach, shown muted in parens on a second line. */
+  frameworksNote?: string
   /** Styling mechanism. */
   styling: string
   /** Accessibility reputation, short. */
@@ -81,7 +83,8 @@ export const SYSTEMS: System[] = [
     tagline:
       "Font Awesome's framework-agnostic web components and CSS framework, the commercial successor to Shoelace.",
     kind: 'Styled web components',
-    frameworks: 'Any: web components (React/Vue/Angular/Svelte guides)',
+    frameworks: 'Any: web components',
+    frameworksNote: 'React, Vue, Angular, Svelte guides',
     styling: 'CSS framework + ::part() + CSS variables',
     a11y: 'Good (inherited from Shoelace)',
     license: 'MIT core + paid Pro tier',
@@ -156,7 +159,8 @@ export const SYSTEMS: System[] = [
     tagline:
       'An enterprise-class React library, strong for data-dense admin and dashboard UIs.',
     kind: 'Styled React components',
-    frameworks: 'React (Angular/Vue community ports)',
+    frameworks: 'React',
+    frameworksNote: 'Angular, Vue community ports',
     styling: 'CSS-in-JS + CSS variables (v6)',
     a11y: 'Weak; no a11y docs',
     license: 'MIT',
@@ -206,7 +210,8 @@ export const SYSTEMS: System[] = [
     tagline:
       "IBM's enterprise design system, with a first-party web-components package alongside React.",
     kind: 'Styled React (+ web components)',
-    frameworks: 'React, web components; Angular/Vue/Svelte (community)',
+    frameworks: 'React wrappers of web components',
+    frameworksNote: 'Angular, Vue, Svelte community',
     styling: 'Sass + CSS variables',
     a11y: 'Strong (IBM Equal Access program)',
     license: 'Apache-2.0',
@@ -356,7 +361,8 @@ export const SYSTEMS: System[] = [
     tagline:
       'A copy-paste collection of Tailwind-styled components you own in your repo, added by CLI rather than installed as a dependency.',
     kind: 'Copy-paste React source',
-    frameworks: 'React (Vue/Svelte community ports)',
+    frameworks: 'React',
+    frameworksNote: 'Vue, Svelte community ports',
     styling: 'Tailwind + CSS variables (oklch)',
     a11y: 'Inherits Radix / Base UI',
     license: 'MIT',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -478,9 +478,10 @@ export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
     nav: 'yes', icons: 'yes', typography: 'yes',
   },
   radix: {
-    select: 'yes', combobox: 'no', choice: 'yes', slider: 'yes', tabs: 'yes',
-    menu: 'yes', tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
-    progress: 'yes', avatar: 'yes', nav: 'partial',
+    button: 'partial', select: 'yes', combobox: 'no', choice: 'yes',
+    slider: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes', dialog: 'yes',
+    toast: 'yes', accordion: 'yes', progress: 'yes', avatar: 'yes',
+    nav: 'partial', icons: 'yes',
   },
   baseui: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -55,7 +55,7 @@ export const SYSTEMS: System[] = [
       'Framework-agnostic web components with thin React/Preact wrappers, a tiny CSS-variable token set, and no style or animation runtime.',
     kind: 'Styled web components + JSX wrappers',
     frameworks: 'React/Preact wrappers of Web components',
-    styling: 'Plain CSS + CSS-variable tokens (oklch)',
+    styling: 'Plain CSS + CSS-variable tokens',
     license: 'MIT',
     pros: [
       'Web components run in React, Preact, or plain HTML; the JSX wrappers are a thin, optional convenience.',
@@ -270,7 +270,7 @@ export const SYSTEMS: System[] = [
   {
     id: 'astryx',
     name: 'Astryx',
-    version: '@astryxdesign/core 0.1.4 (beta)',
+    version: '@astryxdesign/core 0.1.4',
     docs: 'https://astryx.atmeta.com',
     tagline:
       "Meta's new, AI-fluent design system: precompiled CSS and typed React components built on StyleX.",
@@ -349,7 +349,7 @@ export const SYSTEMS: System[] = [
     kind: 'Copy-paste React source',
     frameworks: 'React',
     frameworksNote: 'Vue, Svelte community ports',
-    styling: 'Tailwind + CSS variables (oklch)',
+    styling: 'Tailwind + CSS variables',
     license: 'MIT',
     pros: [
       'Total ownership: no black-box dependency, edit anything.',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -56,7 +56,7 @@ export const SYSTEMS: System[] = [
     tagline:
       'Framework-agnostic web components with thin React/Preact wrappers, a tiny CSS-variable token set, and no style or animation runtime.',
     kind: 'Styled web components + JSX wrappers',
-    frameworks: 'Any: React, Preact, plain HTML',
+    frameworks: 'React/Preact wrappers of Web components',
     styling: 'Plain CSS + CSS-variable tokens (oklch)',
     a11y: 'ARIA layered in wrappers; solid',
     license: 'MIT',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -407,7 +407,6 @@ export const CATEGORIES: Category[] = [
   { id: 'icons', label: 'Icons', members: 'Bundled icon set' },
   { id: 'typography', label: 'Typography', members: 'Text / title components' },
   { id: 'charts', label: 'Charts', members: 'First-party data viz' },
-  { id: 'motion', label: 'Animated art', members: 'Stickers / illustrations' },
 ]
 
 /**
@@ -422,14 +421,14 @@ export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
     button: 'yes', textinput: 'yes', select: 'yes', choice: 'partial',
     datetime: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes',
     accordion: 'yes', table: 'partial', tag: 'yes', progress: 'partial',
-    icons: 'yes', typography: 'yes', motion: 'yes',
+    icons: 'yes', typography: 'yes',
   },
   webawesome: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'paid',
     choice: 'yes', slider: 'yes', datetime: 'paid', tabs: 'yes', menu: 'yes',
     tooltip: 'yes', dialog: 'yes', toast: 'paid', accordion: 'yes',
     tag: 'yes', progress: 'yes', avatar: 'yes', card: 'yes', nav: 'partial',
-    icons: 'yes', typography: 'partial', charts: 'paid', motion: 'partial',
+    icons: 'yes', typography: 'partial', charts: 'paid',
   },
   polaris: {
     button: 'yes', textinput: 'yes', select: 'yes', choice: 'yes',

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -35,8 +35,6 @@ export interface System {
   frameworksNote?: string
   /** Styling mechanism. */
   styling: string
-  /** Accessibility reputation, short. */
-  a11y: string
   /** License, short. */
   license: string
   pros: string[]
@@ -58,7 +56,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled web components + JSX wrappers',
     frameworks: 'React/Preact wrappers of Web components',
     styling: 'Plain CSS + CSS-variable tokens (oklch)',
-    a11y: 'ARIA layered in wrappers; solid',
     license: 'MIT',
     pros: [
       'Web components run in React, Preact, or plain HTML; the JSX wrappers are a thin, optional convenience.',
@@ -86,7 +83,6 @@ export const SYSTEMS: System[] = [
     frameworks: 'Web components',
     frameworksNote: 'React, Vue, Angular, Svelte guides',
     styling: 'CSS framework + ::part() + CSS variables',
-    a11y: 'Good (inherited from Shoelace)',
     license: 'MIT core + paid Pro tier',
     pros: [
       'Framework-agnostic web components that work in any stack or plain HTML.',
@@ -111,7 +107,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled web components (CDN)',
     frameworks: 'Web components',
     styling: 'Locked to the Shopify look',
-    a11y: 'Strong; dev-time a11y warnings',
     license: 'Restricted (Shopify apps only)',
     pros: [
       'Framework-agnostic web components, a rare modern first-party example.',
@@ -136,7 +131,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'CSS-in-JS (Emotion, moving to Pigment)',
-    a11y: 'Mature, generally strong',
     license: 'MIT core + paid MUI X',
     pros: [
       'A large component surface out of the box, plus MUI X for data grid, charts, and pickers.',
@@ -162,7 +156,6 @@ export const SYSTEMS: System[] = [
     frameworks: 'React',
     frameworksNote: 'Angular, Vue community ports',
     styling: 'CSS-in-JS + CSS variables (v6)',
-    a11y: 'Weak; no a11y docs',
     license: 'MIT',
     pros: [
       'One of the largest component libraries, with heavy-duty Table, Form, Transfer, and Cascader.',
@@ -187,7 +180,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'CSS Modules + CSS variables',
-    a11y: 'Good (varies by component)',
     license: 'MIT',
     pros: [
       'Broad coverage out of the box: forms, dates, charts, notifications, and rich text are all official.',
@@ -213,7 +205,6 @@ export const SYSTEMS: System[] = [
     frameworks: 'React wrappers of web components',
     frameworksNote: 'Angular, Vue, Svelte community',
     styling: 'Sass + CSS variables',
-    a11y: 'Strong (IBM Equal Access program)',
     license: 'Apache-2.0',
     pros: [
       'Hardened for enterprise, with data-table and app-shell components most systems lack.',
@@ -238,7 +229,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'Compiled CSS-in-JS + tokens',
-    a11y: 'Strong (WCAG 2.1 AA)',
     license: 'Apache-2.0',
     pros: [
       "Proven at scale in Atlassian's products.",
@@ -263,7 +253,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'Sass-compiled CSS (bp6- classes)',
-    a11y: 'Good for desktop/keyboard',
     license: 'Apache-2.0',
     pros: [
       'Built for dense professional desktop apps: dashboards, tooling, and data grids.',
@@ -288,7 +277,6 @@ export const SYSTEMS: System[] = [
     kind: 'Styled React components',
     frameworks: 'React',
     styling: 'StyleX (precompiled atomic CSS)',
-    a11y: 'Claimed accessible (unaudited)',
     license: 'MIT',
     pros: [
       'Backed by Meta, reportedly matured internally for years before open-sourcing.',
@@ -313,7 +301,6 @@ export const SYSTEMS: System[] = [
     kind: 'Headless React primitives',
     frameworks: 'React',
     styling: 'Unstyled; bring your own',
-    a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
       'Accessibility and interaction behavior that other libraries treat as the reference.',
@@ -338,7 +325,6 @@ export const SYSTEMS: System[] = [
     kind: 'Headless React primitives',
     frameworks: 'React',
     styling: 'Unstyled; bring your own',
-    a11y: 'Reference-grade (WAI-ARIA APG)',
     license: 'MIT',
     pros: [
       'Headless accessibility from the people who wrote Radix and Floating UI, with cleaner APIs.',
@@ -364,7 +350,6 @@ export const SYSTEMS: System[] = [
     frameworks: 'React',
     frameworksNote: 'Vue, Svelte community ports',
     styling: 'Tailwind + CSS variables (oklch)',
-    a11y: 'Inherits Radix / Base UI',
     license: 'MIT',
     pros: [
       'Total ownership: no black-box dependency, edit anything.',

--- a/site/src/pages/comparison.mdx
+++ b/site/src/pages/comparison.mdx
@@ -75,8 +75,6 @@ Carbon, and Blueprint are known for.
 
 ## The systems
 
-Honest strengths and trade-offs for each, Anta first.
-
 <SystemCards />
 
 ## Choosing between them

--- a/site/src/pages/comparison.mdx
+++ b/site/src/pages/comparison.mdx
@@ -71,9 +71,7 @@ leave most cells to you by design; they ship behavior and leave the look to you.
 
 Anta's **Table** and **Select** are marked basic on purpose: they aren't the
 async data grid or virtualized combobox that enterprise kits like Ant Design,
-Carbon, and Blueprint are known for. **Animated art** is Anta's alone here: the
-stickers package ships Lottie-backed `<a-sticker>` elements, a piece none of the
-general-purpose systems carry.
+Carbon, and Blueprint are known for.
 
 ## The systems
 


### PR DESCRIPTION
Removes the **Dark mode** column from the `/comparison` at-a-glance matrix.

- `ComparisonMatrix.astro` — drop the `Dark mode` header and cell; update the file-header comment.
- `comparison-data.ts` — remove the now-dead `dark` field from the `System` interface and all 14 system entries (it was only consumed by that column).

Docs-site only; no consumer-facing change, so nothing for `CHANGELOG.md`.