### PR TITLE
feat: Title is margin-free; pin font-family on Text/Title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,13 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
-## 0.3.11 — July 19, 2026
+## 0.3.10 — Unreleased
 
 ### Changed
 - **`Title` is now margin-free.** `<a-title>` (and `<Title>`) dropped the per-level `margin-block-start` / `margin-block-end` it baked in at every level, so it's a spacing-neutral atom that drops into cards, toolbars, and flex/grid cells without leaking margin or fighting the container's `gap` / `padding` — the parent owns spacing. Matches the margin-free `Text` and the primitives in Radix, Mantine, Chakra, and Polaris. Raw `<h1>`–`<h6>` still carry the per-level vertical rhythm via `src/reset.css` for document prose, so heading markup in running copy is unchanged; only the component diverges. Migration: where you relied on a `<Title>`'s built-in margin, add spacing on the surrounding container (a `gap` on the stack, or padding) — or use a raw heading tag for prose.
 
 ### Fixed
 - **`Text` and `Title` pin their `font-family`.** Both now set `font-family: var(--sans-serif)` on the host instead of relying on inheritance, so a consumer's `font-family` on an ancestor container can no longer reach in and restyle body copy or headings — the same defensive restatement they already do for `font-feature-settings`, and the same pin every shadow-DOM control (`Button`, `Input`, `Tag`, …) already carries. No change where `--sans-serif` is undefined (falls back to inherited, as before).
-
-## 0.3.10 — July 17, 2026
 
 ### Added
 - **Copy button & copying menu item.** `ButtonCopy` and `MenuItemCopy` copy to the clipboard on activation. Exactly one mode (enforced by the `CopyMode` discriminated union): `copy` for a literal string; `copyNode` (bare → nearest `data-copy-source` ancestor; a selector → `closest()`) to copy a DOM region as rich text (`text/html`) + plain text with the copy control stripped from the output; or `copyLazy`, where the content stays out of the DOM until the click fires `onCopyRequest(provide)` and you call `provide(text)` (sync or after an `await`, within the click's activation window). The write lives in the web component (`<a-button>` / `<a-menu-item>`); it reports the result on a non-bubbling `copydone` event, and the wrapper flips the leading icon to a check / ✕ and retones to `success` / `critical` for ~2s. `onCopied(ok)` callback. The `copy` / `copy-node` / `copy-lazy` attributes also work on plain `<Button>` / `<MenuItem>` and hand-authored `<a-button>` / `<a-menu-item>` (the icon/tone feedback is the preset wrappers' part). Exports `ButtonCopy`, `MenuItemCopy`, `ButtonCopyProps`, `MenuItemCopyProps`, and `CopyMode`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
+## 0.3.11 — July 19, 2026
+
+### Changed
+- **`Title` is now margin-free.** `<a-title>` (and `<Title>`) dropped the per-level `margin-block-start` / `margin-block-end` it baked in at every level, so it's a spacing-neutral atom that drops into cards, toolbars, and flex/grid cells without leaking margin or fighting the container's `gap` / `padding` — the parent owns spacing. Matches the margin-free `Text` and the primitives in Radix, Mantine, Chakra, and Polaris. Raw `<h1>`–`<h6>` still carry the per-level vertical rhythm via `src/reset.css` for document prose, so heading markup in running copy is unchanged; only the component diverges. Migration: where you relied on a `<Title>`'s built-in margin, add spacing on the surrounding container (a `gap` on the stack, or padding) — or use a raw heading tag for prose.
+
+### Fixed
+- **`Text` and `Title` pin their `font-family`.** Both now set `font-family: var(--sans-serif)` on the host instead of relying on inheritance, so a consumer's `font-family` on an ancestor container can no longer reach in and restyle body copy or headings — the same defensive restatement they already do for `font-feature-settings`, and the same pin every shadow-DOM control (`Button`, `Input`, `Tag`, …) already carries. No change where `--sans-serif` is undefined (falls back to inherited, as before).
+
 ## 0.3.10 — July 17, 2026
 
 ### Added

