### PR TITLE
chore(release): 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump `@antadesign/anta` to **0.3.6** ahead of publish.

`0.3.6` is already the version documented in `CHANGELOG.md` and covers everything merged to main since 0.3.5: **Dialog**, **InputAutocomplete**, the Select/SelectFaceted `selectAll` defaults + `toneSelected` + isolate accelerator, the shared `select-options` helpers, and the tooltip empty-close fix.

Hand-edit of the `version` field only (no tag), matching the prior `chore(release): 0.3.5` / `0.3.4` commits. Merge, then publish (`npm publish --access public --tag dev` from root, then `pnpm publish` in `stickers/`).