### PR TITLE
docs: 0.3.11 changelog date + sticky colors tone-tabs fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
 
-All notable changes to the `@antadesign/anta` package.
+This page tracks what ships to npm. Documentation website changes are not tracked here.
 
-This file tracks what ships to npm consumers: anything under `src/`, `dist/`, the build and generator scripts, and the root files in the published tarball. Documentation-site updates at `anta.design` aren't consumer-facing and stay out of the changelog; the commit history covers the site.
-
-Versions ending in `-dev.N` are prereleases on the npm `dev` dist-tag; main releases drop the suffix. Pin a specific version (`"@antadesign/anta": "0.1.1-dev.1"`) rather than the floating `"dev"` tag, which changes between installs.
-
-## 0.3.11 — July 20, 2026
+## 0.3.11 — July 21, 2026
 
 ### Changed
 - **Lazy copy is now off-UI-thread safe, and `copyLazy` is gone.** The lazy path no longer hands the consumer a `provide` callback on click — a function can't cross a worker boundary, and the async round-trip missed the click's activation window, so `copyLazy` never worked in a worker-rendered app. Instead, a copy control emits a **serializable `copyrequest`** on **pointerdown** (keyboard: on keydown) whenever it has a `copy` attribute; the consumer refreshes the reactive `copy` value in response, and the **activation** copies whatever `copy` then holds. The pointerdown→click (and keydown→keyup) gap absorbs the round-trip, and only a string crosses the boundary via the normal re-render. Migration: drop `copyLazy`, keep `copy` reactive, and change `onCopyRequest={(provide) => provide(text)}` to `onCopyRequest={() => setCopy(text)}` (a state update that feeds `copy`). The `copy-lazy` element attribute and the `copyrequest` `detail.provide` are removed. (Content that can only be produced by a bare programmatic `.click()`, with no preceding pointer/keyboard event — e.g. some assistive-tech activations — can't be resolved this way; use an eager `copy` there.)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/components/Swatches.module.css
+++ b/site/src/components/Swatches.module.css
@@ -2,11 +2,11 @@
   display: flex;
   flex-direction: column;
   gap: 56px;
-  /* Approximate height of the sticky `.toneTabs` strip: 4 px padding +
-     0.5 px borders + ~24 px button content. Anchor scrolls below add
+  /* Approximate height of the sticky `.toneTabs` strip: 3 px gutter ×2 +
+     0.5 px borders + ~28 px button content. Anchor scrolls below add
      1.5× this on top of html's --scroll-padding-top so the target
      heading lands below the tabs instead of behind them. */
-  --tabs-height: 32px;
+  --tabs-height: 36px;
 }
 
 /* Apply the offset to any anchor-targetable heading inside the page so
@@ -34,6 +34,17 @@
   position: sticky;
   top: var(--scroll-padding-top, 0);
   z-index: 5;
+}
+
+/* The strip overlaps content as the page scrolls under it, so it needs a solid
+   fill — the default track tint is near-transparent and content bleeds through.
+   A 3px gutter around the tabs turns it into a padded well; the outer radius is
+   the 4px tab radius + the 3px gutter so the corners stay concentric. Un-layered,
+   so it wins over `@layer anta`. */
+.toneTabs a-tabs {
+  padding: 3px;
+  background: var(--bg-4);
+  border-radius: 7px;
 }
 
 /* ─── Full-bleed layout ──────────────────────────────────────────────────


### PR DESCRIPTION
Two small docs-only follow-ups after #117 merged.

## Changes
- **`CHANGELOG.md`** — set the 0.3.11 heading date to July 21, 2026, and trimmed the header prose (dropped the "All notable changes…" line and the `-dev.N` versioning paragraph; condensed the scope note to "This page tracks what ships to npm. Documentation website changes are not tracked here.").
- **Colors page sticky tone-tabs** (`site/src/components/Swatches.module.css`) — the sticky `.toneTabs` strip used the near-transparent default track tint, so content bled through it while scrolling. Gave the strip a solid `--bg-4` fill plus a 3px gutter (`padding: 3px`, concentric `border-radius: 7px`), via the "override padding + matching border-radius" path the Tabs CSS documents. Bumped the `--tabs-height` estimate 32→36px so anchor-scroll offsets still clear the taller strip.

Docs-site + changelog metadata only — no consumer-facing package change.