--- a/site/src/pages/dialog.mdx
+++ b/site/src/pages/dialog.mdx
@@ -44,7 +44,7 @@ row.
 <Preview>
   <a-button tabindex="0" data-dialog-open="zones">Open dialog</a-button>
   <a-dialog name="zones">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Enable telemetry?</Title>
+    <Title slot="header" level={4}>Enable telemetry?</Title>
     <Text>
       Anonymous usage data helps us find the bugs that matter. You can change
       this any time in settings.
@@ -96,23 +96,23 @@ viewport: no gap, no radius.
   <a-button tabindex="0" data-dialog-open="drawer-bottom">Bottom</a-button>
   <a-button tabindex="0" data-dialog-open="drawer-full">Fullscreen</a-button>
   <a-dialog name="drawer-left" position="left">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Filters</Title>
+    <Title slot="header" level={4}>Filters</Title>
     <Text>A left drawer runs the full height and slides in from the left edge.</Text>
   </a-dialog>
   <a-dialog name="drawer-right" position="right">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Details</Title>
+    <Title slot="header" level={4}>Details</Title>
     <Text>A right drawer, the common inspector / detail-panel placement.</Text>
   </a-dialog>
   <a-dialog name="drawer-top" position="top">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Notice</Title>
+    <Title slot="header" level={4}>Notice</Title>
     <Text>A top drawer spans the full width and drops down from the top edge.</Text>
   </a-dialog>
   <a-dialog name="drawer-bottom" position="bottom">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Actions</Title>
+    <Title slot="header" level={4}>Actions</Title>
     <Text>A bottom sheet, full width, rising from the bottom edge.</Text>
   </a-dialog>
   <a-dialog name="drawer-full" position="fullscreen">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Fullscreen</Title>
+    <Title slot="header" level={4}>Fullscreen</Title>
     <Text>Fills the entire viewport, edge to edge with no gap or corner radius.</Text>
     <a-button tabindex="0" slot="footer" priority="primary" data-dialog-close="drawer-full">Done</a-button>
     <a-button tabindex="0" slot="close" priority="tertiary" size="large" aria-label="Close" data-dialog-close="drawer-full">
@@ -146,11 +146,11 @@ drawer `round="left"`.
   <a-button tabindex="0" data-dialog-open="round-sheet">Rounded bottom sheet</a-button>
   <a-button tabindex="0" data-dialog-open="round-modal">Rounded modal</a-button>
   <a-dialog name="round-sheet" position="bottom" round="top">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Share</Title>
+    <Title slot="header" level={4}>Share</Title>
     <Text>A bottom sheet with its exposed top edge rounded (<code>round="top"</code>).</Text>
   </a-dialog>
   <a-dialog name="round-modal" round="24px">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Softer corners</Title>
+    <Title slot="header" level={4}>Softer corners</Title>
     <Text>A centered modal with all four corners at 24px (<code>round="24px"</code>).</Text>
     <a-button tabindex="0" slot="footer" priority="primary" data-dialog-close="round-modal">Done</a-button>
   </a-dialog>
@@ -183,7 +183,7 @@ backdrop do.
 <Preview gap="8px">
   <a-button tabindex="0" data-dialog-open="no-x">No close button</a-button>
   <a-dialog name="no-x">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Rename file</Title>
+    <Title slot="header" level={4}>Rename file</Title>
     <Text>No ✕ here; dismiss with the footer buttons, Esc, or the backdrop.</Text>
     <span slot="footer" style={{ display: 'contents' }}>
       <Button data-dialog-close="no-x">Cancel</Button>
@@ -208,7 +208,7 @@ that should be answered deliberately.
 <Preview gap="8px">
   <a-button tabindex="0" data-dialog-open="persistent">Delete account</a-button>
   <a-dialog name="persistent" persistent>
-    <Title slot="header" level={4} style={{ margin: 0 }}>Delete account?</Title>
+    <Title slot="header" level={4}>Delete account?</Title>
     <Text>
       This permanently removes your account and all its data. This can't be
       undone.
