### PR TITLE
fix: statechange no longer bubbles into an ancestor Dialog as a close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
+## Unreleased
+
+### Fixed
+- **A stateful control inside a controlled `Dialog` no longer closes it.** `Checkbox`, `Tabs`, and `RadioGroup` fired their `statechange` with `bubbles: true` / `composed: true`, so the event climbed to an enclosing `<a-dialog>` (or any ancestor listening for `statechange`), which read the descendant's payload in its own vocabulary — `next: "unchecked"` looked like a close request — and dismissed the dialog. Two layers: `statechange` is now point-to-point (neither bubbling nor composed) on every stateful element, matching `Menu` / `Dialog` / `Expander` / `Calendar`, which already were; and the container wrappers (`Dialog`, `Menu`, `Expander`) now ignore any `statechange` that bubbled from a descendant (`event.target !== event.currentTarget`), so a consumer's own or third-party bubbling control can't dismiss them either. The post-apply `change` event still bubbles like a native form control.
+
 ## 0.3.7 — July 15, 2026
 
 ### Fixed

--- a/STATEFUL-COMPONENTS.md
+++ b/STATEFUL-COMPONENTS.md
@@ -53,6 +53,20 @@ CustomEvent<{ next: State; prev: State }>   // cancelable: true; State = the att
 - `preventDefault()` vetoes the transition (see the control model). The element
   gates its own application on `dispatchEvent(evt)` returning `true`.
 - No booleans in the payload — never make a handler translate `true` into `"open"`.
+- **Neither bubbles nor composed.** `statechange` is a point-to-point *request*
+  to the element's own wrapper — which binds the listener on the host itself, in
+  the same light tree — not a notification meant for delegation. The name is
+  shared across every stateful element but the `detail` vocabulary is
+  per-component (`"open"` vs `"checked"` vs a value), so a bubbling event would
+  reach an ancestor listener that reads it in the wrong vocabulary: toggling a
+  `<Checkbox>` inside a controlled `<Dialog>` would surface as `next: "unchecked"`
+  on the dialog's handler, `!== "open"`, and dismiss the dialog. `composed: true`
+  is the shadow-boundary form of the same over-propagation and comes off with it.
+  This matches the native precedent — `<dialog>`'s `cancel` / `close` don't bubble
+  either, so a nested dialog's close isn't misread by an outer one.
+- The **post-apply `change`** event (checkbox / tabs / radio-group) is the
+  opposite: it *does* bubble (not composed), like a native form control's
+  `change` — that one is a notification, not a request.
 
 This mirrors the native cancelable-before pattern (`beforetoggle`, dialog
 `cancel`): fire before, let a handler veto, then apply — so a veto never flickers.

