### PR TITLE
fix(input-time): keep segment digits on one line

### DIFF
--- a/src/elements/a-input-time.ts
+++ b/src/elements/a-input-time.ts
@@ -145,6 +145,7 @@ const SHADOW_STYLE = `
     padding-inline: 1px;
     border-radius: 2px;
     text-align: center;
+    white-space: nowrap;
     outline: none;
     cursor: default;
     font-variant-numeric: tabular-nums;
@@ -153,7 +154,7 @@ const SHADOW_STYLE = `
   .seg[inputmode="numeric"] {
     /* Fixed to two tabular digits so the box never reflows: neither the narrower
        placeholder dashes nor a mid-entry single digit changes the field width. */
-    width: calc(2ch + 2px);
+    width: calc(2ch + 4px);
   }
   .seg:focus {
     background: var(--input-time-seg-focus-bg);


### PR DESCRIPTION
## Problem

In `InputTime`, a two-digit segment could wrap its digits onto two stacked lines — `09` rendering as `0` over `9`. It showed up most clearly in the docs' monospaced example (`::part(segments)` overriding the font):

<!-- before: 09/30 stacked -->

## Root cause

Each numeric segment is fixed to `width: calc(2ch + 2px)` (border-box, with `padding-inline: 1px` × 2), so the content box lands at exactly `2ch`. But `ch` is the font's *declared* "0" advance, and it can read a hair narrower than the actually-rendered digit pair:

- In the docs' monospace font, `1ch` resolves to **9.0px** while each digit paints at **9.2px** — so `09` renders at 18.4px against an 18.0px content box.
- The 0.4px overflow, under the **inherited `overflow-wrap: break-word`** (the site's global reset leaks into the shadow DOM — `overflow-wrap` is inherited), breaks the two digits onto separate lines.

`ch` scales with the font, so this isn't a "fixed width doesn't grow" bug — it's that `ch` under-measures the rendered advance by a sub-pixel amount, and the box had zero headroom.

## Fix

- **`white-space: nowrap` on `.seg`** — a segment's value never wraps regardless of the font's metrics. A fractionally-wide value overflows imperceptibly (centered) instead of stacking. This is the guarantee.
- **`calc(2ch + 2px)` → `calc(2ch + 4px)`** on numeric segments — a little headroom so the common default + monospace cases have breathing room rather than sitting flush against the box edge.

## Verification

Reproduced and fixed in the running docs site (`/input-time/`, monospaced demo): numeric-segment height went 30px → 15px (two lines → one), `09:30 AM` renders on a single line in both the default sans and the monospaced field. `pnpm run build` + `pnpm run typecheck` pass.

Scope: one shadow-style change in `src/elements/a-input-time.ts`. Covers standalone `InputTime` and `InputDate`'s time row (same element). No CHANGELOG entry per request.