@@ -372,7 +372,7 @@ the centered modal (`center` carries no `position` attribute).
 <Preview gap="8px">
   <a-button tabindex="0" data-dialog-open="styled">Wider, softer modal</a-button>
   <a-dialog name="styled" class="styled-dialog">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Custom surface</Title>
+    <Title slot="header" level={4}>Custom surface</Title>
     <Text>A wider centred modal with a bigger radius and a stronger overlay, all via ::part.</Text>
     <a-button tabindex="0" slot="footer" priority="primary" data-dialog-close="styled">Done</a-button>
   </a-dialog>
@@ -433,16 +433,16 @@ for a bottom sheet's top edge, and `round="right"` for a left drawer's inner edg
   <a-button tabindex="0" data-dialog-open="corner-sheet">Bottom, round top</a-button>
   <a-button tabindex="0" data-dialog-open="corner-drawer">Left, round right</a-button>
   <a-dialog name="corner-flat" round="0">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Square corners</Title>
+    <Title slot="header" level={4}>Square corners</Title>
     <Text>A centered modal with no rounding (<code>round={0}</code>).</Text>
     <a-button tabindex="0" slot="footer" priority="primary" data-dialog-close="corner-flat">Done</a-button>
   </a-dialog>
   <a-dialog name="corner-sheet" position="bottom" round="top">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Bottom sheet</Title>
+    <Title slot="header" level={4}>Bottom sheet</Title>
     <Text>Top corners rounded (<code>round="top"</code>).</Text>
   </a-dialog>
   <a-dialog name="corner-drawer" position="left" round="right">
-    <Title slot="header" level={4} style={{ margin: 0 }}>Left drawer</Title>
+    <Title slot="header" level={4}>Left drawer</Title>
     <Text>The inner (right) edge rounded (<code>round="right"</code>).</Text>
   </a-dialog>
 </Preview>

--- a/site/src/pages/normalization.mdx
+++ b/site/src/pages/normalization.mdx
@@ -33,7 +33,7 @@ import '@antadesign/anta/elements'      // web components (client-side only)
 
 This is **not** a neutral normalize — these defaults make raw markup match the components.
 
-- **Headings** adopt the exact scale of `<Title level={n}>` — `h1`–`h6` sizes, line-heights, and block margins, weight `≈585`, `letter-spacing: 0`, color `--text-1`. (Kept in lockstep with `a-title.css`.)
+- **Headings** adopt the exact scale of `<Title level={n}>` — `h1`–`h6` sizes, line-heights, weight `≈585`, `letter-spacing: 0`, color `--text-1` (kept in lockstep with `a-title.css`) — plus per-level block margins for document rhythm. Those margins live only on the raw headings: `<Title>` itself is margin-free and leaves spacing to its container, so running prose gets the rhythm while the component stays neutral.
 - `strong` → `font-weight: 600`.
 - Inline `code` → `line-height: 1em` so it doesn't inflate the line box of surrounding prose.
 - **Lists** (`ul` / `ol`): `3ch` left padding so markers hug the text; a small bottom margin between items; markers toned to `--text-5`.

--- a/site/src/pages/title.mdx
+++ b/site/src/pages/title.mdx
@@ -10,17 +10,20 @@ import titleDemoCode from './title.demo.ts'
 
 # Title
 
-A block-level heading at one of six `level`s. The `level` drives both
-the type scale (font-size + line-height) and the vertical rhythm
-(margins above and below); it's also surfaced to assistive tech via
-`aria-level`. Pair with `priority` (`primary` → `quinary`, mapping to
-`--text-1` … `--text-5`) and `tone` (`neutral` (default, untinted),
-`brand`, `success`, `critical`, `warning`, `info`, or any literal CSS
-color for a one-off custom tone) exactly as you would on `Text`.
+A block-level heading at one of six `level`s. The `level` drives the
+type scale (font-size + line-height); it's also surfaced to assistive
+tech via `aria-level`. `<Title>` carries no vertical margins — it drops
+into any container and the parent owns spacing (a `gap` or padding).
+Pair with `priority` (`primary` → `quinary`, mapping to `--text-1` …
+`--text-5`) and `tone` (`neutral` (default, untinted), `brand`,
+`success`, `critical`, `warning`, `info`, or any literal CSS color for a
+one-off custom tone) exactly as you would on `Text`.
 