--- a/src/anta_helpers.ts
+++ b/src/anta_helpers.ts
@@ -30,12 +30,24 @@ export function wrapLabel(kids: React.ReactNode, tag: string): React.ReactNode {
  * the native event directly. Returns the native event and its `detail`. Shared by
  * every stateful wrapper (`Menu`, `Expander`, `Checkbox`, `RadioGroup`) — don't
  * re-implement it per component.
+ *
+ * `isOwn` is `true` when the event was dispatched on the element the listener is
+ * bound to (`target === currentTarget`), `false` when it bubbled up from a
+ * descendant. `statechange` is a shared event name with a per-component `detail`
+ * vocabulary, so a container wrapper (`Dialog`, `Menu`, `Expander`) that projects
+ * arbitrary children must gate on `isOwn` before acting: a foreign bubbling
+ * `statechange` from a nested control would otherwise be read in the wrong
+ * vocabulary (a checkbox toggle looking like a dialog close). Anta's own controls
+ * no longer bubble `statechange`, so this is defense-in-depth against consumer /
+ * third-party elements that do. Read synchronously during dispatch, so
+ * `currentTarget` is still live. (Read as `true` for the falsy-event guard so a
+ * missing event never spuriously reads as bubbled.)
  */
 export function nativeStateChange<D>(
   e: CustomEvent<D> | { nativeEvent: CustomEvent<D> },
-): { event: CustomEvent<D>; detail?: D } {
+): { event: CustomEvent<D>; detail?: D; isOwn: boolean } {
   const event = ('nativeEvent' in e ? e.nativeEvent : e) as CustomEvent<D>
-  return { event, detail: event?.detail }
+  return { event, detail: event?.detail, isOwn: !event || event.target === event.currentTarget }
 }
 
 // macOS labels the "isolate" accelerator ⌥ (Option); every other platform, Alt.

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -142,8 +142,12 @@ export const Dialog = ({
       onstatechange={
         onStateChange
           ? (e: StateChangeEvent) => {
-              const { event, detail } = nativeStateChange<StateChangeDetail>(e);
-              if (detail)
+              const { event, detail, isOwn } = nativeStateChange<StateChangeDetail>(e);
+              // Ignore a `statechange` bubbled up from a control inside the dialog
+              // (a Checkbox, a consumer's own element): its detail speaks a different
+              // vocabulary and would read as a spurious close. Only the dialog's own
+              // open/closed request counts. See nativeStateChange / STATEFUL-COMPONENTS.md.
+              if (isOwn && detail)
                 onStateChange(event, {
                   next: detail.next === "open",
                   prev: detail.prev === "open",

--- a/src/components/Expander.tsx
+++ b/src/components/Expander.tsx
@@ -152,8 +152,11 @@ export const Expander = ({
       onstatechange={
         onStateChange
           ? (e: StateChangeEvent) => {
-              const { event, detail } = nativeStateChange<StateChangeDetail>(e);
-              if (detail)
+              const { event, detail, isOwn } = nativeStateChange<StateChangeDetail>(e);
+              // Ignore a `statechange` bubbled from a control inside the expander;
+              // only the expander's own open/closed request counts. See
+              // nativeStateChange / STATEFUL-COMPONENTS.md.
+              if (isOwn && detail)
                 onStateChange(event, {
                   next: detail.next === "open",
                   prev: detail.prev === "open",

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -132,13 +132,14 @@ export const Menu = ({
       onstatechange={
         onStateChange
           ? (e: StateChangeEvent) => {
-              const { event, detail } = nativeStateChange<StateChangeDetail>(e)
+              const { event, detail, isOwn } = nativeStateChange<StateChangeDetail>(e)
               // Only the menu's own `statechange` (open/closed) counts. A stateful
-              // component slotted inside the menu — a `Calendar`, `Tabs`, … —
-              // dispatches its *own* bubbling `statechange` (detail.next is a date, a
-              // tab value, …) that reaches this ancestor listener; ignore those, or
-              // they'd read as a spurious close.
-              if (detail && (detail.next === 'open' || detail.next === 'closed'))
+              // component slotted inside the menu — a `Calendar`, `Tabs`, … — could
+              // dispatch its *own* bubbling `statechange` that reaches this ancestor
+              // listener; `isOwn` (target === currentTarget) drops those, or they'd
+              // read as a spurious close. More robust than matching the open/closed
+              // vocabulary, which a nested `Expander` would also satisfy.
+              if (isOwn && detail)
                 onStateChange(event, {
                   next: detail.next === 'open',
                   prev: detail.prev === 'open',

--- a/src/elements/a-checkbox.ts
+++ b/src/elements/a-checkbox.ts
@@ -129,11 +129,15 @@ export class ACheckboxElement extends HTMLElementBase {
     const prev = this.currentState;
     // Indeterminate resolves to checked; otherwise flip (native convention).
     const next: CheckboxState = prev === "checked" ? "unchecked" : "checked";
+    // `statechange` neither bubbles nor is composed: it's a point-to-point
+    // request to this element's own wrapper (which binds the listener on the
+    // host), not a notification. The name is shared across every stateful
+    // element but the `detail` vocabulary is per-component, so a bubbling one
+    // would reach an ancestor listener (e.g. a wrapping <a-dialog>) that reads
+    // it in the wrong vocabulary. See STATEFUL-COMPONENTS.md.
     const ok = this.dispatchEvent(
       new CustomEvent("statechange", {
         cancelable: true,
-        bubbles: true,
-        composed: true,
         detail: { next, prev },
       }),
     );

--- a/src/elements/a-radio-group.ts
+++ b/src/elements/a-radio-group.ts
@@ -199,7 +199,9 @@ export class ARadioGroupElement extends HTMLElementBase {
 
   /** Dispatch the shared `statechange` event. `reason` lets a controller tell a
    *  user pick (cancelable) apart from a form `reset` / bfcache `restore` (not).
-   *  `next` is `null` when nothing is selected (no default / reset-to-none). */
+   *  `next` is `null` when nothing is selected (no default / reset-to-none).
+   *  Neither bubbles nor composed — a point-to-point request to this element's
+   *  own wrapper, not a notification (see STATEFUL-COMPONENTS.md). */
   private emitStateChange(
     next: string | null,
     prev: string | null,
@@ -209,8 +211,6 @@ export class ARadioGroupElement extends HTMLElementBase {
     return this.dispatchEvent(
       new CustomEvent("statechange", {
         cancelable,
-        bubbles: true,
-        composed: true,
         detail: { next, prev, reason },
       }),
     );

--- a/src/elements/a-tabs.ts
+++ b/src/elements/a-tabs.ts
@@ -178,13 +178,13 @@ export class ATabsElement extends HTMLElementBase {
   }
 
   /** Dispatch the shared cancelable `statechange`. `next`/`prev` are values
-   *  (`null` when nothing is selected). Returns false if a listener vetoed. */
+   *  (`null` when nothing is selected). Returns false if a listener vetoed.
+   *  Neither bubbles nor composed — a point-to-point request to this element's
+   *  own wrapper, not a notification (see STATEFUL-COMPONENTS.md). */
   private emitStateChange(next: string | null, prev: string | null): boolean {
     return this.dispatchEvent(
       new CustomEvent("statechange", {
         cancelable: true,
-        bubbles: true,
-        composed: true,
         detail: { next, prev },
       }),
     );


### PR DESCRIPTION
## The bug

A stateful control (`Checkbox`, `Tabs`, `RadioGroup`, …) placed inside a **controlled `<Dialog>`** dismisses it. `statechange` was dispatched with `bubbles: true` / `composed: true`, so it climbed to the enclosing `<a-dialog>`. The dialog's `onstatechange` handler normalizes any `statechange` against its own `'open' | 'closed'` vocabulary, so a checkbox's `next: "unchecked"` became `next === "open"` → `false` → read as a close request, and a typical controlled handler (`if (!next) close()`) closed the dialog.

```tsx
const [open, setOpen] = useState(true)
<Dialog open={open} onStateChange={(_e, { next }) => { if (!next) setOpen(false) }}>
  <Checkbox label="toggle me" />   {/* clicking this closed the dialog */}
</Dialog>
```

Root cause is twofold: **one shared event name** (`statechange`) across every stateful component, with **per-component `detail` vocabulary**, plus **`bubbles`/`composed`** letting it reach any ancestor. The codebase already knew this class of bug — `Menu`/`Dialog`/`Expander`/`Calendar` deliberately don't bubble `statechange` (Calendar has a comment saying exactly why). `Checkbox`/`Tabs`/`RadioGroup` were simply the ones still bubbling.

## The fix — two layers

**1. Source: `statechange` is point-to-point.** Removed `bubbles`/`composed` from the `statechange` dispatch in `a-checkbox`, `a-tabs`, `a-radio-group`, so it can neither climb the tree nor cross a shadow boundary — matching every other stateful element. The post-apply **`change`** event still bubbles like a native form control (it's a notification, not a request).

**2. Listener: origin guard (defense-in-depth).** `nativeStateChange` now returns `isOwn` (`event.target === event.currentTarget`). The arbitrary-content container wrappers — `Dialog`, `Menu`, `Expander` — ignore any `statechange` that bubbled from a descendant, so a **consumer's own or third-party** bubbling control can't dismiss them either. This supersedes `Menu`'s prior open/closed *vocabulary* check, which would false-positive on a nested `Expander` (same words).

## Why not the alternatives
- **Consumer-side guard** (from the report): pushes the fix onto every call site forever — a library bug shouldn't have a per-use tax.
- **Namespacing per component** (`dialog-statechange`, …): the Shoelace model, but it fights the deliberate *one uniform `onStateChange`* contract in `STATEFUL-COMPONENTS.md` and churns every wrapper + the shared helper.

Non-bubbling matches the native precedent — `<dialog>`'s `cancel`/`close` don't bubble — and Radix's point-to-point callback model.

## Docs
- `STATEFUL-COMPONENTS.md` gains the propagation rule (non-bubbling/non-composed `statechange`; bubbling `change`).
- `CHANGELOG.md` entry (consumer-facing).

## Verification
`pnpm run typecheck`, `pnpm run lint` (getter/React-19 rules), and `pnpm run build` all pass. Browser E2E of the checkbox-in-dialog flow not yet run — happy to drive it if you'd like.