### PR TITLE
chore(release): 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
+## 0.3.7 — July 15, 2026
+
+### Fixed
+- **`Menu` opens from the keyboard via the element, not a synthesized click.** `<a-menu>` now binds a keydown on its trigger anchor and opens itself: either arrow (ArrowUp / ArrowDown) on any field trigger, plus Enter / Space on a read-only trigger like `Select` (on an editable one like `InputDate` those stay with the field for typing / commit). Button and link triggers are unchanged — their own Enter/Space click still opens. Removes the `Select` / `InputDate` wrappers reaching for the live trigger node to call `.click()`, which threw in runtimes that reconcile the DOM off the main thread; any custom-trigger menu now gets keyboard-open for free.
+
+### Changed
+- **Read-only `Input` draws its focus ring on keyboard focus only.** A `readOnly` field (a `Select` / `SelectFaceted` trigger) rings when focused by keyboard but not by a mouse click that opens its menu. `:focus-visible` can't express this — a browser reports it `true` for a focused `<input>` on mouse click too — so `Input` tracks the focus source itself (last interaction: pointer vs. key) and rings via an off-DOM `:state(kb-focus)`. Editable fields are unchanged (they ring on any focus — you clicked in to type).
+
 ## 0.3.6 — July 13, 2026
 
 ### Added
@@ -14,11 +22,9 @@ Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main rele
 - **`Menu` / `MenuItem` / `Input` gain an optional `role` prop.** Overrides the element's default ARIA role (`Menu` `menu` → `listbox`, `MenuItem` `menuitem` → `option`), which is what lets `InputAutocomplete` present its dropdown as a combobox listbox.
 
 ### Fixed
-- **`Menu` opens from the keyboard via the element, not a synthesized click.** `<a-menu>` now binds a keydown on its trigger anchor and opens itself: either arrow (ArrowUp / ArrowDown) on any field trigger, plus Enter / Space on a read-only trigger like `Select` (on an editable one like `InputDate` those stay with the field for typing / commit). Button and link triggers are unchanged — their own Enter/Space click still opens. Removes the `Select` / `InputDate` wrappers reaching for the live trigger node to call `.click()`, which threw in runtimes that reconcile the DOM off the main thread; any custom-trigger menu now gets keyboard-open for free.
 - **`Tooltip` closes when its content is emptied while shown.** A bubble whose slotted content is cleared out from under it (a reactive re-render) now self-hides, the mirror of the show-time empty gate. Previously it stayed up as a blank frame.
 
 ### Changed
-- **Read-only `Input` draws its focus ring on keyboard focus only.** A `readOnly` field (a `Select` / `SelectFaceted` trigger) rings when focused by keyboard but not by a mouse click that opens its menu. `:focus-visible` can't express this — a browser reports it `true` for a focused `<input>` on mouse click too — so `Input` tracks the focus source itself (last interaction: pointer vs. key) and rings via an off-DOM `:state(kb-focus)`. Editable fields are unchanged (they ring on any focus — you clicked in to type).
 - **Menu combobox filter fields — Home / End move the caret.** In a menu's search field (`Select`'s `filter`, `InputAutocomplete`), Home / End now move the text caret to the line start / end instead of jumping the option list; PageUp / PageDown jump the list to the first / last option.
 - **`SelectFaceted` gains a `toneSelected` prop.** Tones a selected option row (e.g. `brand`), matching `Select`. Defaults to a neutral selection.
 - **`SelectFaceted` `multiple` facets gain the Alt/⌥-click isolate accelerator + hint.** Alt/⌥-click a row to select only it, taught by a default tooltip — matching `Select`. Tied to the facet's `selectAll`; override the hint via a row's `tooltip`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release **@antadesign/anta 0.3.7**.

Bumps `0.3.6 → 0.3.7` and moves the two consumer-facing changes from #108 into a new `0.3.7` CHANGELOG section — `0.3.6` already shipped to npm (`latest`) without them.

**Shipped in 0.3.7:**
- **Fixed** — `Menu` opens from the keyboard inside `<a-menu>` (both wrapper `.click()` calls gone; ArrowUp/Down open).
- **Changed** — read-only `Input` draws its focus ring on keyboard focus only, via an off-DOM `:state(kb-focus)`.

(The lint guard for `e.currentTarget`/`e.target` method calls also merged in #108 — internal tooling, not consumer-facing, so no changelog entry.)

After merge: publish `@antadesign/anta` from `main`. `@antadesign/stickers` is unchanged and needs no re-release.