### PR TITLE
chore(release): anta 0.3.14, stickers 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 This page tracks what ships to npm. Documentation website changes are not tracked here.
 
-## Unreleased
+## 0.3.14 — July 28, 2026
 
 ### Added
 - **`Select` gains `verbose` — spell the multi-select picks out in the field.** In `selection="multiple"`, the partial-selection summary becomes `3 selected: A, B, C` (labels comma-joined) instead of the bare `3 selected`. The list flows into the read-only field, so it ellipsizes at the field's width when long. Applies to the multi-count case only: `All` stays `All`, a single pick stays its own label, and an empty selection stays the `placeholder`. `renderSummary` overrides it.
 - **`Select` gains `renderSummary` — customise the multi-select field text.** In `selection="multiple"`, the trigger summarises the selection as `All`, one label, or `N selected`; `renderSummary(selected)` replaces that text. It runs only while something is selected (an empty selection still shows the `placeholder`) and receives the resolved options (`selected.length` is the count). Return a **string** and it flows into the same read-only field the default uses, so a long summary ellipsizes at the field's width like a long value; return `undefined` for any case you'd rather leave to the built-in text (e.g. keep the single-label case, override only the count). For rich content, `renderTrigger` still replaces the whole field.
 - **`Banner` (`<a-banner>`) — a full-width, dismissible message strip.** A centered row of `message`, `children`, and `actions` with a ✕ at the right edge; `actions` wrap below the message when the row can't fit. `tone` (named or any CSS colour) tints the surface, text, and ✕. Borderless by default — add `border-bottom-width` / `border-width` for a rule or outline; `round` makes a standalone bar. Closable by default, following Anta's open/closed state contract as `dismissed` / `defaultDismissed` / `onDismiss` (`closable={false}` drops the ✕); dismiss animates a height + opacity collapse. Any control inside the banner carrying **`data-banner-dismiss`** dismisses it on click through the same contract — for an action button or a dropdown item that closes the banner as it acts (works from the keyboard, and on `<a-menu-item>` since the menu keeps its items in the light DOM). Defaults to `role="status"`. `::part(message | content | actions | close)`. Exports `BannerProps`.
+- **`@antadesign/anta/anta_helpers` exports `StateChangeEvent<D>`.** The cross-renderer type a `statechange` handler receives — a raw `CustomEvent<D>` under Preact, `{ nativeEvent: CustomEvent<D> }` under React — paired with the existing `nativeStateChange` unwrap. A custom stateful wrapper can type its handler off this instead of re-declaring the union.
 
 ### Changed
 - **`SelectFaceted`'s facet-row summary chip caps its width and ellipsizes.** A long `text` filter (or a many-picks summary) no longer stretches the whole filter menu — the chip bounds its width and ellipsizes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.13",
+  "version": "0.3.14",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/pages/comparison.mdx
+++ b/site/src/pages/comparison.mdx
@@ -19,7 +19,7 @@ Gravity), **headless primitives** you style yourself (Radix, Base UI),
 are a snapshot from {AS_OF}; follow each system's link for the current
 release.
 
-<Disclosure title="At a glance">
+<Disclosure title="Frameworks, styling, license">
 
 <ComparisonMatrix />
 
@@ -30,26 +30,6 @@ with plain CSS in a single `@layer`, so there is no style runtime and any
 consumer rule overrides a default without a specificity fight.
 
 </Disclosure>
-
-## What Anta adds
-
-- **Runs anywhere, including a Worker.** The web components never mutate
-  their own host attributes; internal state stays inside shadow DOM. They
-  stay in sync when the UI renders from a Worker thread or a non-React
-  reactive engine, and the React/Preact wrappers stay a thin convenience.
-- **No style runtime, no animation runtime.** Nothing ships to parse styles
-  at runtime. The one animation dependency, Lottie, lives in the separate
-  `@antadesign/stickers` package.
-- **A tiny token set.** The global tokens are color roles for text,
-  background, and border, plus fonts and one focus ring. Everything else is
-  a per-component CSS variable, kept local so each part stays independently
-  tunable.
-- **oklch color throughout.** Role tokens and each component's
-  rest/hover/active curve derive from a seed color with
-  `oklch(from <seed> l c h)`; alpha tuning runs through `color-mix` in oklch.
-  Lightness and hue stay perceptually stable, and newer systems are drifting
-  the same way: MUI v9 derives shades with `color-mix()`, shadcn themes in
-  oklch.
 
 ## Component coverage
 
@@ -64,21 +44,3 @@ ship behavior.
 ## The systems
 
 <SystemCards />
-
-## Choosing between them
-
-- **A React app that needs everything now.** Ant Design or Mantine for
-  breadth, MUI for ecosystem and hiring, Carbon or Atlaskit for enterprise
-  rigor, Blueprint for dense desktop tools.
-- **Full control of markup and styling.** Base UI or Radix for headless
-  primitives; shadcn/ui or Untitled UI to own the styled code outright (both
-  need Tailwind).
-- **Components outside React: plain HTML, Preact, several frameworks.** A
-  web-component system. Web Awesome has the widest set (some controls are
-  paid), Polaris works only inside Shopify, and Anta is the open, plain-CSS,
-  runtime-free option, built for UIs that render off the main thread.
-
-Anta is the youngest system on this page. Pick it when its constraints are
-yours: framework portability, a worker-safe declarative DOM, no style
-runtime, oklch color. If you need a data grid or a decade of ecosystem
-today, one of the incumbents will serve you better.

--- a/stickers/package.json
+++ b/stickers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/stickers",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

Version bumps for the next dev-tag release, plus dating the changelog.

- **`@antadesign/anta`** `0.3.13 → 0.3.14`
- **`@antadesign/stickers`** `0.1.1 → 0.1.2`
- **CHANGELOG**: dates the `0.3.14` section (was `Unreleased`) and adds one missing entry — the new `StateChangeEvent<D>` export from `@antadesign/anta/anta_helpers`.

The `0.3.14` changelog covers what already merged since 0.3.13: `Select` `verbose` / `renderSummary` / multi-select "All", the `Banner` component, `SelectFaceted` summary-chip cap + typed-space fix, and the space-key-in-menu-nested-fields fix.

## Publish order (after merge)

Publish anta first so it's live on npm, then stickers — `pnpm publish` rewrites stickers' `workspace:*` to anta's exact version (`0.3.14`) at pack time.

```sh
npm publish --access public --tag dev      # anta, from repo root
cd stickers && pnpm publish --no-git-checks  # stickers
```

## Notes

- No `src/` behavior changes in this PR — version + changelog only.
- Stickers' `src/` changes (a-sticker sizing) already merged to main; this bump ships them.