### PR TITLE
chore(release): 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This file tracks what ships to npm consumers: anything under `src/`, `dist/`, th
 
 Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
 
-## 0.3.10 — Unreleased
+## 0.3.10 — July 20, 2026
 
 ### Changed
 - **`Title` is now margin-free.** `<a-title>` (and `<Title>`) dropped the per-level `margin-block-start` / `margin-block-end` it baked in at every level, so it's a spacing-neutral atom that drops into cards, toolbars, and flex/grid cells without leaking margin or fighting the container's `gap` / `padding` — the parent owns spacing. Matches the margin-free `Text` and the primitives in Radix, Mantine, Chakra, and Polaris. Raw `<h1>`–`<h6>` still carry the per-level vertical rhythm via `src/reset.css` for document prose, so heading markup in running copy is unchanged; only the component diverges. Migration: where you relied on a `<Title>`'s built-in margin, add spacing on the surrounding container (a `gap` on the stack, or padding) — or use a raw heading tag for prose.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.8",
+  "version": "0.3.10",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Release prep for **0.3.10**.

## Changes
- Bump `package.json` version `0.3.8 → 0.3.10`.
- Date the `0.3.10` changelog section (`Unreleased → July 20, 2026`).

## Why 0.3.10 (not 0.3.9)
`main`'s `package.json` was at `0.3.8`, but **`0.3.9` is already published to npm** (current `latest`) — its release bumped the version field without landing a `chore(release)` commit back on `main`, so `main` looked one behind. `0.3.9` is immutable, so the next release is `0.3.10`, matching the changelog's already-authored (previously "Unreleased") section.

## What 0.3.10 ships (from CHANGELOG.md)
- **Changed** — `Title` is now margin-free.
- **Fixed** — `Text` and `Title` pin their `font-family`.
- **Added** — Copy button & copying menu item (`ButtonCopy` / `MenuItemCopy`).

## Notes
- The `/changelog/` "Main releases" summary page (`site/src/changelog-summary.md`) is stale — its newest entry is `0.2.0` and it omits all of `0.3.x`. Not addressed here; flag for a follow-up if that view is meant to stay current.
- No `dist/` or generated docs artifacts are committed (gitignored, rebuilt on install/publish).