-Raw `<h1>`–`<h6>` get the same default styling via anta's reset, so
-reach for a real heading tag when SEO matters and you don't need the
-`tone` / `priority` props. Use `<Title>` when you do.
+Raw `<h1>`–`<h6>` share that type scale via anta's reset, plus the
+document vertical rhythm (per-level top/bottom margins) that suits
+running prose. Reach for a real heading tag when SEO matters or you want
+that built-in rhythm and don't need the `tone` / `priority` props; use
+`<Title>` when you do.
 
 <Disclosure title="Playground" anchor={false} brand>
 
@@ -37,10 +40,11 @@ reach for a real heading tag when SEO matters and you don't need the
 ## Levels in context
 
 Six levels interleaved with paragraphs of `<Text>`, all rendered with
-`tone="brand"` against a branded surface so the type scale and
-vertical rhythm read clearly.
+`tone="brand"` against a branded surface so the type scale reads
+clearly. `<Title>` and `<Text>` are both margin-free, so the spacing
+here comes from the container's `gap`.
 
-<div style={{ background: 'var(--bg-pane-brand)', padding: '24px 32px', borderRadius: '8px', border: '1px solid var(--border-4-brand)' }}>
+<div style={{ display: 'flex', flexDirection: 'column', gap: '16px', background: 'var(--bg-pane-brand)', padding: '24px 32px', borderRadius: '8px', border: '1px solid var(--border-4-brand)' }}>
   <Title level={1} tone="brand">Level 1 — page title</Title>
   <Text tone="brand">
     Donec a tincidunt elit. Mauris vehicula, est nec porta cursus,
@@ -124,20 +128,18 @@ heading elements should hold inline phrasing content only.
 
 ## Level reference
 
-| level | font-size | line-height | margin-block-start | margin-block-end |
-|------:|----------:|------------:|-------------------:|-----------------:|
-| 1     | 28px      | 32px        | 0                  | 16px             |
-| 2     | 24px      | 28px        | 32px               | 12px             |
-| 3     | 20px      | 24px        | 24px               | 12px             |
-| 4     | 17px      | 20px        | 20px               | 8px              |
-| 5     | 15px      | 20px        | 16px               | 8px              |
-| 6     | 13px      | 16px        | 16px               | 4px              |
+| level | font-size | line-height |
+|------:|----------:|------------:|
+| 1     | 28px      | 32px        |
+| 2     | 24px      | 28px        |
+| 3     | 20px      | 24px        |
+| 4     | 17px      | 20px        |
+| 5     | 15px      | 20px        |
+| 6     | 13px      | 16px        |
 
-Level 1 is the only level with a zero `margin-block-start` baked in.
-For the rest, expect a top margin even when the heading is the first
-thing inside its container — wrap the container in something with its
-own padding or zero the heading's margin yourself when you need it
-flush.
+`<Title>` adds no vertical margin at any level — space it with the
+parent's `gap` or padding. Raw `<h1>`–`<h6>` do carry per-level
+top/bottom margins (via `src/reset.css`) for document prose rhythm.
 
 ## Tone × priority
 

--- a/site/src/pages/title.mdx
+++ b/site/src/pages/title.mdx
@@ -25,6 +25,15 @@ running prose. Reach for a real heading tag when SEO matters or you want
 that built-in rhythm and don't need the `tone` / `priority` props; use
 `<Title>` when you do.
 
+> **`<Title>` has no margins.** Spacing between a heading and what
+> follows is the container's job — put a `gap` on the parent (or
+> padding), exactly as with `<Text>`. That keeps a heading neutral so it
+> drops into a card, toolbar, or grid cell without leaking margin or
+> pushing off the container's own padding. For a one-off, add spacing
+> inline (`style={{ marginBlock: '…' }}`). Want the classic document
+> rhythm instead? Reach for a raw `<h1>`–`<h6>`, which keep per-level
+> margins via the reset.
+
 <Disclosure title="Playground" anchor={false} brand>
 
 <Playground
