### PR TITLE
Increase Tooltip default delay to 300ms and make Select option tooltips follow cursor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 This page tracks what ships to npm. Documentation website changes are not tracked here.
 
-## 0.3.13 — July 23, 2026
+## Unreleased
 
 ### Changed
 - **`Tooltip`'s default show delay is now 300ms** (was 250ms) — the wait before a hovered / focused tooltip appears. Pass `delay` to override per tooltip (`~50` for near-instant; never `0`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This page tracks what ships to npm. Documentation website changes are not tracked here.
 
+## 0.3.13 — July 23, 2026
+
+### Changed
+- **`Tooltip`'s default show delay is now 300ms** (was 250ms) — the wait before a hovered / focused tooltip appears. Pass `delay` to override per tooltip (`~50` for near-instant; never `0`).
+- **`Select` and `SelectFaceted` option-row tooltips now follow the cursor.** A `SelectOption.tooltip` used to pin under the row while only the auto-generated multi-select "select only this" (Alt/⌥-click) hint followed the pointer. Now every option-row tooltip tracks the cursor, so it reads as attached to the pointer rather than detached under a wide row; the isolate hint keeps its longer 700ms delay, a consumer's own `tooltip` uses the standard delay.
+
 ## 0.3.12 — July 23, 2026
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.13",
+  "version": "0.3.12",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/pages/tooltip.demo.ts
+++ b/site/src/pages/tooltip.demo.ts
@@ -14,7 +14,7 @@ export default `import { Tooltip, Button } from '@antadesign/anta'
 
 <div className="container">
   <Button label="Hover me">
-    <Tooltip delay={250}>Edit my props on the right →</Tooltip>
+    <Tooltip delay={300}>Edit my props on the right →</Tooltip>
   </Button>
 </div>
 `

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -625,11 +625,6 @@ export const Select = (props: SelectProps) => {
     // row out of the default hint.
     const isolateHint = multiple && selectAll && !disabled ? ISOLATE_HINT : undefined
     const tip = o.tooltip ?? isolateHint
-    // Every option tooltip follows the cursor (a row's box is wide, so a pinned
-    // bubble reads as detached from the pointer). The default isolate hint teaches
-    // an accelerator, so it stays unobtrusive with a longer delay than the 300ms
-    // default (it shouldn't fire on a casual pass over the rows); a consumer's own
-    // `tooltip` uses the standard delay.
     const hintOnly = o.tooltip == null && isolateHint != null
     return (
       <MenuItem

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -625,9 +625,11 @@ export const Select = (props: SelectProps) => {
     // row out of the default hint.
     const isolateHint = multiple && selectAll && !disabled ? ISOLATE_HINT : undefined
     const tip = o.tooltip ?? isolateHint
-    // The default hint teaches an accelerator, so it's unobtrusive: a longer delay
-    // than the 250ms default (it shouldn't fire on a casual pass over the rows) and
-    // it follows the cursor. A consumer's own `tooltip` keeps the default pinned look.
+    // Every option tooltip follows the cursor (a row's box is wide, so a pinned
+    // bubble reads as detached from the pointer). The default isolate hint teaches
+    // an accelerator, so it stays unobtrusive with a longer delay than the 300ms
+    // default (it shouldn't fire on a casual pass over the rows); a consumer's own
+    // `tooltip` uses the standard delay.
     const hintOnly = o.tooltip == null && isolateHint != null
     return (
       <MenuItem
@@ -648,7 +650,7 @@ export const Select = (props: SelectProps) => {
       >
         {custom}
         {tip && (
-          <Tooltip {...(hintOnly ? { follow: true, delay: 700 } : {})}>{tip}</Tooltip>
+          <Tooltip follow {...(hintOnly ? { delay: 700 } : {})}>{tip}</Tooltip>
         )}
       </MenuItem>
     )

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -438,7 +438,7 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
             : setFacet(facet, arr.includes(opt.value) ? arr.filter((v) => v !== opt.value) : [...arr, opt.value])
         }
       >
-        {tip && <Tooltip {...(hintOnly ? { follow: true, delay: 700 } : {})}>{tip}</Tooltip>}
+        {tip && <Tooltip follow {...(hintOnly ? { delay: 700 } : {})}>{tip}</Tooltip>}
       </MenuItem>
     )
   }

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -7,7 +7,7 @@ export interface TooltipProps extends BaseProps {
   children?: React.ReactNode
   /** Show delay in milliseconds after hover / focus. Never use `0` — use
    *  ~`50` for a near-instant tooltip (0 has caused issues in practice).
-   *  @defaultValue 250 */
+   *  @defaultValue 300 */
   delay?: number
   /** Which side of the anchor the bubble prefers. Auto-flips to the other
    *  side when there isn't room.

--- a/src/elements/a-tooltip.ts
+++ b/src/elements/a-tooltip.ts
@@ -11,7 +11,7 @@ const CURSOR_SIZE = 16
  *  cursor lands at the start of the text, not to the left of the whole bubble. */
 const PADDING_X = 8
 /** Default show delay (ms) when nothing else is open. Never use 0 — use ~50. */
-const DEFAULT_DELAY = 250
+const DEFAULT_DELAY = 300
 /** Enter/exit fade duration (ms). Mirrors `--_dur` in the shadow style. */
 const FADE_MS = 150
 /**

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -395,7 +395,7 @@ export interface AIconAttributes extends BaseAttributes {
  * `Tooltip` from `@antadesign/anta`.
  */
 export interface ATooltipAttributes extends BaseAttributes {
-  /** Show delay in milliseconds. Never use `0` — use ~`50`. Defaults to 250. */
+  /** Show delay in milliseconds. Never use `0` — use ~`50`. Defaults to 300. */
   delay?: number | string
   /** Preferred side; auto-flips when there's no room. Defaults to `'bottom'`. */
   placement?: 'top' | 'bottom'


### PR DESCRIPTION
## Summary

Updates the default tooltip show delay from 250ms to 300ms and makes all option-row tooltips in `Select` and `SelectFaceted` follow the cursor for better UX.

## Changes

- **Tooltip default delay**: Increased from 250ms to 300ms across all components (`Tooltip.tsx`, `a-tooltip.ts`, `general_types.ts`, and demo)
- **Select option tooltips**: Now all option-row tooltips follow the cursor (previously only the auto-generated multi-select isolate hint followed). This makes tooltips read as attached to the pointer rather than detached under wide rows
  - Applied `follow` prop to all tooltips in `Select.tsx` and `SelectFaceted.tsx`
  - The isolate hint retains its longer 700ms delay for unobtrusiveness; consumer-provided `tooltip` props use the standard 300ms delay
- **Documentation**: Updated comments in `Select.tsx` to clarify the new tooltip behavior and delay strategy
- **Version bump**: 0.3.12 → 0.3.13
- **Changelog**: Added entry documenting the Tooltip delay change and Select tooltip cursor-following behavior

## Implementation Details

The change simplifies the tooltip configuration by making `follow: true` the default for all option-row tooltips, then conditionally overriding only the `delay` property for hint-only tooltips. This ensures consistent cursor-tracking behavior across all option tooltips while preserving the longer delay for the auto-generated isolate hint.

https://claude.ai/code/session_01PzWCYvwAxMT2vaYiprh4hs