### PR TITLE
fix(checkbox, radio): lighten mark colour

### DIFF
--- a/src/elements/a-checkbox.css
+++ b/src/elements/a-checkbox.css
@@ -22,7 +22,7 @@
     --checkbox-border-hover: #c1b9c1;
     --checkbox-border-active: #9f99a1;
 
-    --checkbox-icon: #f1eff1;
+    --checkbox-icon: #f6f4f6;
     --checkbox-icon-disabled: #c1b9c1;
     --checkbox-bg-disabled: color-mix(in oklch, #44374b 10%, transparent);
     --checkbox-border-disabled: color-mix(in oklch, #44374b 10%, transparent);
@@ -352,7 +352,7 @@
     --checkbox-fill-hover: #534c57;
     --checkbox-fill-active: #635b65;
 
-    --checkbox-icon: #d4ced4;
+    --checkbox-icon: #ece9ec;
     --checkbox-icon-disabled: #534c57;
     --checkbox-bg-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);
     --checkbox-border-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);

--- a/src/elements/a-radio.css
+++ b/src/elements/a-radio.css
@@ -29,7 +29,7 @@
     --radio-border-active: #9f99a1;
 
     /* Off-white dot, matching a-checkbox's checkmark glyph (was pure white). */
-    --radio-dot: #f1eff1;
+    --radio-dot: #f6f4f6;
     --radio-dot-disabled: #c1b9c1;
     --radio-bg-disabled: color-mix(in oklch, #44374b 10%, transparent);
     --radio-border-disabled: color-mix(in oklch, #44374b 10%, transparent);
@@ -373,7 +373,7 @@
     --radio-fill-hover: #534c57;
     --radio-fill-active: #635b65;
 
-    --radio-dot: #d4ced4;
+    --radio-dot: #ece9ec;
     --radio-dot-disabled: #534c57;
     --radio-bg-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);
     --radio-border-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);


### PR DESCRIPTION
Lift the checkbox checkmark glyph (`--checkbox-icon`) and the radio selected dot (`--radio-dot`) a step so both read lighter against the filled control. The two share the same value.

<img width="814" height="340" alt="Screenshot 2026-07-14 at 1 09 19 PM" src="https://github.com/user-attachments/assets/5a445f1b-2f1f-40a7-8eba-13a36f5ac7b6" />


| theme | before | after |
|---|---|---|
| light | `#f1eff1` | `#f6f4f6` |
| dark | `#d4ced4` | `#ece9ec` |

Verified on the docs site in both themes — the resolved glyph/dot colour matches the new values (`rgb(246, 244, 246)` / `rgb(236, 233, 236)`).

No `CHANGELOG.md` entry: visual-only tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)