@@ -93,7 +102,7 @@ here comes from the container's `gap`.
 `icon` / `iconTrailing` props because children are the API. Drop any
 inline content beside the title text.
 
-<Title level={3}>
+<Title level={3} style={{ marginBottom: '12px' }}>
   <Icon shape="book-open" /> Section with a leading icon
 </Title>
 
@@ -105,7 +114,7 @@ inline content beside the title text.
   x-height, which lands visually low in headings.
 </Text>
 
-<Title level={3}>
+<Title level={3} style={{ marginBlock: '20px 12px' }}>
   <Icon shape="info" /> Mix it all — title text and <span style={{ color: 'var(--text-1-brand)' }}>accents</span>
 </Title>
 

--- a/src/components/Title.tsx
+++ b/src/components/Title.tsx
@@ -27,18 +27,22 @@ export interface TitleProps extends BaseProps {
  * — so there are no `icon` / `iconTrailing` props; just compose
  * inside.
  *
- * Raw `<h1>`-`<h6>` get the same visual styling via `src/reset.css`,
- * so use a real heading tag if SEO matters and you don't need the
- * `tone` / `priority` props.
+ * `<Title>` carries no vertical margins: it's a spacing-neutral atom
+ * that drops into any container, and the parent owns spacing (a `gap`
+ * or padding). Raw `<h1>`-`<h6>` do keep per-level top/bottom margins
+ * (via `src/reset.css`) for document prose rhythm — so use a real
+ * heading tag if SEO matters or you want that built-in rhythm and don't
+ * need the `tone` / `priority` props.
  *
  * Styling notes (`a-title.css` ships comment-free): `<a-title>` is
  * intentionally CSS-only — no JS, no shadow DOM, not even
  * `customElements.define`; the browser treats it as a generic unknown
  * element and the CSS gives it block layout, the demi-bold variable-font
- * weight, and the per-level type scale + vertical rhythm. The matching
- * `h1`–`h6` rules in `src/reset.css` are kept in lockstep so raw markup
- * looks the same as `<Title level={n}>`. The tone × priority color matrix
- * has the same shape as `a-text`'s.
+ * weight, and the per-level type scale. The matching `h1`–`h6` rules in
+ * `src/reset.css` share that type scale and weight, so raw markup reads
+ * the same as `<Title level={n}>` — they diverge only on margins: raw
+ * headings carry the document vertical rhythm, `<a-title>` is margin-free.
+ * The tone × priority color matrix has the same shape as `a-text`'s.
  *
  * Requires `@antadesign/anta/elements` to be imported (client-side only)
  * so the CSS ships with the page.

--- a/src/elements/a-text.css
+++ b/src/elements/a-text.css
@@ -5,6 +5,10 @@
     --text-link-hover: var(--link-color-hover);
 
     display: block;
+    /* Pin the family so a consumer's font-family on an ancestor can't reach in
+       and restyle body copy — same reasoning as font-feature-settings below: the
+       property replaces, it doesn't merge. */
+    font-family: var(--sans-serif);
     color: var(--text-color);
     font-size: 15px;
     line-height: 20px;

--- a/src/elements/a-title.css
+++ b/src/elements/a-title.css
@@ -1,6 +1,10 @@
 @layer anta {
   a-title {
     display: block;
+    /* Pin the family so a consumer's font-family on an ancestor can't reach in
+       and restyle headings — same reasoning as font-feature-settings below: the
+       property replaces, it doesn't merge. */
+    font-family: var(--sans-serif);
     color: var(--text-1);
     font-weight: 584.62;
     letter-spacing: 0;
@@ -10,18 +14,21 @@
        so a consumer's font-feature-settings on an ancestor can't drop them — the
        property replaces, not merges. */
     font-feature-settings: 'ss02', 'ss05', 'tnum';
+    /* No vertical margins: <Title> is a spacing-neutral atom that drops into any
+       container, so the parent owns spacing (gap/padding). Raw <h1>-<h6> keep the
+       document prose rhythm via src/reset.css. */
   }
 
   a-title a-icon {
     transform: translateY(-0.05em);
   }
 
-  a-title[level="1"] { font-size: 28px; line-height: 32px; margin-block-start: 0;    margin-block-end: 16px; }
-  a-title[level="2"] { font-size: 24px; line-height: 28px; margin-block-start: 32px; margin-block-end: 12px; }
-  a-title[level="3"] { font-size: 20px; line-height: 24px; margin-block-start: 24px; margin-block-end: 12px; }
-  a-title[level="4"] { font-size: 17px; line-height: 20px; margin-block-start: 20px; margin-block-end: 8px;  }
-  a-title[level="5"] { font-size: 15px; line-height: 20px; margin-block-start: 16px; margin-block-end: 8px;  }
-  a-title[level="6"] { font-size: 13px; line-height: 16px; margin-block-start: 16px; margin-block-end: 4px;  }
+  a-title[level="1"] { font-size: 28px; line-height: 32px; }
+  a-title[level="2"] { font-size: 24px; line-height: 28px; }
+  a-title[level="3"] { font-size: 20px; line-height: 24px; }
+  a-title[level="4"] { font-size: 17px; line-height: 20px; }
+  a-title[level="5"] { font-size: 15px; line-height: 20px; }
+  a-title[level="6"] { font-size: 13px; line-height: 16px; }
 
   a-title[priority="secondary"]  { color: var(--text-2); }
   a-title[priority="tertiary"]   { color: var(--text-3); }


### PR DESCRIPTION
## What

Two small corrections to the text primitives:

### 1. `Title` is margin-free
`<a-title>` (and `<Title>`) dropped the per-level `margin-block-start` / `margin-block-end` it baked in at every level. It's now a spacing-neutral atom that drops into cards, toolbars, and flex/grid cells without leaking margin or fighting the container's `gap` / `padding` — **the parent owns spacing**. This matches:
- Anta's own `Text`, which was already margin-free.
- The convention in Radix (`Heading`), Mantine (`Title`), Chakra (`Heading`), Polaris, Carbon, Base UI — heading primitives ship margin-free; spacing lives on a `Stack`/`Flex` gap. (MUI is opt-in via `gutterBottom`; only Ant Design keeps default margins.)

**Raw `<h1>`–`<h6>` are unchanged** — they keep the per-level vertical rhythm via `src/reset.css`, which is the right behavior for running prose / MDX / document content. So the split is deliberate: `<h2>` = document semantics with rhythm; `<Title>` = context-neutral UI atom.

*Migration:* where you relied on a `<Title>`'s built-in margin, add spacing on the surrounding container (a `gap` on the stack, or padding), or use a raw heading tag for prose.

### 2. `Text` and `Title` pin their `font-family`
Both now set `font-family: var(--sans-serif)` on the host instead of relying on inheritance. A consumer's `font-family` on an ancestor container could previously reach in and restyle body copy / headings. This is the same defensive restatement `a-text` already does for `font-feature-settings` (with that exact rationale in a comment), and the same pin every shadow-DOM control (`Button`, `Input`, `Tag`, …) already carries. No regression where `--sans-serif` is undefined — `font-family` falls back to inherited, as today.

## Files
- `src/elements/a-title.css` — pin `font-family`, drop per-level margins
- `src/elements/a-text.css` — pin `font-family`
- `src/components/Title.tsx` — docstring reflects the margin divergence
- `site/src/pages/title.mdx` — intro, raw-heading note, "Levels in context" demo (now spaced by container `gap`), level table (margin columns removed)
- `CHANGELOG.md` — `0.3.11` entry (Changed: margin-free Title; Fixed: font-family pin)

## Verification
- `pnpm run build` ✓
- `pnpm run typecheck` ✓
- `pnpm --filter anta-site build` ✓