### PR TITLE
docs(site): Anta logo links to anta.design

### DIFF
--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -214,8 +214,10 @@ if (isComponentPage && title) {
     <div class="layout">
       <aside class="sidebar">
         <span class="logo">
-          <img src="/anta-logo.svg" alt="" width="32" height="32" />
-          <span class="logo-label">Anta</span>
+          <a class="logo-home" href="https://anta.design/" aria-label="Anta home">
+            <img src="/anta-logo.svg" alt="" width="32" height="32" />
+            <span class="logo-label">Anta</span>
+          </a>
           <Button class="theme-toggle" priority="tertiary" size="large" aria-label="Switch theme">
             <Icon shape="sun" size={18} />
             <Icon shape="moon" size={18} />
@@ -509,8 +511,18 @@ if (isComponentPage && title) {
     border-radius: 8px;
   }
 
-  /* "Anta" wordmark fills the available space so the toggle sits
-     against the right edge of the sidebar's logo row. */
+  /* The logo (mark + wordmark) links home. It fills the row so the theme
+     toggle stays against the right edge; inherits the brand colour, no
+     underline. */
+  .logo-home {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+    color: inherit;
+    text-decoration: none;
+  }
   .logo .logo-label {
     flex: 1;
   }


### PR DESCRIPTION
The "Anta" logo (mark + wordmark) at the top of the sidebar is now a link to **https://anta.design/**, so it always returns to the canonical home.

- Wraps the logo image + wordmark in an `<a href="https://anta.design/" aria-label="Anta home">`; the theme toggle stays **outside** the link and right-aligned (the link takes the `flex: 1` that the wordmark used to).
- The mobile topbar "Anta" is left as-is — it's the menu-open toggle, not a home link.

Docs-site only. Verified: the logo renders as the anchor with the right href, the wordmark is inside it, and the theme toggle keeps its right-edge position.