### PR TITLE
SelectFaceted: faceted-filter component (+ Select leading, input slot styling)

### DIFF
--- a/site/lib/component-slugs.ts
+++ b/site/lib/component-slugs.ts
@@ -7,6 +7,6 @@
  *  in DocsLayout.astro when adding a component. */
 export const COMPONENT_SLUGS = [
   'button', 'checkbox', 'expander', 'icon', 'input', 'input-date', 'menu',
-  'progress', 'radio', 'select', 'stickers', 'table', 'tabs', 'tag', 'text',
-  'title', 'tooltip',
+  'progress', 'radio', 'select', 'select-faceted', 'stickers', 'table', 'tabs',
+  'tag', 'text', 'title', 'tooltip',
 ]

--- a/site/src/components/SelectFacetedDemos.tsx
+++ b/site/src/components/SelectFacetedDemos.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useState } from 'preact/hooks'
+import { SelectFaceted, Select, Input } from '@antadesign/anta'
+import type { SelectFacet } from '@antadesign/anta'
+
+/** Registers the custom elements client-side (see TabsDemo for the pattern). */
+function useElements() {
+  useEffect(() => {
+    import('@antadesign/anta/elements')
+  }, [])
+}
+
+const PEOPLE = [
+  'Alice Nguyen', 'Bob Carter', 'Carol Diaz', 'Dave Feld', 'Erin Shah',
+  'Frank Lopez', 'Grace Kim', 'Heidi Braun', 'Ivan Petrov', 'Judy Chen',
+  'Karl Ober', 'Liz Moreau',
+]
+
+const FACETS: SelectFacet[] = [
+  // Long list → filterable multi-select.
+  { key: 'assignee', label: 'Assignee', kind: 'multiple', icon: 'circle-dot', filter: true, options: PEOPLE },
+  // Same list under a different facet — "alice" here never collides with an assignee "alice".
+  { key: 'owner', label: 'Owner', kind: 'single', icon: 'circle-dot', filter: true, options: PEOPLE },
+  // Options carry the same fields as Select's — value / label / hint / tone.
+  {
+    key: 'status',
+    label: 'Status',
+    kind: 'single',
+    icon: 'tag',
+    options: [
+      { value: 'open', label: 'Open', hint: 'Not started' },
+      { value: 'in-progress', label: 'In progress', hint: 'Being worked on' },
+      { value: 'closed', label: 'Closed', hint: 'Done' },
+    ],
+  },
+  {
+    key: 'label',
+    label: 'Label',
+    kind: 'multiple',
+    options: [
+      { value: 'bug', label: 'Bug', tone: 'critical' },
+      { value: 'feature', label: 'Feature', tone: 'success' },
+      { value: 'docs', label: 'Docs', tone: 'info' },
+      { value: 'chore', label: 'Chore' },
+    ],
+  },
+  { key: 'title', label: 'Title contains', kind: 'text', icon: 'case-sensitive', placeholder: 'Search title…' },
+  {
+    // A custom facet: object value, your own editor.
+    key: 'duration',
+    label: 'Min duration',
+    kind: 'custom',
+    icon: 'calendar',
+    summary: (v: any) => `≥ ${v.min}s`,
+    render: ({ value, onChange }: any) => (
+      <div data-menu-open style={{ display: 'flex', gap: '6px', alignItems: 'center', padding: '4px' }}>
+        <span>≥</span>
+        <Input
+          size="small"
+          value={value?.min ?? ''}
+          placeholder="0"
+          style={{ width: '72px' }}
+          onInput={(e: any) => onChange(e.currentTarget.value ? { min: e.currentTarget.value } : undefined)}
+        />
+        <span>seconds</span>
+      </div>
+    ),
+  },
+]
+
+const isSet = (v: unknown) => !(v == null || v === '' || (Array.isArray(v) && v.length === 0))
+
+export function SelectFacetedBasicDemo() {
+  useElements()
+  const [value, setValue] = useState<Record<string, unknown>>({ assignee: ['Alice Nguyen'], status: 'open' })
+  const setFacet = (key: string, v: unknown) =>
+    setValue((prev) => {
+      const next = { ...prev }
+      if (isSet(v)) next[key] = v
+      else delete next[key]
+      return next
+    })
+  const active = FACETS.filter((f) => isSet(value[f.key]))
+  return (
+    <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '12px', alignItems: 'center', width: '100%' }}>
+      <SelectFaceted facets={FACETS} value={value} onValueChange={setValue} searchable />
+      {active.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '8px', alignItems: 'center' }}>
+          {active.map((facet) => {
+            // Options facets → an editable Select; the key rides the leading slot.
+            if (facet.kind === 'single' || facet.kind === 'multiple')
+              return (
+                <Select
+                  key={facet.key}
+                  selection={facet.kind}
+                  options={facet.options}
+                  value={value[facet.key] as any}
+                  onValueChange={(v: any) => setFacet(facet.key, v)}
+                  leading={`${facet.label}:`}
+                  className="sf-chip"
+                />
+              )
+            // Free-form text → an editable Input; clearing it drops the filter.
+            if (facet.kind === 'text')
+              return (
+                <Input
+                  key={facet.key}
+                  value={(value[facet.key] as string) ?? ''}
+                  leading={`${facet.label}:`}
+                  clearable
+                  className="sf-chip"
+                  onInput={(e: any) => setFacet(facet.key, e.currentTarget.value || undefined)}
+                />
+              )
+            // Custom (duration) → an Input editing its `min`.
+            return (
+              <Input
+                key={facet.key}
+                value={((value[facet.key] as any)?.min ?? '') as string}
+                leading={`${facet.label}:`}
+                clearable
+                className="sf-chip"
+                onInput={(e: any) =>
+                  setFacet(facet.key, e.currentTarget.value ? { min: e.currentTarget.value } : undefined)
+                }
+              />
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/site/src/components/SelectFacetedDemos.tsx
+++ b/site/src/components/SelectFacetedDemos.tsx
@@ -96,6 +96,8 @@ export function SelectFacetedBasicDemo() {
                   value={value[facet.key] as any}
                   onValueChange={(v: any) => setFacet(facet.key, v)}
                   leading={`${facet.label}:`}
+                  filter={facet.filter}
+                  clearable
                   className="sf-chip"
                 />
               )
@@ -107,6 +109,7 @@ export function SelectFacetedBasicDemo() {
                   value={(value[facet.key] as string) ?? ''}
                   leading={`${facet.label}:`}
                   clearable
+                  dimActions
                   className="sf-chip"
                   onInput={(e: any) => setFacet(facet.key, e.currentTarget.value || undefined)}
                 />
@@ -118,6 +121,7 @@ export function SelectFacetedBasicDemo() {
                 value={((value[facet.key] as any)?.min ?? '') as string}
                 leading={`${facet.label}:`}
                 clearable
+                dimActions
                 className="sf-chip"
                 onInput={(e: any) =>
                   setFacet(facet.key, e.currentTarget.value ? { min: e.currentTarget.value } : undefined)

--- a/site/src/components/SelectFacetedDemos.tsx
+++ b/site/src/components/SelectFacetedDemos.tsx
@@ -96,6 +96,7 @@ export function SelectFacetedBasicDemo() {
                 <Select
                   key={facet.key}
                   selection={facet.kind}
+                  indicator={facet.kind === 'single' ? 'check' : undefined}
                   options={facet.options}
                   value={value[facet.key] as any}
                   onValueChange={(v: any) => setFacet(facet.key, v)}

--- a/site/src/components/SelectFacetedDemos.tsx
+++ b/site/src/components/SelectFacetedDemos.tsx
@@ -71,7 +71,7 @@ const isSet = (v: unknown) => !(v == null || v === '' || (Array.isArray(v) && v.
 
 export function SelectFacetedBasicDemo() {
   useElements()
-  const [value, setValue] = useState<Record<string, unknown>>({ assignee: ['Alice Nguyen'], status: 'open' })
+  const [value, setValue] = useState<Record<string, unknown>>({ assignee: ['Alice Nguyen'], status: 'open', title: 'crash' })
   const setFacet = (key: string, v: unknown) =>
     setValue((prev) => {
       const next = { ...prev }
@@ -79,7 +79,11 @@ export function SelectFacetedBasicDemo() {
       else delete next[key]
       return next
     })
-  const active = FACETS.filter((f) => isSet(value[f.key]))
+  // Keep a text/custom result chip mounted while it's focused, even if emptied — so
+  // backspacing to empty doesn't yank the field mid-edit (only the Clear button or
+  // blurring an empty field removes it).
+  const [focusedKey, setFocusedKey] = useState<string | null>(null)
+  const active = FACETS.filter((f) => isSet(value[f.key]) || f.key === focusedKey)
   return (
     <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: '12px', alignItems: 'center', width: '100%' }}>
       <SelectFaceted facets={FACETS} value={value} onValueChange={setValue} searchable />
@@ -111,7 +115,13 @@ export function SelectFacetedBasicDemo() {
                   clearable
                   dimActions
                   className="sf-chip"
+                  onFocus={() => setFocusedKey(facet.key)}
+                  onBlur={() => setFocusedKey(null)}
                   onInput={(e: any) => setFacet(facet.key, e.currentTarget.value || undefined)}
+                  onClearInput={() => {
+                    setFocusedKey(null)
+                    setFacet(facet.key, undefined)
+                  }}
                 />
               )
             // Custom (duration) → an Input editing its `min`.
@@ -123,9 +133,15 @@ export function SelectFacetedBasicDemo() {
                 clearable
                 dimActions
                 className="sf-chip"
+                onFocus={() => setFocusedKey(facet.key)}
+                onBlur={() => setFocusedKey(null)}
                 onInput={(e: any) =>
                   setFacet(facet.key, e.currentTarget.value ? { min: e.currentTarget.value } : undefined)
                 }
+                onClearInput={() => {
+                  setFocusedKey(null)
+                  setFacet(facet.key, undefined)
+                }}
               />
             )
           })}

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -260,6 +260,7 @@ if (isComponentPage && title) {
           <li><a href="/progress/" aria-current={isCurrent('/progress/') ? 'page' : undefined}><Icon shape="hourglass" size={18} /> Progress</a></li>
           <li><a href="/radio/" aria-current={isCurrent('/radio/') ? 'page' : undefined}><Icon shape="circle-dot" size={18} /> Radio</a></li>
           <li><a href="/select/" aria-current={isCurrent('/select/') ? 'page' : undefined}><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect width="18" height="18" x="3" y="3" rx="2"/><path d="m8 10 4 4 4-4"/></svg> Select</a></li>
+          <li><a href="/select-faceted/" aria-current={isCurrent('/select-faceted/') ? 'page' : undefined}><Icon shape="filter" size={18} /> SelectFaceted</a></li>
           <li><a href="/table/" aria-current={isCurrent('/table/') ? 'page' : undefined}><Icon shape="table-2" size={18} /> Table</a></li>
           <li><a href="/tabs/" aria-current={isCurrent('/tabs/') ? 'page' : undefined}><Icon shape="tabs" size={18} /> Tabs</a></li>
           <li><a href="/tag/" aria-current={isCurrent('/tag/') ? 'page' : undefined}><Icon shape="tag" size={18} /> Tag</a></li>

--- a/site/src/pages/input-date.mdx
+++ b/site/src/pages/input-date.mdx
@@ -1,6 +1,6 @@
 ---
 layout: ../layouts/DocsLayout.astro
-title: InputDate
+title: Date input
 ---
 import Playground from '../components/Playground'
 import Preview from '../components/Preview.astro'
@@ -12,7 +12,7 @@ import dateInputDemoCode from './input-date.demo.ts'
 import CalendarDemo from '../components/CalendarDemo'
 import InputDateDemo from '../components/InputDateDemo'
 
-# InputDate
+# Date input
 
 **`InputDate`** is a date field that replaces the native `type="date"` (and, with
 `time`, `type="datetime-local"`): a text field you can type into, backed by a

--- a/site/src/pages/select-faceted.demo.ts
+++ b/site/src/pages/select-faceted.demo.ts
@@ -1,0 +1,70 @@
+/**
+ * Demo source for the SelectFaceted playground. Kept in a sibling .ts file so
+ * Astro's MDX pipeline doesn't mangle the template literal's indentation.
+ */
+export default `import { SelectFaceted, Input } from '@antadesign/anta'
+
+const people = [
+  'Alice Nguyen', 'Bob Carter', 'Carol Diaz', 'Dave Feld', 'Erin Shah',
+  'Frank Lopez', 'Grace Kim', 'Heidi Braun', 'Ivan Petrov', 'Judy Chen',
+]
+
+<SelectFaceted
+  facets={[
+    // Long list → filterable multi-select.
+    { key: 'assignee', label: 'Assignee', kind: 'multiple', icon: 'circle-dot', filter: true, options: people },
+    { key: 'owner', label: 'Owner', kind: 'single', icon: 'circle-dot', filter: true, options: people },
+    {
+      key: 'status',
+      label: 'Status',
+      kind: 'single',
+      icon: 'tag',
+      options: [
+        { value: 'open', label: 'Open', hint: 'Not started' },
+        { value: 'in-progress', label: 'In progress', hint: 'Being worked on' },
+        { value: 'closed', label: 'Closed', hint: 'Done' },
+      ],
+    },
+    {
+      key: 'label',
+      label: 'Label',
+      kind: 'multiple',
+      options: [
+        { value: 'bug', label: 'Bug', tone: 'critical' },
+        { value: 'feature', label: 'Feature', tone: 'success' },
+        { value: 'docs', label: 'Docs', tone: 'info' },
+        { value: 'chore', label: 'Chore' },
+      ],
+    },
+    {
+      key: 'title',
+      label: 'Title contains',
+      kind: 'text',
+      icon: 'case-sensitive',
+      placeholder: 'Search title…',
+    },
+    {
+      // A custom facet: its value is an object, its editor is your own.
+      key: 'duration',
+      label: 'Min duration',
+      kind: 'custom',
+      icon: 'calendar',
+      summary: (v) => '≥ ' + v.min + 's',
+      render: ({ value, onChange }) => (
+        <div data-menu-open style={{ display: 'flex', gap: '6px', alignItems: 'center', padding: '4px' }}>
+          <span>≥</span>
+          <Input
+            size="small"
+            value={value?.min ?? ''}
+            placeholder="0"
+            style={{ width: '72px' }}
+            onInput={(e) => onChange(e.currentTarget.value ? { min: e.currentTarget.value } : undefined)}
+          />
+          <span>seconds</span>
+        </div>
+      ),
+    },
+  ]}
+  searchable
+  defaultValue={{ assignee: ['Alice Nguyen'], status: 'open' }}
+/>`

--- a/site/src/pages/select-faceted.mdx
+++ b/site/src/pages/select-faceted.mdx
@@ -60,38 +60,57 @@ const FACETS = [
   { key: 'duration', label: 'Min duration', kind: 'custom', summary: (v) => `≥ ${v.min}s`, render: /* … */ },
 ]
 
+const isSet = (v) => !(v == null || v === '' || (Array.isArray(v) && v.length === 0))
+
 function Demo() {
   const [value, setValue] = useState({ assignee: ['Alice Nguyen'], status: 'open' })
-  const active = FACETS.filter((f) => isSet(value[f.key]))
-  const setFacet = (key, v) => setValue((p) => (isSet(v) ? { ...p, [key]: v } : omit(p, key)))
+  const setFacet = (key, v) =>
+    setValue((p) => (isSet(v) ? { ...p, [key]: v } : (({ [key]: _, ...rest }) => rest)(p)))
+
+  // Keep a text/custom chip mounted while it's focused, even when emptied — so
+  // backspacing to empty doesn't yank the field (only Clear or blur-when-empty does).
+  const [focusedKey, setFocusedKey] = useState(null)
+  const active = FACETS.filter((f) => isSet(value[f.key]) || f.key === focusedKey)
 
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
       <SelectFaceted facets={FACETS} value={value} onValueChange={setValue} searchable />
 
-      {/* Each result is its own control, the facet key piped into `leading`:
-          options facets → a Select, free-form / custom facets → an Input. */}
-      {active.map((facet) =>
-        facet.kind === 'single' || facet.kind === 'multiple' ? (
-          <Select
-            key={facet.key}
-            selection={facet.kind}
-            options={facet.options}
-            value={value[facet.key]}
-            onValueChange={(v) => setFacet(facet.key, v)}
-            leading={`${facet.label}:`}
-          />
-        ) : (
+      {/* Each result is its own control, the facet key piped into `leading`. */}
+      {active.map((facet) => {
+        // Options facets → an editable Select (filterable + clearable footer).
+        if (facet.kind === 'single' || facet.kind === 'multiple')
+          return (
+            <Select
+              key={facet.key}
+              selection={facet.kind}
+              options={facet.options}
+              value={value[facet.key]}
+              onValueChange={(v) => setFacet(facet.key, v)}
+              leading={`${facet.label}:`}
+              filter={facet.filter}
+              clearable
+            />
+          )
+
+        // Free-form text / custom → an editable Input.
+        const val = facet.kind === 'text' ? value[facet.key] : value[facet.key]?.min
+        const write = (raw) =>
+          setFacet(facet.key, facet.kind === 'text' ? raw || undefined : raw ? { min: raw } : undefined)
+        return (
           <Input
             key={facet.key}
-            value={facet.kind === 'text' ? value[facet.key] : value[facet.key].min}
+            value={val ?? ''}
             leading={`${facet.label}:`}
             clearable
             dimActions
-            onInput={(e) => setFacet(facet.key, /* text → string, custom → { min } */ e.currentTarget.value)}
+            onFocus={() => setFocusedKey(facet.key)}
+            onBlur={() => setFocusedKey(null)}
+            onInput={(e) => write(e.currentTarget.value)}
+            onClearInput={() => { setFocusedKey(null); setFacet(facet.key, undefined) }}
           />
-        ),
-      )}
+        )
+      })}
     </div>
   )
 }

--- a/site/src/pages/select-faceted.mdx
+++ b/site/src/pages/select-faceted.mdx
@@ -63,7 +63,7 @@ const FACETS = [
 const isSet = (v) => !(v == null || v === '' || (Array.isArray(v) && v.length === 0))
 
 function Demo() {
-  const [value, setValue] = useState({ assignee: ['Alice Nguyen'], status: 'open' })
+  const [value, setValue] = useState({ assignee: ['Alice Nguyen'], status: 'open', title: 'crash' })
   const setFacet = (key, v) =>
     setValue((p) => (isSet(v) ? { ...p, [key]: v } : (({ [key]: _, ...rest }) => rest)(p)))
 
@@ -73,45 +73,50 @@ function Demo() {
   const active = FACETS.filter((f) => isSet(value[f.key]) || f.key === focusedKey)
 
   return (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
+    <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: 12, alignItems: 'center', width: '100%' }}>
       <SelectFaceted facets={FACETS} value={value} onValueChange={setValue} searchable />
 
-      {/* Each result is its own control, the facet key piped into `leading`. */}
-      {active.map((facet) => {
-        // Options facets → an editable Select (filterable + clearable footer).
-        if (facet.kind === 'single' || facet.kind === 'multiple')
-          return (
-            <Select
-              key={facet.key}
-              selection={facet.kind}
-              indicator={facet.kind === 'single' ? 'check' : undefined}
-              options={facet.options}
-              value={value[facet.key]}
-              onValueChange={(v) => setFacet(facet.key, v)}
-              leading={`${facet.label}:`}
-              filter={facet.filter}
-              clearable
-            />
-          )
+      {active.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'row', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
+          {/* Each active facet's result is its own control, the key piped into `leading`. */}
+          {active.map((facet) => {
+            // Options facets → an editable Select (single shows the trailing check;
+            // both are filterable + have a clearable footer).
+            if (facet.kind === 'single' || facet.kind === 'multiple')
+              return (
+                <Select
+                  key={facet.key}
+                  selection={facet.kind}
+                  indicator={facet.kind === 'single' ? 'check' : undefined}
+                  options={facet.options}
+                  value={value[facet.key]}
+                  onValueChange={(v) => setFacet(facet.key, v)}
+                  leading={`${facet.label}:`}
+                  filter={facet.filter}
+                  clearable
+                />
+              )
 
-        // Free-form text / custom → an editable Input.
-        const val = facet.kind === 'text' ? value[facet.key] : value[facet.key]?.min
-        const write = (raw) =>
-          setFacet(facet.key, facet.kind === 'text' ? raw || undefined : raw ? { min: raw } : undefined)
-        return (
-          <Input
-            key={facet.key}
-            value={val ?? ''}
-            leading={`${facet.label}:`}
-            clearable
-            dimActions
-            onFocus={() => setFocusedKey(facet.key)}
-            onBlur={() => setFocusedKey(null)}
-            onInput={(e) => write(e.currentTarget.value)}
-            onClearInput={() => { setFocusedKey(null); setFacet(facet.key, undefined) }}
-          />
-        )
-      })}
+            // Free-form text / custom → an editable Input.
+            const val = facet.kind === 'text' ? value[facet.key] : value[facet.key]?.min
+            const write = (raw) =>
+              setFacet(facet.key, facet.kind === 'text' ? raw || undefined : raw ? { min: raw } : undefined)
+            return (
+              <Input
+                key={facet.key}
+                value={val ?? ''}
+                leading={`${facet.label}:`}
+                clearable
+                dimActions
+                onFocus={() => setFocusedKey(facet.key)}
+                onBlur={() => setFocusedKey(null)}
+                onInput={(e) => write(e.currentTarget.value)}
+                onClearInput={() => { setFocusedKey(null); setFacet(facet.key, undefined) }}
+              />
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/site/src/pages/select-faceted.mdx
+++ b/site/src/pages/select-faceted.mdx
@@ -46,7 +46,7 @@ own [Select](/select/) — editable in place, with the facet key piped into the 
   <style is:inline>{`
     /* Result chips size to their value (field-sizing) and cap at a max-width,
        ellipsizing past it — the .sf-chip class is only for this demo. */
-    .sf-chip { width: fit-content; max-width: 220px; }
+    .sf-chip { width: fit-content; max-width: 240px; }
     .sf-chip::part(input) { field-sizing: content; text-overflow: ellipsis; }
   `}</style>
 </Preview>
@@ -87,6 +87,7 @@ function Demo() {
             value={facet.kind === 'text' ? value[facet.key] : value[facet.key].min}
             leading={`${facet.label}:`}
             clearable
+            dimActions
             onInput={(e) => setFacet(facet.key, /* text → string, custom → { min } */ e.currentTarget.value)}
           />
         ),

--- a/site/src/pages/select-faceted.mdx
+++ b/site/src/pages/select-faceted.mdx
@@ -1,0 +1,103 @@
+---
+layout: ../layouts/DocsLayout.astro
+title: Faceted select
+---
+import Playground from '../components/Playground'
+import Preview from '../components/Preview.astro'
+import PropsTable from '../components/PropsTable.astro'
+import Disclosure from '../components/Disclosure.astro'
+import selectFacetedDemoCode from './select-faceted.demo.ts'
+import { SelectFacetedBasicDemo } from '../components/SelectFacetedDemos'
+
+# Faceted select
+
+A faceted filter: one trigger opens a menu of **facets** (dimensions), each a
+submenu flyout with its own editor. The value is a `Record<facetKey, value>`, so
+the same option value under two facets — assignee "Alice" and owner "Alice" —
+stays distinct. Each facet declares a `kind`: `single`, `multiple`, `text`
+(free-form substring, applied on Enter / blur), or `custom` (bring your own
+editor and value, including an object).
+
+It's a **composed component** built from [Menu](/menu/), [Select](/select/)'s
+option model, [Input](/input/), and [Tag](/tag/) — no new element. Controlled via
+`value`, uncontrolled via `defaultValue`; changes arrive through one
+**`onValueChange`**.
+
+<Disclosure title="Playground" anchor={false} brand>
+
+<Playground
+  client:visible
+  component="SelectFaceted"
+  layout="side"
+  panelHeight={440}
+  initialCode={selectFacetedDemoCode}
+  initialCss={`html, body { height: 100%; }
+.preview { min-height: 100%; justify-content: flex-start; align-items: flex-start; padding: 24px; }`}
+/>
+
+</Disclosure>
+
+The trigger opens the facet menu; each **active** facet's result renders below as its
+own [Select](/select/) — editable in place, with the facet key piped into the trigger's
+`leading` slot as a prefix.
+
+<Preview background="var(--bg-base)">
+  <SelectFacetedBasicDemo client:load />
+  <style is:inline>{`
+    /* Result chips size to their value (field-sizing) and cap at a max-width,
+       ellipsizing past it — the .sf-chip class is only for this demo. */
+    .sf-chip { width: fit-content; max-width: 220px; }
+    .sf-chip::part(input) { field-sizing: content; text-overflow: ellipsis; }
+  `}</style>
+</Preview>
+
+```tsx folded
+const FACETS = [
+  { key: 'assignee', label: 'Assignee', kind: 'multiple', filter: true, options: people },
+  { key: 'owner',    label: 'Owner',    kind: 'single',   filter: true, options: people },
+  { key: 'status',   label: 'Status',   kind: 'single',   options: [{ value: 'open', label: 'Open' }, /* … */] },
+  { key: 'title',    label: 'Title contains', kind: 'text' },
+  { key: 'duration', label: 'Min duration', kind: 'custom', summary: (v) => `≥ ${v.min}s`, render: /* … */ },
+]
+
+function Demo() {
+  const [value, setValue] = useState({ assignee: ['Alice Nguyen'], status: 'open' })
+  const active = FACETS.filter((f) => isSet(value[f.key]))
+  const setFacet = (key, v) => setValue((p) => (isSet(v) ? { ...p, [key]: v } : omit(p, key)))
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 12, alignItems: 'center' }}>
+      <SelectFaceted facets={FACETS} value={value} onValueChange={setValue} searchable />
+
+      {/* Each result is its own control, the facet key piped into `leading`:
+          options facets → a Select, free-form / custom facets → an Input. */}
+      {active.map((facet) =>
+        facet.kind === 'single' || facet.kind === 'multiple' ? (
+          <Select
+            key={facet.key}
+            selection={facet.kind}
+            options={facet.options}
+            value={value[facet.key]}
+            onValueChange={(v) => setFacet(facet.key, v)}
+            leading={`${facet.label}:`}
+          />
+        ) : (
+          <Input
+            key={facet.key}
+            value={facet.kind === 'text' ? value[facet.key] : value[facet.key].min}
+            leading={`${facet.label}:`}
+            clearable
+            onInput={(e) => setFacet(facet.key, /* text → string, custom → { min } */ e.currentTarget.value)}
+          />
+        ),
+      )}
+    </div>
+  )
+}
+```
+
+<Disclosure title="Component props" open>
+
+<PropsTable component="SelectFaceted" />
+
+</Disclosure>

--- a/site/src/pages/select-faceted.mdx
+++ b/site/src/pages/select-faceted.mdx
@@ -84,6 +84,7 @@ function Demo() {
             <Select
               key={facet.key}
               selection={facet.kind}
+              indicator={facet.kind === 'single' ? 'check' : undefined}
               options={facet.options}
               value={value[facet.key]}
               onValueChange={(v) => setFacet(facet.key, v)}

--- a/src/components/Select.module.css
+++ b/src/components/Select.module.css
@@ -19,7 +19,8 @@
 }
 
 /* The `clearable` "Clear" row, pinned in the Menu's footer slot: a hairline
-   separator above it and a 4px inset so the row lines up with the options. */
+   separator above it and a 4px inset so the row lines up with the options.
+   Duplicated in SelectFaceted.module.css `.footer` — keep the two in sync. */
 .footer {
   padding: var(--menu-padding, 4px);
   border-top: 1px solid var(--border-4);

--- a/src/components/Select.module.css
+++ b/src/components/Select.module.css
@@ -17,3 +17,10 @@
      the gap to the first row comes from the scroll body's top padding. */
   padding: 4px 4px 0;
 }
+
+/* The `clearable` "Clear" row, pinned in the Menu's footer slot: a hairline
+   separator above it and a 4px inset so the row lines up with the options. */
+.footer {
+  padding: var(--menu-padding, 4px);
+  border-top: 1px solid var(--border-4);
+}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -124,8 +124,10 @@ export interface TriggerState {
 
 /** Snapshot passed as the 2nd argument to `onValueChange` — describes *what*
  *  changed, alongside the new full value in the 1st argument. A discriminated
- *  union: a row toggle carries `value` + `option`; the "Select all" row carries
- *  `all: true` instead. Narrow on `'all' in attrs` before reading `option`. */
+ *  union: a row toggle carries `value` + `option`; a bulk change (the "Select all"
+ *  row, or the `clearable` "Clear" footer) carries `all: true` instead. **Always
+ *  narrow on `'all' in attrs` before reading `option`** — the `all` variant fires
+ *  for single-select too (via `clearable`), not just multiple. */
 export type SelectChangeAttrs =
   | {
       /** The option value that changed — the chosen value (single) or the toggled
@@ -137,9 +139,11 @@ export type SelectChangeAttrs =
       selected?: boolean
     }
   | {
-      /** Marks the change as coming from the "Select all" row (multiple only). */
+      /** Marks the change as a bulk one with no single `option`: the "Select all"
+       *  row (multiple), or the `clearable` "Clear" footer (single or multiple). */
       all: true
-      /** Whether Select-all turned everything **on** (true) or cleared it. */
+      /** Whether the bulk change turned everything **on** (true) or cleared it
+       *  (false — always false for a "Clear"). */
       selected: boolean
     }
 
@@ -236,8 +240,10 @@ export interface SelectCommonProps extends Omit<BaseProps, 'children'> {
    *  the menu anchors to it (its own previous DOM sibling) and opens it on click,
    *  so a fragment, multiple siblings, or a non-focusable wrapper will misanchor
    *  (the menu warns in the console if the trigger has no focusable element). Give
-   *  the element `aria-haspopup="menu"` plus `aria-expanded={state.open}`. The field
-   *  props (`label`, `hint`, `size`, `status`, `placeholder`, `round`) don't apply. */
+   *  the element `aria-haspopup="menu"` plus `aria-expanded={state.open}`. The custom
+   *  trigger owns its own styling: the field props (`label`, `hint`, `size`, `status`,
+   *  `placeholder`, `round`) and `className` / `style` apply to the *default* trigger
+   *  only — put your own on the element you return. */
   renderTrigger?: (state: TriggerState) => React.ReactNode
   /** Render content in the menu body when the (filtered) option list is empty —
    *  a "no results" message, a loading indicator (gated on your own external
@@ -609,11 +615,13 @@ export const Select = (props: SelectProps) => {
     if (!controlled) setInternal(next)
     emit?.(next, { all: true, selected: !allSelected })
   }
-  // Footer "Clear": empty the selection (single → '', multiple → []).
+  // Footer "Clear": empty the selection (single → undefined, multiple → []). Single
+  // must clear to `undefined`, not '': `selectedValues` treats '' as a present pick,
+  // which would keep the footer's Clear row visible with nothing to clear.
   const clear = () => {
-    const next: string | string[] = multiple ? [] : ''
+    const next = multiple ? [] : undefined
     if (!controlled) setInternal(next)
-    emit?.(next, { all: true, selected: false })
+    emit?.(next as string | string[], { all: true, selected: false })
   }
 
   // One option row. `disabled` is the leaf's *effective* disabled (cascaded).

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -209,6 +209,13 @@ export interface SelectCommonProps extends Omit<BaseProps, 'children'> {
   /** Label for the `selectAll` row.
    *  @defaultValue Select all */
   selectAllLabel?: string
+  /** Add a "Clear" row pinned in the menu **footer** that empties the selection
+   *  (single → none, multiple → `[]`). Shown only while something is selected, so
+   *  it never scrolls away in a long or filtered list. */
+  clearable?: boolean
+  /** Label for the `clearable` footer row.
+   *  @defaultValue Clear */
+  clearLabel?: string
   /** Render the **content** of each option row yourself, replacing the built-in
    *  `label`/`hint`/`icon` layout. Select still supplies the row box, click, ARIA,
    *  and the selection indicator — you return only what goes *inside*. Read extra
@@ -425,6 +432,8 @@ export const Select = (props: SelectProps) => {
     filter,
     selectAll,
     selectAllLabel = 'Select all',
+    clearable,
+    clearLabel = 'Clear',
     renderOption,
     renderIndicator,
     renderTrigger,
@@ -599,6 +608,12 @@ export const Select = (props: SelectProps) => {
     const next = allSelected ? keep : [...keep, ...enabledValues]
     if (!controlled) setInternal(next)
     emit?.(next, { all: true, selected: !allSelected })
+  }
+  // Footer "Clear": empty the selection (single → '', multiple → []).
+  const clear = () => {
+    const next: string | string[] = multiple ? [] : ''
+    if (!controlled) setInternal(next)
+    emit?.(next, { all: true, selected: false })
   }
 
   // One option row. `disabled` is the leaf's *effective* disabled (cascaded).
@@ -815,6 +830,12 @@ export const Select = (props: SelectProps) => {
           : flattening
             ? renderFlat()
             : renderTree(options, false)}
+        {clearable && selectedValues.length > 0 && (
+          // Pinned in the footer so it never scrolls away in a long / filtered list.
+          <div slot="footer" className={styles.footer}>
+            <MenuItem icon="x" label={clearLabel} data-menu-open="" onSelect={clear} />
+          </div>
+        )}
       </Menu>
     </>
   )

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -169,6 +169,11 @@ export interface SelectCommonProps extends Omit<BaseProps, 'children'> {
    *  `leading` slot). With a custom `renderTrigger`, it's passed through as
    *  `state.icon` instead — the consumer places it. */
   icon?: IconShape
+  /** Arbitrary content for the default trigger's leading slot (piped straight to
+   *  `Input`'s `leading`) — e.g. a key prefix before the value. Overrides the
+   *  `icon`-derived glyph when both are set; include your own `<Icon>` if you want
+   *  one alongside. Ignored with a custom `renderTrigger`. */
+  leading?: React.ReactNode
   /** Field label, above the trigger (Input's `label`). */
   label?: string
   /** Helper text under the field (Input's `hint`). */
@@ -408,6 +413,7 @@ export const Select = (props: SelectProps) => {
     onValueChange,
     placeholder,
     icon,
+    leading,
     label,
     hint,
     size,
@@ -722,7 +728,7 @@ export const Select = (props: SelectProps) => {
         readOnly
         dimActions
         disabled={disabled}
-        leading={icon ? <Icon shape={icon} /> : undefined}
+        leading={leading ?? (icon ? <Icon shape={icon} /> : undefined)}
         size={size}
         status={status}
         statusIcon={statusIcon}

--- a/src/components/SelectFaceted.module.css
+++ b/src/components/SelectFaceted.module.css
@@ -1,0 +1,14 @@
+.search {
+  /* The global search field, pinned in the menu header. 4px inset matches the
+     scroll body so the field lines up with the rows below it. */
+  padding: var(--menu-padding, 4px);
+}
+
+.footer {
+  /* Pins the "Clear" action below the scrolling options with a hairline separator,
+     so it never scrolls away in a long or filtered list. The 4px inset matches the
+     menu scroll body's padding (--menu-padding) so the row lines up with the options
+     above it. */
+  padding: var(--menu-padding, 4px);
+  border-top: 1px solid var(--border-4);
+}

--- a/src/components/SelectFaceted.module.css
+++ b/src/components/SelectFaceted.module.css
@@ -8,7 +8,7 @@
   /* Pins the "Clear" action below the scrolling options with a hairline separator,
      so it never scrolls away in a long or filtered list. The 4px inset matches the
      menu scroll body's padding (--menu-padding) so the row lines up with the options
-     above it. */
+     above it. Duplicated in Select.module.css `.footer` — keep the two in sync. */
   padding: var(--menu-padding, 4px);
   border-top: 1px solid var(--border-4);
 }

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -7,7 +7,8 @@
 //
 // Hooks come from the jsx-runtime indirection (configurable via `configure()`),
 // not a hard `react` import — same rule as `Select` / `RadioGroup`.
-import { useState } from '../jsx-runtime'
+import { useState, useMemo } from '../jsx-runtime'
+import { nativeStateChange } from '../anta_helpers'
 import type { BaseProps } from '../general_types'
 import type { IconShape } from '../elements/a-icon.shapes'
 import type { SelectItem, SelectOption } from './Select'
@@ -186,7 +187,9 @@ export interface SelectFacetedProps extends Omit<BaseProps, 'children'> {
   /** Render your own trigger in place of the default `Button`. Receives a
    *  `SelectFacetedTriggerState`; **return exactly one focusable element** (the
    *  menu anchors to it as its previous sibling and opens it on click). Give it
-   *  `aria-haspopup="menu"` plus `aria-expanded={state.open}`. */
+   *  `aria-haspopup="menu"` plus `aria-expanded={state.open}`. The custom trigger
+   *  owns its own styling — `className` / `style` / other props apply to the
+   *  *default* trigger only, so put your own on the element you return. */
   renderTrigger?: (state: SelectFacetedTriggerState) => React.ReactNode
 }
 
@@ -214,12 +217,14 @@ const leavesOf = (items: SelectItem[]): SelectOption[] => {
 const isEmpty = (v: unknown): boolean =>
   v == null || v === '' || (Array.isArray(v) && v.length === 0)
 
-/** The built-in filter matcher — case-insensitive substring of an option's
- *  value / label / hint (matching `Select`'s default). */
+/** The built-in filter matcher — case-insensitive, with each run of whitespace in
+ *  the query matching any gap (`\s+`), matching `Select`'s default matcher exactly. */
+const escapeRe = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 const defaultMatch = (o: SelectOption, query: string): boolean => {
-  const q = query.trim().toLowerCase()
+  const q = query.trim()
   if (!q) return true
-  return [o.value, o.label, o.hint].some((v) => typeof v === 'string' && v.toLowerCase().includes(q))
+  const re = new RegExp(q.split(/\s+/).map(escapeRe).join('\\s+'), 'i')
+  return [o.value, o.label, o.hint].some((v) => typeof v === 'string' && re.test(v))
 }
 
 /**
@@ -310,11 +315,25 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
   // global search, the facet key for a per-facet filter.
   const [activeIds, setActiveIds] = useState<Record<string, string | null>>({})
   const onActive = (key: string) => (e: any) => {
-    const id = ((e.nativeEvent ?? e).detail?.id) ?? null
+    const id = nativeStateChange<{ id: string | null }>(e).detail?.id ?? null
     setActiveIds((s) => (s[key] === id ? s : { ...s, [key]: id }))
   }
 
   const activeCount = facets.reduce((n, f) => n + (isEmpty(current[f.key]) ? 0 : 1), 0)
+
+  // Flatten each options facet's leaves once per `facets` change — visibleLeavesOf,
+  // renderFlatResults, and summaryOf all read this instead of re-running the recursive
+  // leavesOf() on every render / global-search keystroke.
+  const leavesByKey = useMemo(
+    () =>
+      new Map<string, SelectOption[]>(
+        facets.map((f) => [
+          f.key,
+          f.kind === 'single' || f.kind === 'multiple' ? leavesOf(f.options) : [],
+        ]),
+      ),
+    [facets],
+  )
 
   const commit = (next: SelectFacetedValue, attrs: SelectFacetedChangeAttrs) => {
     if (!controlled) setInternal(next)
@@ -335,7 +354,7 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
 
   // Leaves of an options facet, narrowed by its filter query when `filter` is on.
   const visibleLeavesOf = (facet: SelectFacetSingle | SelectFacetMultiple): SelectOption[] => {
-    const leaves = leavesOf(facet.options)
+    const leaves = leavesByKey.get(facet.key) ?? []
     if (!facet.filter) return leaves
     const q = queries[facet.key] ?? ''
     const match = typeof facet.filter === 'function' ? facet.filter : defaultMatch
@@ -445,7 +464,7 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
       .filter((f): f is SelectFacetSingle | SelectFacetMultiple => f.kind === 'single' || f.kind === 'multiple')
       .map((facet) => {
         const match = typeof facet.filter === 'function' ? facet.filter : defaultMatch
-        return { facet, matched: leavesOf(facet.options).filter((o) => match(o, rootQuery)) }
+        return { facet, matched: (leavesByKey.get(facet.key) ?? []).filter((o) => match(o, rootQuery)) }
       })
       .filter((g) => g.matched.length > 0)
     return groups.map(({ facet, matched }) => (
@@ -458,7 +477,12 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
   const renderText = (facet: SelectFacetText) => {
     const applied = (current[facet.key] as string | undefined) ?? ''
     const draft = drafts[facet.key] ?? applied
-    const apply = () => setFacet(facet, draft.trim() || undefined)
+    // Commit only when the draft actually differs from the committed value, so a
+    // focus/blur with no edit doesn't fire a spurious onValueChange.
+    const apply = () => {
+      const next = draft.trim() || undefined
+      if (next !== (applied || undefined)) setFacet(facet, next)
+    }
     return (
       // `data-menu-open` keeps the menu open through typing; the value commits on
       // Enter / blur, not per keystroke.
@@ -529,7 +553,7 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
     if (isEmpty(v)) return null
     switch (facet.kind) {
       case 'single': {
-        const opt = leavesOf(facet.options).find((o) => o.value === v)
+        const opt = (leavesByKey.get(facet.key) ?? []).find((o) => o.value === v)
         return opt?.label ?? String(v)
       }
       case 'multiple':

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -280,6 +280,26 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
   const [open, setOpen] = useState(false)
   // Text-facet drafts — the value only commits to `current` on Enter / blur.
   const [drafts, setDrafts] = useState<Record<string, string>>({})
+  // Re-seed a text draft when its committed value changes from OUTSIDE this editor
+  // (cleared elsewhere, controlled update). Adjust-state-during-render, guarded per key
+  // by the last value seen — so active typing (draft diverged, value unchanged) is
+  // never clobbered, but an external change flows into the field.
+  const [seenText, setSeenText] = useState<Record<string, unknown>>({})
+  {
+    let nextSeen: Record<string, unknown> | null = null
+    let nextDrafts = drafts
+    for (const f of facets) {
+      if (f.kind !== 'text') continue
+      if (seenText[f.key] !== current[f.key]) {
+        nextSeen = { ...(nextSeen ?? seenText), [f.key]: current[f.key] }
+        nextDrafts = { ...nextDrafts, [f.key]: (current[f.key] as string) ?? '' }
+      }
+    }
+    if (nextSeen) {
+      setSeenText(nextSeen)
+      setDrafts(nextDrafts)
+    }
+  }
   // Per-facet option-filter queries (for facets with `filter`).
   const [queries, setQueries] = useState<Record<string, string>>({})
   // The global search query (for `searchable`) — resets when the menu closes.

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -1,0 +1,612 @@
+// SelectFaceted — a faceted filter control. Composed like `Select` (there is no
+// `a-select-faceted` element): a trigger `Button` followed by a `Menu` whose rows
+// are per-facet submenu flyouts, each carrying its own editor (single / multiple /
+// text / custom). The value is a `Record<facetKey, perKindValue>`, so the same
+// option value can live under two facets (assignee "alice", owner "alice") without
+// colliding — identity is (facetKey, value), not the bare value.
+//
+// Hooks come from the jsx-runtime indirection (configurable via `configure()`),
+// not a hard `react` import — same rule as `Select` / `RadioGroup`.
+import { useState } from '../jsx-runtime'
+import type { BaseProps } from '../general_types'
+import type { IconShape } from '../elements/a-icon.shapes'
+import type { SelectItem, SelectOption } from './Select'
+import { Button } from './Button'
+import { Menu } from './Menu'
+import { MenuItem } from './MenuItem'
+import { MenuGroup } from './MenuGroup'
+import { MenuSeparator } from './MenuSeparator'
+import { Tag } from './Tag'
+import { Input } from './Input'
+import styles from './SelectFaceted.module.css'
+
+// ---- Facet config -------------------------------------------------------
+
+interface FacetBase {
+  /** The facet's namespace — the key its value is stored under in the value
+   *  record, and what `onValueChange`'s `attrs.facet` reports. Unique across
+   *  `facets`. */
+  key: string
+  /** The facet's row label in the menu. */
+  label: string
+  /** Leading icon on the facet's row. */
+  icon?: IconShape
+}
+
+/** A per-facet option-list filter (like `Select`'s `filter`): `true` uses the
+ *  built-in case-insensitive substring match on an option's value / label /
+ *  hint; a function `(option, query) => boolean` does custom matching. */
+export type FacetFilter = boolean | ((option: SelectOption, query: string) => boolean)
+
+/** Pick **one** option. Value: the chosen option's `value` string (or
+ *  `undefined` when cleared). Re-picking the selected option clears it. Options
+ *  are `Select`'s `SelectItem`s — bare strings or `SelectOption`s carrying the
+ *  same fields (`value`, `label`, `hint`, `icon`, `tone`, `disabled`). */
+export interface SelectFacetSingle extends FacetBase {
+  kind: 'single'
+  /** The options — bare strings or `SelectOption`s (groups / submenus are
+   *  flattened to their leaves). */
+  options: SelectItem[]
+  /** Add a search field atop this facet's flyout that filters its options. */
+  filter?: FacetFilter
+}
+
+/** Pick **any number** of options. Value: an array of the chosen `value`
+ *  strings (empty array clears the facet). Options are the same `SelectItem`s
+ *  as `single`. */
+export interface SelectFacetMultiple extends FacetBase {
+  kind: 'multiple'
+  /** The options — bare strings or `SelectOption`s (groups / submenus flattened). */
+  options: SelectItem[]
+  /** Add a search field atop this facet's flyout that filters its options. */
+  filter?: FacetFilter
+  /** Add a "Select all" row that toggles every option. */
+  selectAll?: boolean
+  /** Label for the `selectAll` row.
+   *  @defaultValue Select all */
+  selectAllLabel?: string
+}
+
+/** Free-form substring. Value: the typed string (or `undefined` when empty).
+ *  Applies on Enter or blur — not on every keystroke. */
+export interface SelectFacetText extends FacetBase {
+  kind: 'text'
+  /** Placeholder for the text field. */
+  placeholder?: string
+}
+
+/** Context handed to a `custom` facet's `render`. */
+export interface SelectFacetCustomContext<V> {
+  /** The facet's current value (`undefined` when unset). */
+  value: V | undefined
+  /** Apply a new value for this facet — pass `undefined` to clear it. */
+  onChange: (next: V | undefined) => void
+  /** Close the whole filter menu (e.g. after applying from a custom editor). */
+  close: () => void
+}
+
+/** Bring your own editor and value type — the escape hatch for anything the
+ *  built-in kinds don't cover, including object-shaped values (a date range, a
+ *  numeric comparator, …). */
+export interface SelectFacetCustom<V = unknown> extends FacetBase {
+  kind: 'custom'
+  /** Render the facet's editor inside its flyout. The returned node stays
+   *  mounted while the menu is open. */
+  render: (ctx: SelectFacetCustomContext<V>) => React.ReactNode
+  /** Reduce an active value to a short summary shown on the facet's row (a
+   *  string or any node). Called only when the value is set. */
+  summary: (value: V) => React.ReactNode
+}
+
+/** One facet (dimension) of the filter, discriminated by `kind`. */
+export type SelectFacet =
+  | SelectFacetSingle
+  | SelectFacetMultiple
+  | SelectFacetText
+  | SelectFacetCustom
+
+/** The filter value: a facet key → that facet's value. Per kind the value is a
+ *  `string` (single / text), a `string[]` (multiple), or your own `V` (custom).
+ *  A cleared facet is absent from the record (not a falsy entry). */
+export type SelectFacetedValue = Record<string, unknown>
+
+/** Second argument to `onValueChange` — what changed. A single-facet edit
+ *  carries `facet` / `kind` / the facet's new `value`; the "Clear all" row
+ *  carries `all: true`. Narrow on `'all' in attrs`. */
+export type SelectFacetedChangeAttrs =
+  | {
+      /** The facet key that changed. */
+      facet: string
+      /** That facet's kind. */
+      kind: SelectFacet['kind']
+      /** The facet's new value (`undefined` when the facet was cleared). */
+      value: unknown
+    }
+  | {
+      /** Marks the change as the "Clear all" row emptying every facet. */
+      all: true
+    }
+
+/** Snapshot passed to `renderTrigger` so a custom trigger can reflect the
+ *  current filter and open state. */
+export interface SelectFacetedTriggerState {
+  /** Whether the menu is open — use it for `aria-expanded` and a chevron. */
+  open: boolean
+  /** The whole current value record. */
+  value: SelectFacetedValue
+  /** Number of **active facets** (each facet with a value counts once,
+   *  regardless of how many options it holds) — the default badge count. */
+  count: number
+  /** Whether the whole control is disabled. */
+  disabled: boolean
+}
+
+export interface SelectFacetedProps extends Omit<BaseProps, 'children'> {
+  /** The facets (dimensions) to filter across, each with its own editor kind. */
+  facets: SelectFacet[]
+  /** Controlled value — the facet-keyed record. When provided, the consumer
+   *  owns state: a pick only *requests* a change via `onValueChange` (reject by
+   *  not updating). Leave undefined for uncontrolled. */
+  value?: SelectFacetedValue
+  /** Initial value for the uncontrolled case (the wrapper then owns it). */
+  defaultValue?: SelectFacetedValue
+  /** Fires after any facet changes, with the new full value record and an
+   *  attrs snapshot of what changed. */
+  onValueChange?: (value: SelectFacetedValue, attrs: SelectFacetedChangeAttrs) => void
+  /** Default trigger's button label.
+   *  @defaultValue Filter */
+  label?: string
+  /** Default trigger's leading icon.
+   *  @defaultValue filter */
+  icon?: IconShape
+  /** Default trigger's button size.
+   *  @defaultValue medium */
+  size?: 'small' | 'medium' | 'large'
+  /** Default trigger's button priority.
+   *  @defaultValue secondary */
+  priority?: 'primary' | 'secondary'
+  /** Disable the whole control. */
+  disabled?: boolean
+  /** Add a single search field to the top of the root menu that flattens every
+   *  `single` / `multiple` facet's options into one list and searches across them
+   *  — typing "alice" surfaces it under both an Assignee and an Owner facet, each
+   *  selectable in place. `text` / `custom` facets are reachable when the search is
+   *  empty. Matching uses each facet's `filter` function if it has one, else the
+   *  built-in substring match. */
+  searchable?: boolean
+  /** Placeholder for the global search field.
+   *  @defaultValue Filter… */
+  searchPlaceholder?: string
+  /** Show the per-facet "Clear" row and the "Clear all" row.
+   *  @defaultValue true */
+  clearable?: boolean
+  /** Label for the "Clear all" row.
+   *  @defaultValue Clear all */
+  clearAllLabel?: string
+  /** Render your own trigger in place of the default `Button`. Receives a
+   *  `SelectFacetedTriggerState`; **return exactly one focusable element** (the
+   *  menu anchors to it as its previous sibling and opens it on click). Give it
+   *  `aria-haspopup="menu"` plus `aria-expanded={state.open}`. */
+  renderTrigger?: (state: SelectFacetedTriggerState) => React.ReactNode
+}
+
+// ---- Helpers ------------------------------------------------------------
+
+const normalizeOpt = (o: SelectOption | string): SelectOption =>
+  typeof o === 'string' ? { value: o, label: o } : o
+
+/** Flatten a facet's `options` (strings, options, groups, submenus) to leaf
+ *  `SelectOption`s — v1 renders a facet's choices as a flat list. */
+const leavesOf = (items: SelectItem[]): SelectOption[] => {
+  const out: SelectOption[] = []
+  for (const it of items) {
+    if (typeof it !== 'string' && Array.isArray((it as { submenu?: unknown }).submenu))
+      out.push(...leavesOf((it as { submenu: SelectItem[] }).submenu))
+    else if (typeof it !== 'string' && Array.isArray((it as { options?: unknown }).options))
+      out.push(...leavesOf((it as { options: SelectItem[] }).options))
+    else out.push(normalizeOpt(it as SelectOption | string))
+  }
+  return out
+}
+
+/** A facet value counts as unset when it's null/undefined, an empty string, or
+ *  an empty array. Such facets are absent from the value record and the count. */
+const isEmpty = (v: unknown): boolean =>
+  v == null || v === '' || (Array.isArray(v) && v.length === 0)
+
+/** The built-in filter matcher — case-insensitive substring of an option's
+ *  value / label / hint (matching `Select`'s default). */
+const defaultMatch = (o: SelectOption, query: string): boolean => {
+  const q = query.trim().toLowerCase()
+  if (!q) return true
+  return [o.value, o.label, o.hint].some((v) => typeof v === 'string' && v.toLowerCase().includes(q))
+}
+
+/**
+ * `<SelectFaceted>` — a faceted filter: one trigger opens a menu of facets
+ * (dimensions), each a submenu flyout with its own editor. Facet kinds:
+ * `'single'` (pick one), `'multiple'` (pick many), `'text'` (free-form
+ * substring, applied on Enter / blur), and `'custom'` (bring your own editor +
+ * value, including object-shaped values). The value is a
+ * `Record<facetKey, value>`, so the same option value under two facets stays
+ * distinct.
+ *
+ * Controlled (`value` + `onValueChange`) or uncontrolled (`defaultValue`).
+ * There is no `a-select-faceted` element — this wrapper is the coordinator.
+ *
+ * Requires `@antadesign/anta/elements` (client-side only).
+ *
+ * @example
+ * ```tsx
+ * <SelectFaceted
+ *   facets={[
+ *     { key: 'assignee', label: 'Assignee', kind: 'multiple', options: people },
+ *     { key: 'owner',    label: 'Owner',    kind: 'single',   options: people },
+ *     { key: 'title',    label: 'Title',    kind: 'text' },
+ *   ]}
+ *   value={filters}
+ *   onValueChange={setFilters}
+ * />
+ * ```
+ */
+export const SelectFaceted = (props: SelectFacetedProps) => {
+  const {
+    facets,
+    value,
+    defaultValue,
+    onValueChange,
+    label = 'Filter',
+    icon = 'filter',
+    size,
+    priority = 'secondary',
+    disabled,
+    searchable,
+    searchPlaceholder = 'Filter…',
+    clearable = true,
+    clearAllLabel = 'Clear all',
+    renderTrigger,
+    className,
+    style,
+    ...rest
+  } = props
+
+  const controlled = value !== undefined
+  // Uncontrolled selection lives here (component state re-render is allowed
+  // where element DOM mutation isn't).
+  const [internal, setInternal] = useState<SelectFacetedValue>(defaultValue ?? {})
+  const current = controlled ? value : internal
+  // The root menu is controlled so a `custom` facet's `close()` can dismiss it;
+  // submenus stay uncontrolled regardless.
+  const [open, setOpen] = useState(false)
+  // Text-facet drafts — the value only commits to `current` on Enter / blur.
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
+  // Per-facet option-filter queries (for facets with `filter`).
+  const [queries, setQueries] = useState<Record<string, string>>({})
+  // The global search query (for `searchable`) — resets when the menu closes.
+  const [rootQuery, setRootQuery] = useState('')
+  // Combobox active-option ids, reported by each menu's `activedescendant` event and
+  // reflected onto the owning filter field's `aria-activedescendant` (the element must
+  // not write that light-DOM attribute itself). Keyed by field: `__root__` for the
+  // global search, the facet key for a per-facet filter.
+  const [activeIds, setActiveIds] = useState<Record<string, string | null>>({})
+  const onActive = (key: string) => (e: any) => {
+    const id = ((e.nativeEvent ?? e).detail?.id) ?? null
+    setActiveIds((s) => (s[key] === id ? s : { ...s, [key]: id }))
+  }
+
+  const activeCount = facets.reduce((n, f) => n + (isEmpty(current[f.key]) ? 0 : 1), 0)
+
+  const commit = (next: SelectFacetedValue, attrs: SelectFacetedChangeAttrs) => {
+    if (!controlled) setInternal(next)
+    onValueChange?.(next, attrs)
+  }
+
+  const setFacet = (facet: SelectFacet, nextValue: unknown) => {
+    const cleared = isEmpty(nextValue)
+    const next = { ...current }
+    if (cleared) delete next[facet.key]
+    else next[facet.key] = nextValue
+    commit(next, { facet: facet.key, kind: facet.kind, value: cleared ? undefined : nextValue })
+  }
+
+  const clearAll = () => commit({}, { all: true })
+
+  // ---- Per-kind editors -------------------------------------------------
+
+  // Leaves of an options facet, narrowed by its filter query when `filter` is on.
+  const visibleLeavesOf = (facet: SelectFacetSingle | SelectFacetMultiple): SelectOption[] => {
+    const leaves = leavesOf(facet.options)
+    if (!facet.filter) return leaves
+    const q = queries[facet.key] ?? ''
+    const match = typeof facet.filter === 'function' ? facet.filter : defaultMatch
+    return leaves.filter((o) => match(o, q))
+  }
+
+  // A `slot="header"` filter field for an options facet (only when `filter` is set).
+  // Pinned above the scrolling options, like Select's filter.
+  const filterHeader = (facet: SelectFacetSingle | SelectFacetMultiple) =>
+    facet.filter ? (
+      <div slot="header" data-menu-open="" style={{ padding: '4px' }}>
+        <Input
+          // `data-menu-search` puts this flyout in combobox mode: a typed query
+          // pseudo-focuses the first match (arrow-nav, Enter selects), same as Select.
+          data-menu-search=""
+          size="small"
+          value={queries[facet.key] ?? ''}
+          placeholder="Filter…"
+          aria-label={`Filter ${facet.label}`}
+          aria-autocomplete="list"
+          aria-activedescendant={activeIds[facet.key] ?? undefined}
+          onInput={(e: any) => setQueries((s) => ({ ...s, [facet.key]: e.currentTarget.value }))}
+        />
+      </div>
+    ) : null
+
+  // One option row — the same whether it renders in a facet's flyout or in the
+  // flattened global-search results. Single uses a trailing check (re-pick clears);
+  // multiple uses a checkbox (toggles). `keyPrefix` namespaces the React key so the
+  // same option value under two facets stays a distinct row in the flat list.
+  const optionRow = (facet: SelectFacetSingle | SelectFacetMultiple, opt: SelectOption, keyPrefix = '') => {
+    const shared = {
+      icon: opt.icon,
+      label: opt.label ?? opt.value,
+      hint: opt.hint,
+      tone: opt.tone,
+      disabled: opt.disabled,
+      'data-menu-open': '',
+    }
+    if (facet.kind === 'single') {
+      const cur = current[facet.key] as string | undefined
+      return (
+        <MenuItem
+          key={`${keyPrefix}${opt.value}`}
+          {...shared}
+          selectionIndicator="check"
+          selected={cur === opt.value}
+          onSelect={() => setFacet(facet, cur === opt.value ? undefined : opt.value)}
+        />
+      )
+    }
+    const arr = (current[facet.key] as string[] | undefined) ?? []
+    return (
+      <MenuItem
+        key={`${keyPrefix}${opt.value}`}
+        {...shared}
+        selectionIndicator="checkbox"
+        selected={arr.includes(opt.value)}
+        onSelect={() =>
+          setFacet(facet, arr.includes(opt.value) ? arr.filter((v) => v !== opt.value) : [...arr, opt.value])
+        }
+      />
+    )
+  }
+
+  const renderSingle = (facet: SelectFacetSingle) => visibleLeavesOf(facet).map((opt) => optionRow(facet, opt))
+
+  const renderMultiple = (facet: SelectFacetMultiple) => {
+    const arr = (current[facet.key] as string[] | undefined) ?? []
+    const leaves = visibleLeavesOf(facet)
+    // "Select all" acts on the *visible* (filtered) enabled options, like Select.
+    const enabled = leaves.filter((o) => !o.disabled).map((o) => o.value)
+    const allOn = enabled.length > 0 && enabled.every((v) => arr.includes(v))
+    const someOn = enabled.some((v) => arr.includes(v))
+    return (
+      <>
+        {facet.selectAll && leaves.length > 0 && (
+          <>
+            <MenuItem
+              selectionIndicator="checkbox"
+              selected={allOn}
+              indeterminate={someOn && !allOn}
+              label={facet.selectAllLabel ?? 'Select all'}
+              data-menu-open=""
+              onSelect={() =>
+                setFacet(
+                  facet,
+                  // Toggle only the visible set, preserving picks hidden by the filter.
+                  allOn ? arr.filter((v) => !enabled.includes(v)) : [...new Set([...arr, ...enabled])],
+                )
+              }
+            />
+            <MenuSeparator />
+          </>
+        )}
+        {leaves.map((opt) => optionRow(facet, opt))}
+      </>
+    )
+  }
+
+  // Global search: flatten every options facet into one grouped, searchable list.
+  // Each facet with matches becomes a MenuGroup (heading = facet label); a match
+  // under two facets shows once per facet, selectable in place. A facet's own
+  // `filter` function matches if set, else the built-in substring match.
+  const renderFlatResults = () => {
+    const groups = facets
+      .filter((f): f is SelectFacetSingle | SelectFacetMultiple => f.kind === 'single' || f.kind === 'multiple')
+      .map((facet) => {
+        const match = typeof facet.filter === 'function' ? facet.filter : defaultMatch
+        return { facet, matched: leavesOf(facet.options).filter((o) => match(o, rootQuery)) }
+      })
+      .filter((g) => g.matched.length > 0)
+    return groups.map(({ facet, matched }) => (
+      <MenuGroup key={facet.key} label={facet.label}>
+        {matched.map((opt) => optionRow(facet, opt, `${facet.key}:`))}
+      </MenuGroup>
+    ))
+  }
+
+  const renderText = (facet: SelectFacetText) => {
+    const applied = (current[facet.key] as string | undefined) ?? ''
+    const draft = drafts[facet.key] ?? applied
+    const apply = () => setFacet(facet, draft.trim() || undefined)
+    return (
+      // `data-menu-open` keeps the menu open through typing; the value commits on
+      // Enter / blur, not per keystroke.
+      <div data-menu-open="" style={{ padding: '4px' }}>
+        <Input
+          size="small"
+          value={draft}
+          placeholder={facet.placeholder}
+          aria-label={facet.label}
+          onInput={(e: any) => setDrafts((d) => ({ ...d, [facet.key]: e.currentTarget.value }))}
+          onKeyDown={(e: any) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              apply()
+            }
+          }}
+          onBlur={apply}
+        />
+      </div>
+    )
+  }
+
+  const renderCustom = (facet: SelectFacetCustom) => (
+    <div data-menu-open="">
+      {facet.render({
+        value: current[facet.key],
+        onChange: (next) => setFacet(facet, next),
+        close: () => setOpen(false),
+      })}
+    </div>
+  )
+
+  const renderEditor = (facet: SelectFacet) => {
+    const isOptions = facet.kind === 'single' || facet.kind === 'multiple'
+    const body =
+      facet.kind === 'single'
+        ? renderSingle(facet)
+        : facet.kind === 'multiple'
+          ? renderMultiple(facet)
+          : facet.kind === 'text'
+            ? renderText(facet)
+            : renderCustom(facet)
+    const hasValue = !isEmpty(current[facet.key])
+    return (
+      <Menu onactivedescendant={isOptions && facet.filter ? onActive(facet.key) : undefined}>
+        {isOptions && filterHeader(facet)}
+        {body}
+        {/* Clear rides the pinned `footer` slot, so it never scrolls away in a
+            long (or filtered) option list. Wrapped in a slotted div (MenuItem has
+            no `slot` prop) — the same pattern as Select's slot="header" filter. */}
+        {clearable && hasValue && (
+          <div slot="footer" className={styles.footer}>
+            <MenuItem
+              icon="x"
+              label="Clear"
+              data-menu-open=""
+              onSelect={() => setFacet(facet, undefined)}
+            />
+          </div>
+        )}
+      </Menu>
+    )
+  }
+
+  // Short summary shown as a Tag on the facet's row when it has a value.
+  const summaryOf = (facet: SelectFacet): React.ReactNode => {
+    const v = current[facet.key]
+    if (isEmpty(v)) return null
+    switch (facet.kind) {
+      case 'single': {
+        const opt = leavesOf(facet.options).find((o) => o.value === v)
+        return opt?.label ?? String(v)
+      }
+      case 'multiple':
+        return String((v as string[]).length)
+      case 'text':
+        return String(v)
+      case 'custom':
+        return facet.summary(v as never)
+    }
+  }
+
+  const triggerState: SelectFacetedTriggerState = {
+    open,
+    value: current,
+    count: activeCount,
+    disabled: !!disabled,
+  }
+
+  return (
+    <>
+      {renderTrigger ? (
+        renderTrigger(triggerState)
+      ) : (
+        <Button
+          icon={icon}
+          label={label}
+          priority={priority}
+          size={size}
+          disabled={disabled}
+          aria-haspopup="menu"
+          aria-expanded={open ? 'true' : 'false'}
+          className={className}
+          style={style}
+          {...rest}
+        >
+          {activeCount > 0 && (
+            <Tag size="small" priority="primary" tone="brand">
+              {String(activeCount)}
+            </Tag>
+          )}
+        </Button>
+      )}
+      {/* Anchors to the trigger (its previous sibling); opens on click. Controlled
+          so `custom` facets can `close()` it; user dismiss (Esc / outside-click)
+          fires onStateChange, which we apply — and clears the global search. */}
+      <Menu
+        open={open}
+        onStateChange={(_e, { next }) => {
+          setOpen(next)
+          if (!next) setRootQuery('')
+        }}
+        onactivedescendant={searchable ? onActive('__root__') : undefined}
+      >
+        {searchable && (
+          // Pinned global search: flattens all options facets while a query is active.
+          <div slot="header" data-menu-open="" className={styles.search}>
+            <Input
+              // Combobox mode: a typed query pseudo-focuses the first flattened match
+              // (arrow-nav, Enter selects), same as Select's filter.
+              data-menu-search=""
+              size="small"
+              value={rootQuery}
+              placeholder={searchPlaceholder}
+              aria-label="Filter all facets"
+              aria-autocomplete="list"
+              aria-activedescendant={activeIds['__root__'] ?? undefined}
+              onInput={(e: any) => setRootQuery(e.currentTarget.value)}
+            />
+          </div>
+        )}
+        {searchable && rootQuery.trim()
+          ? renderFlatResults()
+          : facets.map((facet) => (
+              <MenuItem key={facet.key} submenu icon={facet.icon} label={facet.label}>
+                {(() => {
+                  const s = summaryOf(facet)
+                  return s != null ? (
+                    <Tag size="small" tone="brand">
+                      {s}
+                    </Tag>
+                  ) : null
+                })()}
+                {renderEditor(facet)}
+              </MenuItem>
+            ))}
+        {clearable && (
+          <div slot="footer" className={styles.footer}>
+            <MenuItem
+              icon="filter-x"
+              label={clearAllLabel}
+              disabled={activeCount === 0}
+              data-menu-open=""
+              onSelect={clearAll}
+            />
+          </div>
+        )}
+      </Menu>
+    </>
+  )
+}

--- a/src/elements/a-input.css
+++ b/src/elements/a-input.css
@@ -121,7 +121,7 @@
     --input-text: var(--text-1);
     --input-label: var(--text-3);
     --input-placeholder: var(--text-4);
-    --input-adornment: var(--text-4);
+    --input-adornment: var(--text-3);
     --input-hint: var(--text-3);
 
     /* `display` is owned by the shadow `:host` (a grid) so consumer CSS can

--- a/src/elements/a-input.ts
+++ b/src/elements/a-input.ts
@@ -132,7 +132,10 @@ const SUPPORTS_FIELD_SIZING =
 //  • slots — leading/trailing/clear are display:none until they hold content
 //    (toggled via slotchange), so an empty slot reserves no box or phantom gap.
 //    Adornments are muted (--input-adornment) and inherit currentColor; a slotted
-//    <a-button> keeps its own colour. `dim-actions` rests them at 0.6 and brightens
+//    <a-button> keeps its own colour. Slotted TEXT gets the field's type scale
+//    (--_fs/--_lh) plus a condensed wdth 88, so a key prefix lines up with the value
+//    and reads as a compact label; icons carry their own explicit size + width.
+//    `dim-actions` rests them at 0.6 and brightens
 //    to full on field hover/focus — but never while disabled. The clear slot shows
 //    only when filled + editable (hidden when disabled/readonly). A leading item is
 //    inset to line up with the text's left rhythm. Single-line, adornments center
@@ -237,7 +240,13 @@ const SHADOW_STYLE = `
   input::-webkit-outer-spin-button { -webkit-appearance: none; appearance: none; display: none; }
   input::-ms-clear, input::-ms-reveal { display: none; }
 
-  slot[name="leading"], slot[name="trailing"] { display: none; color: var(--input-adornment); }
+  slot[name="leading"], slot[name="trailing"] {
+    display: none;
+    color: var(--input-adornment);
+    font-size: var(--_fs);
+    line-height: var(--_lh);
+    font-variation-settings: "wdth" 88, "slnt" 0, "ital" 0;
+  }
   .field.has-leading slot[name="leading"],
   .field.has-trailing slot[name="trailing"] {
     display: flex;

--- a/src/elements/a-menu-item.css
+++ b/src/elements/a-menu-item.css
@@ -139,6 +139,17 @@
     pointer-events: none;
   }
 
+  /* The standalone checkbox / radio offsets its box (::before) + glyph (::after) with a
+     margin-block-start to sit on a label's first-line centre (see a-checkbox.css /
+     a-radio.css). In a menu the mark is label-less and the row centres it, so that
+     compensation drops it a touch low — zero it to keep the mark on the row's centre. */
+  a-menu-item > a-checkbox::before,
+  a-menu-item > a-checkbox::after,
+  a-menu-item > a-radio::before,
+  a-menu-item > a-radio::after {
+    margin-block-start: 0;
+  }
+
   /* A leading mark (icon, checkbox, radio, or a custom `[data-indicator]`) reads
      better with the left padding pulled in to equal the vertical padding, so the mark
      hugs the corner symmetrically instead of floating in the wider inline inset. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,19 @@ export type {
   SelectedSubmenu,
   SelectedItem,
 } from './components/Select'
+export { SelectFaceted } from './components/SelectFaceted'
+export type {
+  SelectFacetedProps,
+  SelectFacet,
+  SelectFacetSingle,
+  SelectFacetMultiple,
+  SelectFacetText,
+  SelectFacetCustom,
+  SelectFacetCustomContext,
+  SelectFacetedValue,
+  SelectFacetedChangeAttrs,
+  SelectFacetedTriggerState,
+} from './components/SelectFaceted'
 export { Tabs } from './components/Tabs'
 export type { TabsProps, TabOption, TabsChangeAttrs } from './components/Tabs'
 export { TabPanel } from './components/TabPanel'


### PR DESCRIPTION
## Summary

Adds **`SelectFaceted`** — a Linear-style faceted filter — plus supporting changes to `Select` and `Input`. **Draft: docs prose + CHANGELOG still to come.**

### `SelectFaceted` (new)
A trigger opens a menu of **facets** (dimensions); each is a submenu flyout with its own editor. Value is a `Record<facetKey, value>`, so the same option value under two facets (assignee "Alice" / owner "Alice") stays distinct — identity is `(facetKey, value)`, not the bare value.

Facet `kind`s:
- **`single`** — pick one (value: `string`)
- **`multiple`** — pick many (value: `string[]`), optional `selectAll`
- **`text`** — free-form substring, applied on Enter/blur (value: `string`)
- **`custom`** — bring your own editor + value, incl. objects (`render` + `summary`)

Features: per-facet **`filter`** (search field in a flyout), opt-in **`searchable`** global flatten-search across all options facets, **combobox pseudo-focus** on every filter field (`data-menu-search`, first match active, arrow-nav, Enter selects), per-facet **Clear** + **Clear all** pinned in the menu footer, count badge (active facets), controlled/uncontrolled. Pure composition over `Menu`/`Select`/`Input`/`Tag` — no new element.

### Supporting changes
- **`Select`** — new **`leading`** prop, piped to the trigger `Input`'s leading slot (e.g. a key prefix before the value).
- **`Input`** — leading/trailing slots now match the field's type scale (`--_fs`/`--_lh`) and use a condensed `wdth 88`, so slotted text reads as a compact, aligned label; **`--input-adornment` `--text-4` → `--text-3`**. *Consumer-facing:* affects every Input/Select/InputDate adornment (subtly darker + condensed slot text).
- **`a-menu-item`** — zero the checkbox/radio mark `margin-block-start` in menus (the offset only makes sense next to a label; menu marks are label-less and row-centered).

### Docs
- New **`/select-faceted`** page: Playground (above), a live left-aligned Preview whose results render as per-facet `Select`s (key in `leading`) / `Input`s (text & custom), and a Code expander. Sidebar entry **SelectFaceted**, page title **Faceted select**.
- **InputDate** page title → **Date input**.

## Not yet done (draft)
- Per-kind docs prose + `## Styling` section on the SelectFaceted page
- `Select.leading` note on the Select page
- `CHANGELOG.md` entries
- Decision to confirm: keep the site-wide `--input-adornment` → `--text-3` change, or scope it back

## Testing
- `pnpm run typecheck`, `pnpm run lint`, `pnpm --filter anta-site lint:css`, `pnpm run build` all pass
- Manual (Playwright): all four facet kinds, per-facet + global search, combobox pseudo-focus (first match active), footer Clear, count badge, result Select/Input chips, mark alignment
