### PR TITLE
Add Loader component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ changes are not listed.
 
 ### Added
 
+- `Loader` provides animated icon-sized feedback, determinate circular progress,
+  a `speed` prop, and the `loader` icon-shape alias for string-only icon props.
 - `Progress` shows an indeterminate loading animation when `value` is omitted
   or set to `false`.
 - `Progress` supports `small`, `medium`, and `large` sizes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Added
+
+- `Progress` shows an indeterminate loading animation when `value` is omitted
+  or set to `false`.
+
 ## 0.3.17 — July 31, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,23 @@ changes are not listed.
 
 ## Unreleased
 
+### Changed
+
+- The Anta theme's `--focus-ring` now follows its brand text color.
+- `reset.css` gives plain keyboard-focused HTML the 1px Anta focus ring.
+
 ### Added
 
 - `Progress` shows an indeterminate loading animation when `value` is omitted
   or set to `false`.
+- `Progress` supports `small`, `medium`, and `large` sizes.
+- Native HTML `<progress>` elements opt into the Progress appearance with
+  `data-anta`.
+
+### Fixed
+
+- Custom `Progress` tones now use the same track, fill, and edge progression as
+  named tones in light and dark themes.
 
 ## 0.3.17 — July 31, 2026
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ recommended; the reference theme is optional.
 | Import | Provides | Skip if… |
 |---|---|---|
 | `@antadesign/anta/tokens.css` | Six seed tokens, derived role scales (`--bg-1…5`, `--text-1…5`, `--border-1…5`), `.dark`, the 15px root size, and layer order. Override a seed to reskin its tone. | You provide those variables. |
-| `@antadesign/anta/reset.css` | A small reset plus Anta's heading, list, and link typography in `@layer anta`. | You use another reset and typography. |
+| `@antadesign/anta/reset.css` | A small reset plus Anta's focus, heading, list, and link typography in `@layer anta`. | You use another reset and typography. |
 | `@antadesign/anta/elements` | Registers every `<a-*>` element and its CSS. Per-element entries register one; see [Registering elements](#registering-elements). | You render only on the server or register elements individually. |
 | `@antadesign/anta` | Typed React/Preact wrappers such as `Progress`, `Text`, and `Icon`. | You write `<a-*>` elements directly. |
 | `@antadesign/anta/theme-anta.css` *(optional)* | The hand-tuned reference palette. Import last to replace the seed-derived default. | You want the seed-derived or your own palette. |

--- a/site/lib/component-slugs.ts
+++ b/site/lib/component-slugs.ts
@@ -6,8 +6,8 @@
  *  generators to filter the root `.mdx` set. Keep in sync with the sidebar nav
  *  in DocsLayout.astro when adding a component. */
 export const COMPONENT_SLUGS = [
-  'banner', 'button', 'card', 'checkbox', 'dialog', 'expander', 'icon', 'input',
+  'banner', 'button', 'card', 'checkbox', 'dialog', 'expander', 'icon', 'loader', 'progress', 'input',
   'input-autocomplete', 'input-date', 'input-time', 'slider',
-  'menu', 'progress', 'radio', 'select', 'select-faceted', 'stickers', 'table',
+  'menu', 'radio', 'select', 'select-faceted', 'stickers', 'table',
   'switch', 'tabs', 'tag', 'text', 'title', 'toaster', 'tooltip',
 ]

--- a/site/src/components/AnimatedLoader.tsx
+++ b/site/src/components/AnimatedLoader.tsx
@@ -1,0 +1,14 @@
+import { useEffect, useState } from 'preact/hooks'
+import { Loader } from '@antadesign/anta'
+
+/** Docs-only preview of a slow, repeating determinate Loader cycle. */
+export default function AnimatedLoader() {
+  const [value, setValue] = useState(0)
+
+  useEffect(() => {
+    const id = setInterval(() => setValue((current) => (current + 1) % 101), 100)
+    return () => clearInterval(id)
+  }, [])
+
+  return <Loader value={value} label="Processing records" />
+}

--- a/site/src/components/InputLoaderDemo.tsx
+++ b/site/src/components/InputLoaderDemo.tsx
@@ -1,0 +1,15 @@
+import { Icon, Input } from '@antadesign/anta'
+
+/** Documents a decorative loader in Input's trailing slot. */
+export default function InputLoaderDemo() {
+  return (
+    <Input
+      label="Workspace"
+      defaultValue="Anta"
+      hint="Checking availability"
+      dimActions
+      style={{ width: '220px' }}
+      trailing={<Icon shape="loader" aria-hidden="true" />}
+    />
+  )
+}

--- a/site/src/components/Playground.module.css
+++ b/site/src/components/Playground.module.css
@@ -331,7 +331,10 @@
 .exampleHeader:hover,
 .exampleHeader:focus-visible {
   color: var(--text-1);
-  outline: none;
+}
+.exampleHeader:focus-visible {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: -1px;
 }
 
 .exampleHeaderOpen {
@@ -366,9 +369,11 @@
 
 .form {
   padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
+  /* Match Input's "label column" pattern: each row adopts these shared
+     tracks, so every control begins at one stable right-hand edge. */
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  gap: 8px;
   flex: 1;
   min-height: 0;
   min-width: 0;
@@ -376,15 +381,18 @@
 }
 
 .field {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  align-items: center;
+  row-gap: 4px;
   min-width: 0;
 }
 
 .fieldLabel {
   display: flex;
-  align-items: flex-start;
+  grid-column: 1;
+  align-items: center;
   justify-content: space-between;
   gap: 8px;
   font-size: 13px;
@@ -401,28 +409,32 @@
 }
 
 .fieldHint {
+  grid-column: 1 / -1;
   font-size: 12px;
   line-height: 1.2;
   color: var(--text-4);
 }
 
-/* Inline layout for boolean fields: checkbox + label on one row so
-   the prop reads like a regular settings toggle. */
-.fieldBoolean {
-  display: flex;
-  align-items: flex-start;
-  gap: 8px;
-  font-size: 13px;
-  cursor: pointer;
+/* Inputs with an own label join the form's tracks through their shadow parts,
+   following the documented Input "label column" recipe. Other controls are
+   the second child of `.field` and occupy the right track below. */
+.field > a-input {
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  align-items: center;
+}
+.field > a-input::part(label) {
+  grid-column: 1;
+  margin: 0;
+}
+.field > a-input::part(field),
+.field > a-input::part(hint) {
+  grid-column: 2;
   min-width: 0;
 }
-.fieldBoolean > span {
+.field > :nth-child(2) {
+  grid-column: 2;
   min-width: 0;
-  overflow-wrap: anywhere;
-}
-.fieldBoolean input[type="checkbox"] {
-  flex-shrink: 0;
-  margin: 0.25em 0 0;
 }
 
 .fieldValueLabel {
@@ -465,12 +477,13 @@
   pointer-events: none;
 }
 
-/* Enum / tone pickers are Anta <Tabs> (primary, small). A long option set (e.g. tone)
-   ellipsizes its labels (default a-tabs behaviour) rather than widening the panel; each
-   option carries a truncatedOnly tooltip (set in the control JSX), so a clipped label
-   reveals its full text on hover — like the Tabs Overflow example. */
+/* Short enum pickers use Anta <Tabs> (primary, small). Longer lists, including
+   tone, use Anta <Select> so their labels never crowd the panel. */
 .segTabs {
   max-width: 100%;
+}
+.selectControl {
+  width: 100%;
 }
 
 /* Prop name — plain monospace value, not a copyable code pill. Inherits its
@@ -479,6 +492,12 @@
   font-family: var(--monospace);
   letter-spacing: 0;
   font-size: 12px;
+}
+
+/* Playground prop descriptions often span several lines. Give their tooltip
+   bubbles a little more inset than the compact component default. */
+.root a-tooltip {
+  --tooltip-padding: 8px 12px;
 }
 
 /* `children` / ReactNode fields hold JSX/markup — monospace, code-style value text.
@@ -490,7 +509,7 @@
   font-size: 12px;
 }
 
-/* Tone control: the named/Custom tab row plus, when Custom is active, a
+/* Tone control: the named/Custom picker plus, when Custom is active, a
    color input + the current value beneath. */
 .toneControl {
   display: flex;

--- a/site/src/components/Playground.tsx
+++ b/site/src/components/Playground.tsx
@@ -17,7 +17,7 @@
  * See site/lib/sandbox/* for the moving parts.
  */
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks'
-import { Input, Tooltip, Text, Checkbox, Tabs } from '@antadesign/anta'
+import { Input, Tooltip, Text, Checkbox, Select, Tabs } from '@antadesign/anta'
 import { marked } from 'marked'
 import s from './Playground.module.css'
 // Monaco ships its structural CSS as ~110 separate `import './x.css'`
@@ -66,11 +66,14 @@ interface Props {
    *  playground doesn't grow with form content and so switching tabs
    *  doesn't reflow. Defaults to 400. */
   panelHeight?: number
+  /** Whether the Code editor initially folds every foldable region.
+   *  Defaults to false so source opens expanded. */
+  codeInitiallyFolded?: boolean
 }
 
 type Tab = 'props' | 'code' | 'css'
 
-export default function Playground({ component, initialCode, initialCss = '', layout = 'stacked', panelHeight = 400 }: Props) {
+export default function Playground({ component, initialCode, initialCss = '', layout = 'stacked', panelHeight = 400, codeInitiallyFolded = false }: Props) {
   const [code, setCode] = useState(initialCode)
   // CSS state is independent of the code — the user owns it. The CSS
   // tab is unconditionally available; no auto-seed from any className
@@ -720,16 +723,13 @@ export default function Playground({ component, initialCode, initialCss = '', la
                     onMonacoMount(editor, monaco)
                     installJsxAwareCommentToggle(editor, monaco)
                     editor.layout()
-                    // Collapse every foldable region on first mount.
-                    // The authoring convention is to put the `# Heading`
-                    // on the opening `/​**` line, which Monaco keeps
-                    // visible when the comment is folded — so the
-                    // example label stays readable while the body
-                    // collapses away. Deferred so the language service
-                    // has time to compute fold ranges before we run.
-                    setTimeout(() => {
-                      editor.getAction('editor.foldAll')?.run()
-                    }, 400)
+                    if (codeInitiallyFolded) {
+                      // Deferred so Monaco's language service has time to
+                      // compute fold ranges before we collapse them.
+                      setTimeout(() => {
+                        editor.getAction('editor.foldAll')?.run()
+                      }, 400)
+                    }
                   }}
                   options={editorOptions(monoFontFamily)}
                 />
@@ -924,22 +924,22 @@ function FormField({
   }
 
   if (c.kind === 'boolean') {
-    // Dogfood Anta's <Checkbox> (small) for boolean controls — the prop name is
-    // its label (kept in the monospace field-name style); the description rides
-    // along as a native title. aria-label is set explicitly since the label is a
-    // vnode, not a plain string the wrapper could derive a name from.
+    // Keep booleans in the same label/control grid as the other props. The
+    // checkbox takes its accessible name explicitly because its visual label is
+    // rendered in the shared left-hand column.
     return (
-      <div class={s.fieldBoolean}>
+      <div class={s.field}>
+        <div class={s.fieldLabel}>
+          <span><FieldName name={c.name} description={c.description} /></span>
+          {fromExpression ? <span class={s.fieldExpressionBadge}>set by code</span> : null}
+        </div>
         <Checkbox
           size="small"
           checked={value === true}
           disabled={fromExpression}
           aria-label={c.name}
           onStateChange={(_e, { next }) => handle(next === true)}
-        >
-          <FieldName name={c.name} description={c.description} />
-        </Checkbox>
-        {fromExpression ? <span class={s.fieldExpressionBadge}>set by code</span> : null}
+        />
       </div>
     )
   }
@@ -1076,13 +1076,30 @@ function FieldControl({
         />
       )
     case 'segmented': {
-      // Dogfood Anta <Tabs> (primary = segmented-control look, small) as the enum
-      // picker. Controlled via `value`; a pick requests the change through
-      // `onStateChange`, which we forward to the form. When no literal is set in
-      // code we fall back to the control's default so the implicit choice still
-      // reads as active. `clearable` adds a leading "none" tab that omits the attr.
+      // A short enum is clearest as Anta <Tabs>; longer lists become an Anta
+      // <Select> so labels do not crowd or overflow the fixed-size panel. When no
+      // literal is set in code, fall back to the control's default so the implicit
+      // choice still reads as selected. `clearable` adds a leading "none" option
+      // that omits the attribute.
       const selected = value !== undefined ? value : control.defaultValue
       const active = selected === undefined ? '__none' : String(selected)
+      const options = [
+        ...(control.clearable ? [{ value: '__none', label: 'none', tooltip: 'none' }] : []),
+        ...control.options.map((opt) => ({ value: opt, label: opt, tooltip: opt })),
+      ]
+      if (options.length > 4) {
+        return (
+          <Select
+            className={s.selectControl}
+            size="small"
+            aria-label={control.name}
+            value={active}
+            disabled={disabled}
+            onValueChange={(next) => onChange(next === '__none' ? null : next)}
+            options={options}
+          />
+        )
+      }
       return (
         <Tabs
           className={s.segTabs}
@@ -1092,18 +1109,15 @@ function FieldControl({
           value={active}
           disabled={disabled}
           onStateChange={(_e, { next }) => onChange(next === '__none' ? null : next)}
-          options={[
-            ...(control.clearable ? [{ value: '__none', label: 'none', tooltip: 'none' }] : []),
-            ...control.options.map((opt) => ({ value: opt, label: opt, tooltip: opt })),
-          ]}
+          options={options}
         />
       )
     }
     case 'tone': {
-      // Named-tone tabs + a "custom" tab, as Anta <Tabs> (small). A value outside
-      // `options` (a colour literal) means custom → reveal the colour picker. The
-      // picker only reflects valid hex; a hand-typed `oklch(…)` stays in the code
-      // and shows beside the picker without being overwritten.
+      // Named tones are a seven-item choice, so use Anta <Select> rather than tabs.
+      // A value outside `options` (a colour literal) means custom → reveal the colour
+      // picker. The picker only reflects valid hex; a hand-typed `oklch(…)` stays in
+      // the code and shows beside the picker without being overwritten.
       const v = typeof value === 'string' ? value : undefined
       const selected = v ?? control.defaultValue
       const isCustom = v !== undefined && !control.options.includes(v)
@@ -1111,14 +1125,13 @@ function FieldControl({
       const active = isCustom ? 'custom' : String(selected)
       return (
         <div class={`${s.toneControl} ${cls}`}>
-          <Tabs
-            className={s.segTabs}
-            priority="primary"
+          <Select
+            className={s.selectControl}
             size="small"
-            label={control.name}
+            aria-label={control.name}
             value={active}
             disabled={disabled}
-            onStateChange={(_e, { next }) =>
+            onValueChange={(next) =>
               onChange(next === 'custom' ? (isCustom ? (v as string) : '#ff1493') : next)
             }
             options={[

--- a/site/src/components/a-toc.ts
+++ b/site/src/components/a-toc.ts
@@ -75,7 +75,14 @@ export class ATocElement extends HTMLElement {
       root.querySelectorAll<HTMLElement>(HEADING_SELECTOR),
     ).filter((h) => h.textContent?.trim() && Number(h.tagName[1]) <= maxLevel)
 
-    if (this.headings.length < MIN_HEADINGS) return
+    const hasEntries = this.headings.length >= MIN_HEADINGS
+    this.toggleAttribute('data-empty', !hasEntries)
+    this.dispatchEvent(new CustomEvent('anta-tocchange', {
+      bubbles: true,
+      composed: true,
+      detail: { hasEntries },
+    }))
+    if (!hasEntries) return
 
     const entries: Entry[] = this.headings.map((h) => ({
       id: h.id,

--- a/site/src/components/a-toc.ts
+++ b/site/src/components/a-toc.ts
@@ -291,7 +291,10 @@ export class ATocElement extends HTMLElement {
       .toc-title:hover,
       .toc-title:focus-visible {
         color: var(--text-1-brand);
-        outline: none;
+      }
+      .toc-title:focus-visible {
+        outline: 1px solid var(--focus-ring);
+        outline-offset: 2px;
       }
       .list-wrap {
         position: relative;
@@ -331,11 +334,14 @@ export class ATocElement extends HTMLElement {
       a:hover,
       a:focus-visible {
         color: var(--text-1);
-        outline: none;
         text-decoration: underline dotted;
         text-decoration-color: color-mix(in srgb, currentColor 75%, transparent);
         text-decoration-thickness: 1px;
         text-underline-offset: 3px;
+      }
+      a:focus-visible {
+        outline: 1px solid var(--focus-ring);
+        outline-offset: 2px;
       }
       a[aria-current="true"] {
         color: var(--text-1);

--- a/site/src/components/posthog.astro
+++ b/site/src/components/posthog.astro
@@ -3,7 +3,7 @@
 // Uses is:inline to prevent Astro from processing the script.
 // Includes an initialization guard to prevent stack overflow with ClientRouter.
 ---
-<script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN, apiHost: import.meta.env.PUBLIC_POSTHOG_HOST }}>
+<script is:inline define:vars={{ apiKey: import.meta.env.PUBLIC_POSTHOG_PROJECT_TOKEN }}>
   if (!apiKey && (typeof process === 'undefined' || process.env.NODE_ENV !== 'production')) {
     console.error('PUBLIC_POSTHOG_PROJECT_TOKEN variable required by PostHog is missing or un-configured, this causes events to be silently missed. This error stops appearing once PUBLIC_POSTHOG_PROJECT_TOKEN is configured');
   }
@@ -12,10 +12,12 @@
   // script, causing a stack overflow error.
   if (apiKey && !window.__posthog_initialized) {
     window.__posthog_initialized = true;
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys getNextSurveyStep onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog&&window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="an ln init xn Cn Br kn In capture Fn nn calculateEventProperties On register register_once register_for_session unregister unregister_for_session Ln getFeatureFlag getFeatureFlagPayload getFeatureFlagResult getAllFeatureFlags isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Dn identify setPersonProperties unsetPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset shutdown setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException addExceptionStep captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty An Rn createPersonProfile setInternalOrTestUser $n yn jn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing Tn debug Ur Rt getPageViewId captureTraceFeedback captureTraceMetric pn".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
     posthog.init(apiKey, {
-      api_host: apiHost || 'https://us.i.posthog.com',
-      defaults: '2026-01-30',
+      api_host: 'https://m.anta.design',
+      ui_host: 'https://us.posthog.com',
+      defaults: '2026-05-30',
+      person_profiles: 'identified_only',
       // Track pageviews automatically on every soft navigation via ClientRouter.
       capture_pageview: 'history_change'
     });

--- a/site/src/icons/docs-icons.css
+++ b/site/src/icons/docs-icons.css
@@ -34,6 +34,10 @@
     --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%0A  %3Crect x='2' y='4' width='20' height='16' rx='2' /%3E%0A  %3Cpath d='M10 4v4' /%3E%0A  %3Cpath d='M2 8h20' /%3E%0A  %3Cpath d='M6 4v4' /%3E%0A%3C/svg%3E%0A");
   }
 
+  a-icon[shape="loader-docs"] {
+    --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%0A  %3Cpath d='M12 2v4' /%3E%0A  %3Cpath d='m16.2 7.8 2.9-2.9' /%3E%0A  %3Cpath d='M18 12h4' /%3E%0A  %3Cpath d='m16.2 16.2 2.9 2.9' /%3E%0A  %3Cpath d='M12 18v4' /%3E%0A  %3Cpath d='m4.9 19.1 2.9-2.9' /%3E%0A  %3Cpath d='M2 12h4' /%3E%0A  %3Cpath d='m4.9 4.9 2.9 2.9' /%3E%0A%3C/svg%3E%0A");
+  }
+
   a-icon[shape="octagon-pause"] {
     --icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%0A  %3Cpath d='M10 15V9' /%3E%0A  %3Cpath d='M14 15V9' /%3E%0A  %3Cpath d='M2.586 16.726A2 2 0 0 1 2 15.312V8.688a2 2 0 0 1 .586-1.414l4.688-4.688A2 2 0 0 1 8.688 2h6.624a2 2 0 0 1 1.414.586l4.688 4.688A2 2 0 0 1 22 8.688v6.624a2 2 0 0 1-.586 1.414l-4.688 4.688a2 2 0 0 1-1.414.586H8.688a2 2 0 0 1-1.414-.586z' /%3E%0A%3C/svg%3E%0A");
   }

--- a/site/src/icons/docs-icons.ts
+++ b/site/src/icons/docs-icons.ts
@@ -11,6 +11,7 @@ export const ICON_SHAPES = [
   'circle-play',
   'clipboard-paste',
   'dialog',
+  'loader-docs',
   'octagon-pause',
   'search-slash',
   'settings-2',
@@ -35,6 +36,7 @@ declare module '@antadesign/anta' {
     'circle-play': true
     'clipboard-paste': true
     'dialog': true
+    'loader-docs': true
     'octagon-pause': true
     'search-slash': true
     'settings-2': true

--- a/site/src/icons/svgs/loader-docs.svg
+++ b/site/src/icons/svgs/loader-docs.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2v4" />
+  <path d="m16.2 7.8 2.9-2.9" />
+  <path d="M18 12h4" />
+  <path d="m16.2 16.2 2.9 2.9" />
+  <path d="M12 18v4" />
+  <path d="m4.9 19.1 2.9-2.9" />
+  <path d="M2 12h4" />
+  <path d="m4.9 4.9 2.9 2.9" />
+</svg>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -362,6 +362,7 @@ if (isComponentPage && title) {
             underline="dotted"
             label="On this page"
             aria-label="Open table of contents"
+            data-toc-pending
           />
         )}
         <slot />
@@ -427,6 +428,17 @@ if (isComponentPage && title) {
         if (e.key === 'Escape') closeAll()
       })
       window.addEventListener('hashchange', () => setToc(false))
+
+      // `<a-toc>` only renders when the page has enough headings to navigate.
+      // Keep the mobile trigger hidden until it reports that it has entries,
+      // so overview-style pages never open an empty panel.
+      document.addEventListener('anta-tocchange', (e) => {
+        const target = e.target
+        if (!(target instanceof HTMLElement) || target.localName !== 'a-toc') return
+        const hasEntries = Boolean((e as CustomEvent<{ hasEntries?: boolean }>).detail?.hasEntries)
+        document.querySelector('.toc-toggle')?.toggleAttribute('data-toc-pending', !hasEntries)
+        if (!hasEntries) setToc(false)
+      })
 
       // Theme toggle: flip `.dark` (and the theme-color meta) via the head
       // script's shared apply, then persist the choice. Cold loads apply
@@ -784,6 +796,10 @@ if (isComponentPage && title) {
   /* The in-content "On this page" TOC trigger is mobile-only; on desktop
      the .toc-rail is always visible, so the button is hidden. */
   .toc-toggle {
+    display: none;
+  }
+
+  .toc-toggle[data-toc-pending] {
     display: none;
   }
 

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -313,6 +313,8 @@ if (isComponentPage && title) {
           <li><a href="/tag/" aria-current={isCurrent('/tag/') ? 'page' : undefined}><Icon shape="tag" size={18} /> Tag</a></li>
           <li><a href="/tooltip/" aria-current={isCurrent('/tooltip/') ? 'page' : undefined}><Icon shape="chat" size={18} /> Tooltip</a></li>
           <li><a href="/icon/" aria-current={isCurrent('/icon/') ? 'page' : undefined}><Icon shape="bug" size={18} /> Icon</a></li>
+          <li><a href="/loader/" aria-current={isCurrent('/loader/') ? 'page' : undefined}><Icon shape="loader-docs" size={18} /> Loader</a></li>
+          <li><a href="/progress/" aria-current={isCurrent('/progress/') ? 'page' : undefined}><Icon shape="hourglass" size={18} /> Progress</a></li>
         </menu>
         <hr class="sidebar-separator" />
         <menu>
@@ -342,7 +344,6 @@ if (isComponentPage && title) {
           <li><a href="/banner/" aria-current={isCurrent('/banner/') ? 'page' : undefined}><Icon shape="banner" size={18} /> Banner</a></li>
           <li><a href="/card/" aria-current={isCurrent('/card/') ? 'page' : undefined}><Icon shape="card" size={18} /> Card</a></li>
           <li><a href="/dialog/" aria-current={isCurrent('/dialog/') ? 'page' : undefined}><Icon shape="dialog" size={18} /> Dialog</a></li>
-          <li><a href="/progress/" aria-current={isCurrent('/progress/') ? 'page' : undefined}><Icon shape="hourglass" size={18} /> Progress</a></li>
           <li><a href="/toaster/" aria-current={isCurrent('/toaster/') ? 'page' : undefined}><Icon shape="toaster" size={18} /> Toaster</a></li>
         </menu>
         <h4>Packages</h4>

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -712,6 +712,10 @@ if (isComponentPage && title) {
     align-items: center;
     gap: 0.75ch;
     padding: 4px 0;
+    /* Match the compact corner treatment of Anta menu rows. It also gives
+       the shared focus outline a rounded shape without changing the sidebar's
+       text alignment. */
+    border-radius: var(--radius-sm, 4px);
     color: var(--text-3);
     font-size: 14px;
     font-weight: 400;
@@ -757,6 +761,10 @@ if (isComponentPage && title) {
   .sidebar menu li a[aria-current="page"] > a-icon,
   .package-link:hover > a-icon {
     color: var(--text-1-brand);
+  }
+  .sidebar a:focus-visible {
+    outline: 1px solid var(--focus-ring);
+    outline-offset: 2px;
   }
 
   /* Fill the whole track between the sidebars. The 960px prose measure

--- a/site/src/layouts/DocsLayout.astro
+++ b/site/src/layouts/DocsLayout.astro
@@ -66,6 +66,8 @@ const ogImage = new URL('/og-image.png', Astro.site).href
 const pageUrl = new URL(Astro.url.pathname, Astro.site).href
 const pageTitle = title ? `${title} — Anta` : 'Anta'
 const description = "Antithesis design system: global CSS tokens, framework-agnostic web components, and JSX wrappers for React and Preact."
+// Keep local development free of analytics traffic and token configuration.
+const shouldLoadPostHog = import.meta.env.PROD
 
 // JSON-LD structured data. Every page declares the WebSite; component
 // pages add a breadcrumb trail so search results show the site hierarchy.
@@ -116,7 +118,7 @@ if (isComponentPage && title) {
         registry, fonts, and loaded CSS survive and `a-*` elements upgrade
         instantly. Script rules live in site/AGENTS.md ("ClientRouter"). */}
     <ClientRouter />
-    <PostHog />
+    {shouldLoadPostHog && <PostHog />}
     <title>{pageTitle}</title>
     <meta name="description" content={description} />
     <link rel="canonical" href={pageUrl} />

--- a/site/src/layouts/element-host-styles.css
+++ b/site/src/layouts/element-host-styles.css
@@ -25,6 +25,7 @@
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-expander.css');
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-icon.css');
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-icon.shapes.css');
+@import url('../../node_modules/@antadesign/anta/dist/elements/a-loader.css');
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-input.css');
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-slider.css');
 @import url('../../node_modules/@antadesign/anta/dist/elements/a-input-time.css');

--- a/site/src/pages/button.mdx
+++ b/site/src/pages/button.mdx
@@ -921,6 +921,68 @@ a-button.glass a-button-label {               /* beautified label — gradient t
 }
 ```
 
+<Columns>
+<Col>
+
+<Preview>
+  <Button className="custom" tone="brand" loading label="Saving changes" />
+  <style is:inline>{`
+    /* Replace the standard loading stripes with the loader's rotating field. */
+    a-button.custom[loading]::before {
+      inset: -200%;
+      border-radius: 100%;
+      background: conic-gradient(
+        from 0deg,
+        color-mix(in oklch, currentColor 0%, transparent),
+        color-mix(in oklch, currentColor 10%, transparent)
+      );
+      opacity: 1;
+      filter: none;
+      animation: button-loader-field-spin 1s linear infinite;
+      animation-delay: -9999s;
+    }
+
+    @keyframes button-loader-field-spin {
+      to { transform: rotate(1turn); }
+    }
+  `}</style>
+</Preview>
+
+```tsx folded
+<Button className="custom" tone="brand" loading label="Saving changes" />
+
+<style>{`
+  /* Keep loading's blocked interaction; replace only its stripe overlay. */
+  a-button.custom[loading]::before {
+    inset: -200%;
+    border-radius: 100%;
+    background: conic-gradient(
+      from 0deg,
+      color-mix(in oklch, currentColor 0%, transparent),
+      color-mix(in oklch, currentColor 10%, transparent)
+    );
+    opacity: 1;
+    filter: none;
+    animation: button-loader-field-spin 1s linear infinite;
+    animation-delay: -9999s;
+  }
+
+  @keyframes button-loader-field-spin {
+    to { transform: rotate(1turn); }
+  }
+`}</style>
+```
+
+</Col>
+<Col>
+
+**Loader field.** `loading` still blocks pointer and keyboard activation. This
+only replaces its default stripe overlay with the Loader’s conic field, scaled
+beyond the button so it can rotate behind the label without exposing an edge.
+
+</Col>
+</Columns>
+
 Don't reach for the resolved `--button-fg` / `--button-bg`: they're recomputed per
 state, so setting one only catches a single state — restyle per state as above, or
 use `tone` for a full custom-colour curve.

--- a/site/src/pages/icon.mdx
+++ b/site/src/pages/icon.mdx
@@ -14,6 +14,10 @@ Inline-block icon rendered via CSS `mask-image`. Color follows
 `shape`. The set of valid shapes is the union of Anta's built-ins plus
 any custom icons you generate yourself.
 
+`shape="loader"` is the exception: it is Anta's animated loading alias for
+string-only icon props. Use `Loader` when you need a progress value, speed, or
+accessible loading status.
+
 > In practice you'll rarely reach for `<Icon>` directly. Most Anta
 > components that need an icon expose an `icon` prop that's typed
 > against `IconShape` — autocomplete and type-checking work the same

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -8,9 +8,8 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
   <h1>Overview</h1>
 
   <div class="overview-intro">
-    <StickerThumbsUpAnimated size={256} className="overview-sticker" />
     <Text size="large" className="overview-copy">
-      <p>The <a href="https://antithesis.com" target="_blank">Antithesis</a> design system, <b>Anta</b>, is pretty cool because:</p>
+      <p><b>Anta</b> is <a href="https://antithesis.com" target="_blank">Antithesis</a> design system.<br />Here is why you might like it:</p>
       <ul>
         <li>it's carefully made <dfn>for web apps<Tooltip follow>Import the whole library (~200kb gzipped)<br />or selected components to minimize your bundle.<br />There is <b>no CSS-in-JS runtime</b>.</Tooltip></dfn></li>
         <li>it has a <dfn>clean, attribute-driven DOM<Tooltip follow><b>No piles of utility classes and wrapping containers</b>.<br />Variants, tones, and behavior are attributes: <code>tone="critical"</code>, <code>size="large"</code>.</Tooltip></dfn></li>
@@ -20,6 +19,7 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
         <li>it's well documented, typed, and AI-ready</li>
       </ul>
     </Text>
+    <StickerThumbsUpAnimated size={256} delay={0.5} playOnce replayOnClick label="Replay thumbs-up animation" className="overview-sticker" />
   </div>
 </DocsLayout>
 
@@ -28,8 +28,12 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 12px;
   }
-  .overview-sticker { flex: none; }
-  .overview-copy { flex: 1 1 auto; min-width: min(100%, 28rem); }
+  .overview-sticker { flex: none; transform: scaleX(-1); }
+  .overview-copy { flex: 1 1 auto; min-width: min(100%, 33ch); max-width: 33ch; }
+  .overview-copy ul { padding-left: 1.5ch; }
+  @media (max-width: 640px) {
+    .overview-intro { flex-direction: column; align-items: flex-start; }
+    .overview-sticker { order: -1; }
+  }
 </style>

--- a/site/src/pages/loader.demo.ts
+++ b/site/src/pages/loader.demo.ts
@@ -1,0 +1,5 @@
+/** Playground source for the Loader docs page. */
+export default `import { Loader } from '@antadesign/anta'
+
+<Loader label="Loading results" />
+`

--- a/site/src/pages/loader.mdx
+++ b/site/src/pages/loader.mdx
@@ -235,4 +235,52 @@ opening stop faint so the rotating hand still has a readable leading edge.
 </Col>
 </Columns>
 
+<Columns>
+<Col>
+
+<Preview background="var(--bg-2)">
+  <Loader className="ring-loader" size={32} label="Loading results" />
+  <style is:inline>{`
+    a-loader.ring-loader {
+      position: relative;
+      color: var(--anta-seed-brand);
+    }
+
+    a-loader.ring-loader::after {
+      content: "";
+      position: absolute;
+      inset: 5px;
+      border-radius: 100%;
+      background: var(--bg-2);
+      pointer-events: none;
+    }
+  `}</style>
+</Preview>
+
+```css folded
+a-loader.ring-loader {
+  position: relative;
+  color: var(--anta-seed-brand);
+}
+
+a-loader.ring-loader::after {
+  content: "";
+  position: absolute;
+  inset: 5px;
+  border-radius: 100%;
+  background: var(--bg-2); /* the known surface behind the Loader */
+  pointer-events: none;
+}
+```
+
+</Col>
+<Col>
+
+**Known surface.** This paints a `--bg-2` circle over the Loader, matching
+this preview’s explicit background and making a visual hole. Use the same
+approach only when your Loader sits on a known opaque surface.
+
+</Col>
+</Columns>
+
 </Disclosure>

--- a/site/src/pages/loader.mdx
+++ b/site/src/pages/loader.mdx
@@ -1,0 +1,238 @@
+---
+layout: ../layouts/DocsLayout.astro
+title: Loader
+---
+import Playground from '../components/Playground'
+import Preview from '../components/Preview.astro'
+import PropsTable from '../components/PropsTable.astro'
+import Disclosure from '../components/Disclosure.astro'
+import Columns from '../components/Columns.astro'
+import Col from '../components/Col.astro'
+import AnimatedLoader from '../components/AnimatedLoader'
+import InputLoaderDemo from '../components/InputLoaderDemo'
+import loaderDemoCode from './loader.demo.ts'
+import { Button, Loader, Tag } from '@antadesign/anta'
+
+# Loader
+
+`Loader` is an animated, icon-sized indicator for active work. It rotates while
+the duration is unknown. Pass `value` when the current proportion is known.
+
+<Disclosure title="Playground" anchor={false} brand>
+
+<Playground
+  client:visible
+  component="Loader"
+  layout="side"
+  initialCode={loaderDemoCode}
+/>
+
+</Disclosure>
+
+## Indeterminate and determinate work
+
+<Columns>
+<Col>
+
+<Preview gap="20px">
+  <Loader label="Loading results" />
+  <Loader value={42} label="Uploading files" />
+  <AnimatedLoader client:visible />
+</Preview>
+
+```tsx folded
+// No value: the gradient communicates active work.
+<Loader label="Loading results" />
+
+// A value fills the circle through the current proportion.
+<Loader value={42} label="Uploading files" />
+```
+
+</Col>
+<Col>
+
+Without `value`, the faded gradient rotates. With `value`, the filled section
+starts at 12 o’clock, has a sharp edge at the current proportion, and stays
+still. The final preview is a slow, docs-only 0–100% cycle. `max` defaults to
+`100`.
+
+</Col>
+</Columns>
+
+## Size and speed
+
+<Columns>
+<Col>
+
+<Preview gap="20px">
+  <Loader size={14} speed={1} label="Slow loading" />
+  <Loader label="Loading" />
+  <Loader size={32} label="Loading" />
+</Preview>
+
+```tsx folded
+<Loader size={14} speed={1} label="Slow loading" />
+<Loader label="Loading" />                       // 16px, 0.75 seconds
+<Loader size={32} label="Loading" />
+```
+
+</Col>
+<Col>
+
+`size` is a pixel value, matching `Icon`. `speed` is seconds per rotation. All
+loaders with the same speed share a rotation phase.
+
+</Col>
+</Columns>
+
+## Icon-shape alias
+
+Use `loader` where an Anta component accepts an `IconShape` string. The alias
+is indeterminate and follows the surrounding icon size and color.
+
+<Columns>
+<Col>
+
+<Preview>
+  <Button tone="brand" icon="loader" label="Saving" />
+  <Tag tone="info" icon="loader" label="Syncing" />
+  <InputLoaderDemo client:load />
+</Preview>
+
+```tsx
+<Button tone="brand" icon="loader" label="Saving" />
+<Tag tone="info" icon="loader" label="Syncing" />
+<Input
+  label="Workspace"
+  defaultValue="Anta"
+  hint="Checking availability"
+  dimActions
+  trailing={<Icon shape="loader" aria-hidden="true" />}
+/>
+```
+
+</Col>
+<Col>
+
+The alias uses the same conic field as an alpha mask, keeping the icon slot's
+own color. It is decorative; the surrounding control or field provides its
+label, state, and semantics.
+
+</Col>
+</Columns>
+
+Use `<Loader>` when you need a value, speed, or accessible loading status.
+
+<Disclosure title="Component props">
+
+<PropsTable component="Loader" />
+
+</Disclosure>
+
+<Disclosure title="Vanilla web component">
+
+Use a raw `<a-loader>` when you are not using the JSX wrapper. Set its size,
+speed, and determinate percentage with CSS custom properties. `value` selects
+the static ring; `--loader-value` is the percentage it shows.
+
+<Preview gap="20px">
+  <a-loader role="progressbar" aria-label="Loading files" style={{ '--loader-size': '24px', '--loader-speed': '1s' }}></a-loader>
+  <a-loader value="42" role="progressbar" aria-label="Uploading files" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" style={{ '--loader-size': '24px', '--loader-value': '42%' }}></a-loader>
+</Preview>
+
+```html
+<!-- Indeterminate -->
+<a-loader
+  role="progressbar"
+  aria-label="Loading files"
+  style="--loader-size: 24px; --loader-speed: 1s"
+></a-loader>
+
+<!-- Determinate -->
+<a-loader
+  value="42"
+  role="progressbar"
+  aria-label="Uploading files"
+  aria-valuenow="42"
+  aria-valuemin="0"
+  aria-valuemax="100"
+  style="--loader-size: 24px; --loader-value: 42%"
+></a-loader>
+```
+
+When the value is unknown, omit `value` and give a standalone loader an
+accessible name. Mark a loader beside visible status text with `aria-hidden`.
+
+</Disclosure>
+
+<Disclosure title="Styling">
+
+The standalone Loader uses the quiet `--text-3` color by default. Set `color`
+directly when it needs a deliberate semantic or one-off color; the `loader`
+icon alias inherits its parent control’s color.
+
+<Columns>
+<Col>
+
+<Preview>
+  <Loader className="loader-demo" label="Saving" />
+  <style is:inline>{`
+    .loader-demo { color: mediumaquamarine; }
+  `}</style>
+</Preview>
+
+```css folded
+.loader-demo { color: mediumaquamarine; }
+```
+
+</Col>
+<Col>
+
+The `.loader-demo` class is only for this preview. Use a color on a parent or
+your own selector in an application stylesheet.
+
+</Col>
+</Columns>
+
+<Columns>
+<Col>
+
+<Preview>
+  <Loader className="rainbow-loader" label="Loading colors" />
+  <style is:inline>{`
+    a-loader.rainbow-loader:not([value]) {
+      background: conic-gradient(
+        from 0deg,
+        color-mix(in oklch, #ff5d8f 8%, transparent),
+        #ff5d8f 25%,
+        #9b6cf5 50%,
+        #55b8e8 75%,
+        #45ca9f
+      );
+    }
+  `}</style>
+</Preview>
+
+```css folded
+a-loader.rainbow-loader:not([value]) {
+  background: conic-gradient(
+    from 0deg,
+    color-mix(in oklch, #ff5d8f 8%, transparent),
+    #ff5d8f 25%,
+    #9b6cf5 50%,
+    #55b8e8 75%,
+    #45ca9f
+  );
+}
+```
+
+</Col>
+<Col>
+
+Override `background` to tune an indeterminate gradient field. Keep the
+opening stop faint so the rotating hand still has a readable leading edge.
+
+</Col>
+</Columns>
+
+</Disclosure>

--- a/site/src/pages/normalization.mdx
+++ b/site/src/pages/normalization.mdx
@@ -27,6 +27,8 @@ import '@antadesign/anta/elements'      // web components (client-side only)
 - `margin: 0` on everything — apps build spacing from explicit values.
 - Replaced elements (`img`, `picture`, `video`, `canvas`, `svg`) → `display: block` + `max-width: 100%`, so a stray large asset can't blow out the layout.
 - Form controls (`input`, `button`, `textarea`, `select`) → `font: inherit`.
+- Keyboard-focused elements → a 1px `--focus-ring` outline. Component-specific
+  focus styles keep their own geometry.
 - `overflow-wrap: break-word` on paragraphs + headings; `text-wrap: pretty` on `<p>` and `text-wrap: balance` on headings.
 
 ### Typography (Anta's opinion)

--- a/site/src/pages/progress.mdx
+++ b/site/src/pages/progress.mdx
@@ -6,7 +6,8 @@ import Playground from '../components/Playground'
 import PropsTable from '../components/PropsTable.astro'
 import Disclosure from '../components/Disclosure.astro'
 import Preview from '../components/Preview.astro'
-import AnimatedProgress from '../components/AnimatedProgress'
+import Columns from '../components/Columns.astro'
+import Col from '../components/Col.astro'
 import { Progress } from '@antadesign/anta'
 // The demo source lives in a sibling `.ts` file rather than inline
 // here because Astro's MDX pipeline trims leading whitespace from
@@ -26,50 +27,144 @@ pass `false`, while work is underway without a known duration.
   client:visible
   component="Progress"
   layout="side"
+  codeInitiallyFolded
   initialCode={progressDemoCode}
 />
 
 </Disclosure>
 
-## Examples
+## Value, label and hint
 
-<Preview>
-  <div style={{ display: 'flex', flexDirection: 'column', gap: '20px', width: '100%' }}>
+<Columns>
+<Col>
+
+<Preview gap="12px">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
     <Progress value={60} />
-    <Progress value={42} tone="brand" label="Uploading files…" hint="3 of 7" />
-    <Progress value={75} tone="info" label="Processing" />
-    <Progress value={60} tone="warning" label="Uploading" hint="3 of 5" style={{ borderBottomWidth: '1px' }} />
-    <AnimatedProgress client:visible speed={2} tone="critical" />
-    <Progress label="Preparing upload…" />
+    <Progress value={42} label="Uploading files…" hint="3 of 7" />
+    <Progress label="Preparing upload…" hint="~ 3 minutes left" />
   </div>
 </Preview>
 
-```tsx
-// Minimum invocation — just a value.
+```tsx folded
 <Progress value={60} />
-
-// Pair the value with a descriptive label and a right-aligned hint.
-<Progress value={42} tone="brand" label="Uploading files…" hint="3 of 7" />
-
-// A named tone re-tints every internal color via the --*-{tone} token cascade.
-<Progress value={75} tone="info" label="Processing" />
-
-// The host pre-declares border colour + style with width 0 — give it any
-// width to opt in; the colour auto-tracks the tone.
-<Progress value={60} tone="warning" label="Uploading" hint="3 of 5" style={{ borderBottomWidth: '1px' }} />
-
-// Animate by driving `value` over time.
-function AnimatedProgress({ speed = 1 }) {
-  const [v, setV] = useState(0)
-  useEffect(() => {
-    const id = setInterval(() => setV((x) => (x + speed) % 101), 50)
-    return () => clearInterval(id)
-  }, [speed])
-  return <Progress value={v} label="Animated" />
-}
+<Progress value={42} label="Uploading files…" hint="3 of 7" />
 
 // Omit value, or pass false, while the duration is unknown.
-<Progress label="Preparing upload…" />
+<Progress label="Preparing upload…" hint="~ 3 minutes left" />
+```
+
+</Col>
+<Col>
+
+`value` sets known completion relative to `max`, which defaults to `100`.
+`label` follows the percentage. `hint` is right-aligned. With no `value`, the
+label identifies indeterminate work and the loading animation takes the track.
+
+</Col>
+</Columns>
+
+## Size
+
+`size` scales the track and the default label row together. `medium` is the
+default.
+
+<Preview gap="8px">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+    <Progress size="small" tone="info" value={60} label="Small" hint="~ 3 minutes left" />
+    <Progress tone="info" value={60} label="Medium" hint="~ 3 minutes left" />
+    <Progress size="large" tone="info" value={60} label="Large" hint="~ 3 minutes left" />
+  </div>
+</Preview>
+
+```tsx folded
+<Progress size="small" tone="info" value={60} label="Small" hint="~ 3 minutes left" />
+<Progress tone="info" value={60} label="Medium" hint="~ 3 minutes left" />
+<Progress size="large" tone="info" value={60} label="Large" hint="~ 3 minutes left" />
+```
+
+## Tone
+
+`tone` colors the track, indicator, and label row. Use `neutral` for the
+default, a named semantic tone, or any CSS color.
+
+<Preview gap="12px">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+    <Progress value={60} tone="brand" label="Brand" />
+    <Progress value={60} tone="info" label="Info" />
+    <Progress value={60} tone="success" label="Success" />
+    <Progress value={60} tone="warning" label="Warning" />
+    <Progress value={60} tone="critical" label="Critical" />
+    <Progress value={60} tone="#e0457b" label="Custom" />
+  </div>
+</Preview>
+
+```tsx folded
+<Progress value={60} tone="brand" label="Brand" />
+<Progress value={60} tone="info" label="Info" />
+<Progress value={60} tone="success" label="Success" />
+<Progress value={60} tone="warning" label="Warning" />
+<Progress value={60} tone="critical" label="Critical" />
+<Progress value={60} tone="#e0457b" label="Custom" />
+```
+
+## Border
+
+The track starts borderless. Set a border width to reveal its tone-aware border
+color. A bottom edge works for an indicator at the top of an app. A top edge
+works for one at the bottom.
+
+<Preview gap="12px">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+    <Progress value={60} tone="warning" label="Border on every edge" hint="3 of 5" style={{ borderWidth: '2px' }} />
+    <Progress value={60} tone="info" label="Top-mounted indicator" hint="3 of 5" style={{ borderWidth: '0 0 1px' }} />
+    <Progress value={60} tone="brand" label="Bottom-mounted indicator" hint="3 of 5" style={{ borderTopWidth: '1px' }} />
+  </div>
+</Preview>
+
+```tsx folded
+<Progress
+  value={60}
+  tone="warning"
+  label="Border on every edge"
+  hint="3 of 5"
+  style={{ borderWidth: '2px' }}
+/>
+
+// A bottom border works when the indicator is at the top of the app.
+<Progress
+  value={60}
+  tone="info"
+  label="Top-mounted indicator"
+  hint="3 of 5"
+  style={{ borderWidth: '0 0 1px' }}
+/>
+
+// A top border works when the indicator is at the bottom of the app.
+<Progress
+  value={60}
+  tone="brand"
+  label="Bottom-mounted indicator"
+  hint="3 of 5"
+  style={{ borderTopWidth: '1px' }}
+/>
+```
+
+## Round
+
+`round` makes the track fully round. Pass a number or CSS length for a custom
+radius.
+
+<Preview gap="12px">
+  <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
+    <Progress value={60} round label="Fully round" />
+    <Progress value={60} round={4} label="4px radius" />
+  </div>
+</Preview>
+
+```tsx folded
+<Progress value={60} round label="Fully round" />
+<Progress value={60} round={4} label="4px radius" />
 ```
 
 <Disclosure title="Component props" open>
@@ -85,14 +180,14 @@ Use this when you are not using the React or Preact wrapper and a native HTML co
 Add the progressbar semantics and label structure when using the element directly.
 
 <Preview>
-  <a-progress style={{ width: '100%' }} value="42" max="100" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Upload, 42%">
+  <a-progress style={{ width: '100%' }} value="42" max="100" tone="info" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Upload, 42%">
     <a-progress-label>
       <a-progress-number>42%</a-progress-number>
       <a-progress-text>Upload</a-progress-text>
     </a-progress-label>
   </a-progress>
 
-  <a-progress style={{ width: '100%' }} role="progressbar" aria-label="Preparing upload">
+  <a-progress style={{ width: '100%' }} round="50px" role="progressbar" aria-label="Preparing upload">
     <a-progress-label>
       <a-progress-text>Preparing upload</a-progress-text>
     </a-progress-label>
@@ -100,7 +195,7 @@ Add the progressbar semantics and label structure when using the element directl
 </Preview>
 
 ```html
-<a-progress style="width: 100%" value="42" max="100" role="progressbar"
+<a-progress style="width: 100%" value="42" max="100" tone="info" role="progressbar"
   aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Upload, 42%">
   <a-progress-label>
     <a-progress-number>42%</a-progress-number>
@@ -109,25 +204,43 @@ Add the progressbar semantics and label structure when using the element directl
 </a-progress>
 
 <!-- Omit value for indeterminate progress. -->
-<a-progress style="width: 100%" role="progressbar" aria-label="Preparing upload">
+<a-progress style="width: 100%" round="50px" role="progressbar" aria-label="Preparing upload">
   <a-progress-label>
     <a-progress-text>Preparing upload</a-progress-text>
   </a-progress-label>
 </a-progress>
 ```
 
+### Native HTML progress
+
+For a plain HTML progress indicator, add `data-anta` to `<progress>`. It keeps
+the browser's native semantics, including indeterminate progress when `value`
+is absent, while using Anta's track, fill, tone, and size treatments. Native
+progress does not render Anta's label or hint structure; give it an accessible
+name instead.
+
+<Preview gap="12px">
+  <progress data-anta value="42" max="100" tone="info" aria-label="Uploading, 42%" style={{ width: '100%' }} />
+  <progress data-anta round="50px" aria-label="Preparing upload" style={{ width: '100%' }} />
+</Preview>
+
+```html
+<progress
+  data-anta
+  value="42"
+  max="100"
+  tone="info"
+  aria-label="Uploading, 42%"
+  style="width: 100%"
+></progress>
+
+<!-- Omit value for native indeterminate progress. -->
+<progress data-anta round="50px" aria-label="Preparing upload" style="width: 100%"></progress>
+```
+
 </Disclosure>
 
 <Disclosure title="Styling">
-
-Reach for **`tone`** first — a named tone (`brand` / `info` / `success` / `warning`
-/ `critical`) or any CSS colour for a custom tone (it derives the track, indicator,
-and text in oklch):
-
-```tsx folded
-<Progress value={60} tone="success" />
-<Progress value={60} tone="#e0457b" />
-```
 
 For one-offs, the **track** is the host (style `a-progress` directly) and the
 **indicator** (fill bar) is a shadow **part** — `::part(indicator)`. The `.fancy`

--- a/site/src/pages/progress.mdx
+++ b/site/src/pages/progress.mdx
@@ -66,8 +66,8 @@ label identifies indeterminate work and the loading animation takes the track.
 
 ## Size
 
-`size` scales the track and the default label row together. `medium` is the
-default.
+<Columns>
+<Col>
 
 <Preview gap="8px">
   <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
@@ -83,10 +83,19 @@ default.
 <Progress size="large" tone="info" value={60} label="Large" hint="~ 3 minutes left" />
 ```
 
+</Col>
+<Col>
+
+`size` scales the track and the default label row together. `medium` is the
+default.
+
+</Col>
+</Columns>
+
 ## Tone
 
-`tone` colors the track, indicator, and label row. Use `neutral` for the
-default, a named semantic tone, or any CSS color.
+<Columns>
+<Col>
 
 <Preview gap="12px">
   <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
@@ -108,11 +117,19 @@ default, a named semantic tone, or any CSS color.
 <Progress value={60} tone="#e0457b" label="Custom" />
 ```
 
+</Col>
+<Col>
+
+`tone` colors the track, indicator, and label row. Use `neutral` for the
+default, a named semantic tone, or any CSS color.
+
+</Col>
+</Columns>
+
 ## Border
 
-The track starts borderless. Set a border width to reveal its tone-aware border
-color. A bottom edge works for an indicator at the top of an app. A top edge
-works for one at the bottom.
+<Columns>
+<Col>
 
 <Preview gap="12px">
   <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
@@ -150,10 +167,20 @@ works for one at the bottom.
 />
 ```
 
+</Col>
+<Col>
+
+The track starts borderless. Set a border width to reveal its tone-aware border
+color. A bottom edge works for an indicator at the top of an app. A top edge
+works for one at the bottom.
+
+</Col>
+</Columns>
+
 ## Round
 
-`round` makes the track fully round. Pass a number or CSS length for a custom
-radius.
+<Columns>
+<Col>
 
 <Preview gap="12px">
   <div style={{ display: 'flex', flexDirection: 'column', gap: '12px', width: '100%' }}>
@@ -167,6 +194,15 @@ radius.
 <Progress value={60} round={4} label="4px radius" />
 ```
 
+</Col>
+<Col>
+
+`round` makes the track fully round. Pass a number or CSS length for a custom
+radius.
+
+</Col>
+</Columns>
+
 <Disclosure title="Component props" open>
 
 <PropsTable component="Progress" />
@@ -175,9 +211,8 @@ radius.
 
 <Disclosure title="Vanilla web component">
 
-Use this when you are not using the React or Preact wrapper and a native HTML control does not fit: construct the equivalent Anta web component from the elements below.
-
-Add the progressbar semantics and label structure when using the element directly.
+<Columns>
+<Col>
 
 <Preview>
   <a-progress style={{ width: '100%' }} value="42" max="100" tone="info" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100" aria-label="Upload, 42%">
@@ -211,13 +246,23 @@ Add the progressbar semantics and label structure when using the element directl
 </a-progress>
 ```
 
+</Col>
+<Col>
+
+Use this when you are not using the React or Preact wrapper and a native HTML
+control does not fit: construct the equivalent Anta web component from the
+elements below.
+
+Add the progressbar semantics and label structure when using the element
+directly.
+
+</Col>
+</Columns>
+
 ### Native HTML progress
 
-For a plain HTML progress indicator, add `data-anta` to `<progress>`. It keeps
-the browser's native semantics, including indeterminate progress when `value`
-is absent, while using Anta's track, fill, tone, and size treatments. Native
-progress does not render Anta's label or hint structure; give it an accessible
-name instead.
+<Columns>
+<Col>
 
 <Preview gap="12px">
   <progress data-anta value="42" max="100" tone="info" aria-label="Uploading, 42%" style={{ width: '100%' }} />
@@ -238,13 +283,24 @@ name instead.
 <progress data-anta round="50px" aria-label="Preparing upload" style="width: 100%"></progress>
 ```
 
+</Col>
+<Col>
+
+For a plain HTML progress indicator, add `data-anta` to `<progress>`. It keeps
+the browser's native semantics, including indeterminate progress when `value`
+is absent, while using Anta's track, fill, tone, and size treatments. Native
+progress does not render Anta's label or hint structure; give it an accessible
+name instead.
+
+</Col>
+</Columns>
+
 </Disclosure>
 
 <Disclosure title="Styling">
 
-For one-offs, the **track** is the host (style `a-progress` directly) and the
-**indicator** (fill bar) is a shadow **part** — `::part(indicator)`. The `.fancy`
-class is just for the demo:
+<Columns>
+<Col>
 
 <Preview>
   <div style={{ width: '100%' }}>
@@ -285,5 +341,15 @@ a-progress.fancy a-progress-number,
 a-progress.fancy a-progress-text { color: #fff; }
 a-progress.fancy a-progress-hint { color: var(--text-2); }
 ```
+
+</Col>
+<Col>
+
+For one-offs, the **track** is the host (style `a-progress` directly) and the
+**indicator** (fill bar) is a shadow **part** — `::part(indicator)`. The `.fancy`
+class is just for the demo.
+
+</Col>
+</Columns>
 
 </Disclosure>

--- a/site/src/pages/progress.mdx
+++ b/site/src/pages/progress.mdx
@@ -17,8 +17,8 @@ import progressDemoCode from './progress.demo.ts'
 
 # Progress
 
-A progress indicator for displaying task completion. Consists of a track
-(background bar), an indicator (filled portion), and an optional label area.
+`Progress` shows task completion. Pass `value` for known progress. Omit it, or
+pass `false`, while work is underway without a known duration.
 
 <Disclosure title="Playground" anchor={false} brand>
 
@@ -40,6 +40,7 @@ A progress indicator for displaying task completion. Consists of a track
     <Progress value={75} tone="info" label="Processing" />
     <Progress value={60} tone="warning" label="Uploading" hint="3 of 5" style={{ borderBottomWidth: '1px' }} />
     <AnimatedProgress client:visible speed={2} tone="critical" />
+    <Progress label="Preparing upload…" />
   </div>
 </Preview>
 
@@ -66,6 +67,9 @@ function AnimatedProgress({ speed = 1 }) {
   }, [speed])
   return <Progress value={v} label="Animated" />
 }
+
+// Omit value, or pass false, while the duration is unknown.
+<Progress label="Preparing upload…" />
 ```
 
 <Disclosure title="Component props" open>
@@ -87,6 +91,12 @@ Add the progressbar semantics and label structure when using the element directl
       <a-progress-text>Upload</a-progress-text>
     </a-progress-label>
   </a-progress>
+
+  <a-progress style={{ width: '100%' }} role="progressbar" aria-label="Preparing upload">
+    <a-progress-label>
+      <a-progress-text>Preparing upload</a-progress-text>
+    </a-progress-label>
+  </a-progress>
 </Preview>
 
 ```html
@@ -95,6 +105,13 @@ Add the progressbar semantics and label structure when using the element directl
   <a-progress-label>
     <a-progress-number>42%</a-progress-number>
     <a-progress-text>Upload</a-progress-text>
+  </a-progress-label>
+</a-progress>
+
+<!-- Omit value for indeterminate progress. -->
+<a-progress style="width: 100%" role="progressbar" aria-label="Preparing upload">
+  <a-progress-label>
+    <a-progress-text>Preparing upload</a-progress-text>
   </a-progress-label>
 </a-progress>
 ```

--- a/site/src/pages/stickers.mdx
+++ b/site/src/pages/stickers.mdx
@@ -33,7 +33,7 @@ The full set is also published as a [Telegram sticker pack](https://t.me/addstic
 
 ## Props
 
-Both flavors share the same base props; the animated flavor adds `paused`.
+Both flavors share the same base props; the animated flavor adds playback props.
 
 ### `Sticker{Name}` (static)
 
@@ -51,6 +51,9 @@ Same as the static base, plus:
 | Prop | Type | Description |
 |---|---|---|
 | `paused?` | `boolean \| number` | `true` freezes at the current frame; a number freezes at that time in seconds. Omit (or pass `false`) to play. |
+| `delay?` | `number` | Seconds to wait at the first frame before playing. |
+| `playOnce?` | `boolean` | Plays once and holds the final frame instead of looping. |
+| `replayOnClick?` | `boolean` | With `playOnce`, lets people click or press Enter/Space to replay the animation. The sticker becomes a labeled button. |
 
 <Disclosure title="Vanilla web component">
 
@@ -104,14 +107,18 @@ sticker size too:
 
 ## Animation control
 
-`paused` only applies to `Sticker{Name}Animated`. It maps to the
-element's observed `paused` attribute:
+`paused`, `delay`, `playOnce`, and `replayOnClick` only apply to
+`Sticker{Name}Animated`.
+They map to observed element attributes:
 
 ```tsx
 <StickerCodingAnimated />                  // autoplay, looping
 <StickerCodingAnimated paused />           // freeze at the current frame
 <StickerCodingAnimated paused={1.5} />     // freeze at 1.5 seconds
 <StickerCodingAnimated paused={false} />   // explicitly play (same as omitted)
+<StickerCodingAnimated delay={0.5} />      // wait half a second, then play
+<StickerCodingAnimated playOnce />         // play once, then hold the final frame
+<StickerCodingAnimated playOnce replayOnClick label="Replay coding sticker" />
 ```
 
 ## Adding your own stickers

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -499,8 +499,8 @@ pre code { background: none; padding: 0; }
   cursor: pointer;
 }
 .content .expressive-code .frame .header:focus-visible {
-  outline: 2px solid var(--border-2);
-  outline-offset: -2px;
+  outline: 1px solid var(--focus-ring);
+  outline-offset: -1px;
 }
 /* Bar tint — the chevron (currentColor) and label (inherit) follow this:
    text-4 at rest → text-2 on hover → back to text-4 while pressed. */

--- a/src/components/Loader.tsx
+++ b/src/components/Loader.tsx
@@ -1,0 +1,73 @@
+import type { BaseProps } from '../general_types'
+
+export interface LoaderProps extends BaseProps {
+  /** Current progress value. Omit this prop, or pass `false`, for an
+   * indeterminate rotating gradient. */
+  value?: number | false
+  /** Upper bound of the range.
+   * @defaultValue 100 */
+  max?: number
+  /** Width and height in pixels.
+   * @defaultValue 16 */
+  size?: number
+  /** Seconds per rotation. Pass a positive number.
+   * @defaultValue 0.75 */
+  speed?: number
+  /** Accessible name for a standalone loader. Without a label, the loader is
+   * decorative so nearby status text remains the single announcement. */
+  label?: string
+}
+
+/**
+ * Animated, icon-sized feedback for loading work.
+ *
+ * Omit `value` for the rotating gradient. Pass `value` to fill a static circle
+ * to the current proportion. `shape="loader"` provides the indeterminate
+ * visual for string-only icon props such as `Button`'s `icon`.
+ *
+ * Requires `@antadesign/anta/elements` to be imported (client-side only) to
+ * register the underlying custom element.
+ *
+ * @example Indeterminate
+ * ```tsx
+ * <Loader label="Loading results" />
+ * ```
+ *
+ * @example Determinate
+ * ```tsx
+ * <Loader value={42} label="Uploading files" />
+ * ```
+ */
+export const Loader = ({ value, max = 100, size, speed, label, className, style, ...rest }: LoaderProps) => {
+  const determinate = typeof value === 'number' && Number.isFinite(value)
+  const safeMax = Number.isFinite(max) && max > 0 ? max : 100
+  const clampedValue = determinate ? Math.min(safeMax, Math.max(0, value)) : undefined
+  const percentage = clampedValue != null ? (clampedValue / safeMax) * 100 : undefined
+  const computedStyle = {
+    ...style,
+    ...(size != null ? { ['--loader-size' as string]: `${size}px` } : {}),
+    ...(!determinate && speed != null && Number.isFinite(speed) && speed > 0
+      ? { ['--loader-speed' as string]: `${speed}s` }
+      : {}),
+    ...(percentage != null ? { ['--loader-value' as string]: `${percentage}%` } : {}),
+  } as React.CSSProperties
+  const a11y = label != null
+    ? {
+        role: 'progressbar',
+        'aria-label': label,
+        'aria-valuenow': determinate ? clampedValue : undefined,
+        'aria-valuemin': determinate ? 0 : undefined,
+        'aria-valuemax': determinate ? safeMax : undefined,
+      }
+    : { 'aria-hidden': 'true' as const }
+
+  return (
+    <a-loader
+      {...(determinate ? { value: clampedValue } : {})}
+      class={className}
+      style={computedStyle}
+      {...a11y}
+      {...rest}
+    />
+  )
+}

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -2,8 +2,9 @@ import type { BaseProps } from "../general_types"
 import { hasChildren, toneStyle, roundStyle, roundAttr } from "../anta_helpers"
 
 export interface ProgressProps extends BaseProps {
-  /** Current progress value. Negative values are clamped to 0. */
-  value: number
+  /** Current progress value. Omit this prop, or pass `false`, to show
+   * indeterminate progress. Negative values are clamped to 0. */
+  value?: number | false
   /** Upper bound of the range.
    *  @defaultValue 100 */
   max?: number
@@ -15,10 +16,10 @@ export interface ProgressProps extends BaseProps {
   /** Fully-round track (`border-radius: 999px`); the fill is clipped to it. Pass a
    *  `number` (px) or a CSS length string for a custom radius. */
   round?: boolean | number | string
-  /** Text label displayed after the percentage. When you provide custom
-   *  `children` (which replace the default label row), `label` is no longer
-   *  rendered — but it still supplies the progressbar's accessible name, so
-   *  pass it for screen readers to announce more than the bare percentage. */
+  /** Text label displayed after the percentage, or on its own for
+   *  indeterminate progress. When you provide custom `children` (which replace
+   *  the default label row), `label` is no longer rendered — but it still
+   *  supplies the progressbar's accessible name. */
   label?: string
   /** Right-aligned hint text (e.g. "3 of 7"). Like `label`, it's not rendered
    *  when custom `children` are provided but still feeds the accessible name. */
@@ -26,7 +27,7 @@ export interface ProgressProps extends BaseProps {
 }
 
 /**
- * Progress indicator for displaying task completion.
+ * Progress indicator for task completion and indeterminate work.
  *
  * Renders an `<a-progress>` web component with an optional label area
  * showing percentage, text label, and hint.
@@ -47,34 +48,41 @@ export interface ProgressProps extends BaseProps {
  * <Progress value={42} label="Uploading files..." hint="3 of 7" />
  * ```
  *
+ * @example Indeterminate
+ * ```tsx
+ * <Progress label="Preparing upload..." />
+ * ```
+ *
  * @example Info tone
  * ```tsx
  * <Progress value={75} tone="info" label="Processing" />
  * ```
  */
 export const Progress = ({ value, max = 100, tone, round, label, hint, className, style, children, ...rest }: ProgressProps) => {
-  const percent = max > 0 ? Math.round(Math.min(100, Math.max(0, (value / max) * 100))) : 0
+  const indeterminate = value == null || value === false
+  const numericValue = typeof value === 'number' ? value : 0
+  const percent = max > 0 ? Math.round(Math.min(100, Math.max(0, (numericValue / max) * 100))) : 0
   // Clamp the announced value to [0, max] so screen readers never report an
   // out-of-range progress (e.g. "150 of 100") that contradicts the visually
   // clamped bar and the percentage shown in the label.
-  const clampedValue = max > 0 ? Math.min(max, Math.max(0, value)) : 0
+  const clampedValue = max > 0 ? Math.min(max, Math.max(0, numericValue)) : 0
   // ARIA wiring is added here in the wrapper, not in the web component
   // (see AGENTS.md "ARIA goes in JSX wrappers"). The aria-label echoes
   // every visible piece — label text, percentage, and hint — so screen
-  // readers announce what sighted users see, in one phrase. The role
-  // and aria-value* attributes are still set independently for tooling
-  // that prefers them.
-  const ariaLabel = [label, `${percent}%`, hint].filter(Boolean).join(' · ') || undefined
+  // readers announce what sighted users see, in one phrase. Indeterminate
+  // progress omits the ARIA value attributes, matching native `<progress>`.
+  const ariaLabel = [label, !indeterminate && `${percent}%`, hint].filter(Boolean).join(" · ")
+    || (indeterminate ? "Loading" : undefined)
   return (
     <a-progress
-      value={value}
+      value={indeterminate ? false : numericValue}
       max={max}
       tone={tone && tone !== 'neutral' ? tone : undefined}
       round={roundAttr(round)}
       role="progressbar"
-      aria-valuenow={clampedValue}
-      aria-valuemin={0}
-      aria-valuemax={max}
+      aria-valuenow={indeterminate ? undefined : clampedValue}
+      aria-valuemin={indeterminate ? undefined : 0}
+      aria-valuemax={indeterminate ? undefined : max}
       aria-label={ariaLabel}
       class={className}
       style={roundStyle(round, '--progress-round', toneStyle(tone, '--progress-tone-source', style))}
@@ -82,7 +90,7 @@ export const Progress = ({ value, max = 100, tone, round, label, hint, className
     >
       {hasChildren(children) ? children : (
         <a-progress-label>
-          <a-progress-number>{percent}%</a-progress-number>
+          {!indeterminate && <a-progress-number>{percent}%</a-progress-number>}
           {label != null && <a-progress-text>{label}</a-progress-text>}
           {hint != null && <a-progress-hint>{hint}</a-progress-hint>}
         </a-progress-label>

--- a/src/components/Progress.tsx
+++ b/src/components/Progress.tsx
@@ -13,6 +13,9 @@ export interface ProgressProps extends BaseProps {
    *  light/dark automatically.
    *  @defaultValue 'neutral' */
   tone?: 'neutral' | 'brand' | 'info' | 'success' | 'warning' | 'critical' | (string & {})
+  /** Size variant. Scales the track and the default label row together.
+   *  @defaultValue medium */
+  size?: 'small' | 'medium' | 'large'
   /** Fully-round track (`border-radius: 999px`); the fill is clipped to it. Pass a
    *  `number` (px) or a CSS length string for a custom radius. */
   round?: boolean | number | string
@@ -58,7 +61,7 @@ export interface ProgressProps extends BaseProps {
  * <Progress value={75} tone="info" label="Processing" />
  * ```
  */
-export const Progress = ({ value, max = 100, tone, round, label, hint, className, style, children, ...rest }: ProgressProps) => {
+export const Progress = ({ value, max = 100, tone, size, round, label, hint, className, style, children, ...rest }: ProgressProps) => {
   const indeterminate = value == null || value === false
   const numericValue = typeof value === 'number' ? value : 0
   const percent = max > 0 ? Math.round(Math.min(100, Math.max(0, (numericValue / max) * 100))) : 0
@@ -78,6 +81,7 @@ export const Progress = ({ value, max = 100, tone, round, label, hint, className
       value={indeterminate ? false : numericValue}
       max={max}
       tone={tone && tone !== 'neutral' ? tone : undefined}
+      size={size && size !== 'medium' ? size : undefined}
       round={roundAttr(round)}
       role="progressbar"
       aria-valuenow={indeterminate ? undefined : clampedValue}

--- a/src/elements/a-button.css
+++ b/src/elements/a-button.css
@@ -20,14 +20,16 @@
 
     --button-loading-stripe: 14px;
     --button-loading-stripe-gap: 16px;
-    --button-loading-period: 30px;
+    --button-loading-period: calc(
+      var(--button-loading-stripe) + var(--button-loading-stripe-gap)
+    );
     --button-loading-angle: 125deg;
 
     --button-loading-x-period: calc(
       var(--button-loading-period) / cos(var(--button-loading-angle) - 90deg)
     );
     --button-loading-opacity: 0.15;
-    --button-loading-blur: 2.5px;
+    --button-loading-blur: 5px;
 
     /* Tone — every priority/state is derived in oklch from --_src (the tone's
        seed, or a custom literal colour) with the per-tone --_tone-* constants

--- a/src/elements/a-icon.ts
+++ b/src/elements/a-icon.ts
@@ -1,6 +1,7 @@
 import { HTMLElementBase } from '../anta_helpers'
 import './a-icon.css'
 import './a-icon.shapes.css'
+import './a-loader.css'
 
 /**
  * `<a-icon shape="…">` — pure declarative icon element.

--- a/src/elements/a-loader.css
+++ b/src/elements/a-loader.css
@@ -1,0 +1,65 @@
+@layer anta {
+  /* A standalone loader begins at the legacy text-3 colour. The icon alias
+     intentionally inherits its parent control's colour instead. */
+  a-loader {
+    color: var(--text-3);
+  }
+
+  :where(a-loader, a-icon[shape="loader"]) {
+    display: inline-block;
+    inline-size: var(--loader-size, var(--icon-size, 16px));
+    block-size: var(--loader-size, var(--icon-size, 16px));
+    flex: none;
+    vertical-align: middle;
+    border-radius: 50%;
+    animation: loader-spin var(--loader-speed, 0.75s) linear infinite;
+    animation-delay: -9999s;
+  }
+
+  a-loader {
+    background: conic-gradient(
+      from 0deg,
+      color-mix(in oklch, currentColor 6%, transparent),
+      color-mix(in oklch, currentColor 75%, transparent)
+    );
+  }
+
+  /* `a-icon[shape="loader"]` is the string-shape alias for APIs such as
+     `<Button icon="loader">`. Its normal currentColor background stays in
+     place; the conic field is its alpha mask. */
+  a-icon[shape="loader"] {
+    -webkit-mask-image: conic-gradient(
+      from 0deg,
+      color-mix(in oklch, #000 6%, transparent),
+      color-mix(in oklch, #000 75%, transparent)
+    );
+    mask-image: conic-gradient(
+      from 0deg,
+      color-mix(in oklch, #000 6%, transparent),
+      color-mix(in oklch, #000 75%, transparent)
+    );
+  }
+
+  /* The wrapper resolves the number into --loader-value. A raw element can do
+     the same in inline CSS. Determinate progress deliberately stays still. */
+  a-loader[value] {
+    background: conic-gradient(
+      from 0deg,
+      color-mix(in oklch, currentColor 60%, transparent) 0,
+      color-mix(in oklch, currentColor 75%, transparent) var(--loader-value, 0%),
+      color-mix(in oklch, currentColor 6%, transparent) var(--loader-value, 0%) 100%
+    );
+    animation: none;
+  }
+
+  @keyframes loader-spin {
+    to { transform: rotate(1turn); }
+  }
+
+  @media (forced-colors: active) {
+    a-loader {
+      forced-color-adjust: none;
+      color: CanvasText;
+    }
+  }
+}

--- a/src/elements/a-loader.css
+++ b/src/elements/a-loader.css
@@ -20,7 +20,7 @@
     background: conic-gradient(
       from 0deg,
       color-mix(in oklch, currentColor 6%, transparent),
-      color-mix(in oklch, currentColor 75%, transparent)
+      color-mix(in oklch, currentColor 70%, transparent)
     );
   }
 
@@ -31,7 +31,7 @@
     -webkit-mask-image: conic-gradient(
       from 0deg,
       color-mix(in oklch, #000 6%, transparent),
-      color-mix(in oklch, #000 75%, transparent)
+      color-mix(in oklch, #000 70%, transparent)
     );
     mask-image: conic-gradient(
       from 0deg,

--- a/src/elements/a-loader.ts
+++ b/src/elements/a-loader.ts
@@ -1,0 +1,22 @@
+import { HTMLElementBase } from '../anta_helpers'
+import './a-loader.css'
+
+/**
+ * `<a-loader>` — a declarative, icon-sized loading indicator.
+ *
+ * Its visual treatment is entirely external CSS. The wrapper supplies
+ * `--loader-value` for a determinate ring; no shadow DOM or element state is
+ * needed.
+ */
+export class ALoaderElement extends HTMLElementBase {}
+
+export function register_a_loader() {
+  if (typeof customElements === 'undefined') return
+  if (!customElements.get('a-loader')) {
+    customElements.define('a-loader', ALoaderElement)
+  }
+}
+
+// Importing this module registers the element (granular entry point). The
+// barrel re-exports it, so importing the barrel registers it too. Idempotent.
+register_a_loader()

--- a/src/elements/a-progress.css
+++ b/src/elements/a-progress.css
@@ -57,8 +57,14 @@
      fill indicator to the rounded shape, so only the host radius is needed. A
      value (`round="6px"`, or the wrapper's `round={6}`) sets a custom radius. */
   a-progress[round] {
-    --progress-round: attr(round type(<length>), 999px);
-    border-radius: var(--progress-round, 999px);
+    --progress-round: 999px;
+    border-radius: var(--progress-round);
+  }
+
+  @supports (border-radius: attr(round type(<length>), 999px)) {
+    a-progress[round] {
+      --progress-round: attr(round type(<length>), 999px);
+    }
   }
 
   /* Named tones — each re-aliases the surface/indicator/text to the matching
@@ -101,23 +107,25 @@
 
   /* Custom tone — mirror the corresponding named color roles so the track,
      fill, and right edge retain their `bg-4` → `bg-5` → `border-4` order. */
-  :where(a-progress, progress[data-anta])[tone]:not(
-      [tone=""], [tone="neutral"], [tone="brand"], [tone="info"],
-      [tone="success"], [tone="warning"], [tone="critical"]) {
-    --progress-tone-source: attr(tone type(<color>), transparent);
+  @supports (color: attr(tone type(<color>), transparent)) {
+    :where(a-progress, progress[data-anta])[tone]:not(
+        [tone=""], [tone="neutral"], [tone="brand"], [tone="info"],
+        [tone="success"], [tone="warning"], [tone="critical"]) {
+      --progress-tone-source: attr(tone type(<color>), transparent);
 
-    --progress-bg:             oklch(from var(--progress-tone-source) 0.955 0.02 h);
-    --progress-border-color:   oklch(from var(--progress-tone-source) 0.9 0.04 h);
-    --progress-indicator-bg:   oklch(from var(--progress-tone-source) 0.935 0.03 h);
-    --progress-text-color:     oklch(from var(--progress-tone-source) 0.43 0.15 h);
-    --progress-hint-color:     color-mix(in oklch, var(--progress-text-color) 82%, transparent);
+      --progress-bg:             oklch(from var(--progress-tone-source) 0.955 0.02 h);
+      --progress-border-color:   oklch(from var(--progress-tone-source) 0.9 0.04 h);
+      --progress-indicator-bg:   oklch(from var(--progress-tone-source) 0.935 0.03 h);
+      --progress-text-color:     oklch(from var(--progress-tone-source) 0.43 0.15 h);
+      --progress-hint-color:     color-mix(in oklch, var(--progress-text-color) 82%, transparent);
 
-    .dark & {
-      --progress-bg:           oklch(from var(--progress-tone-source) 0.185 0.05 h);
-      --progress-border-color: oklch(from var(--progress-tone-source) 0.26 0.06 h);
-      --progress-indicator-bg: oklch(from var(--progress-tone-source) 0.205 0.055 h);
-      --progress-text-color:   oklch(from var(--progress-tone-source) 0.77 0.11 h);
-      --progress-hint-color:   color-mix(in oklch, var(--progress-text-color) 80%, transparent);
+      .dark & {
+        --progress-bg:           oklch(from var(--progress-tone-source) 0.185 0.05 h);
+        --progress-border-color: oklch(from var(--progress-tone-source) 0.26 0.06 h);
+        --progress-indicator-bg: oklch(from var(--progress-tone-source) 0.205 0.055 h);
+        --progress-text-color:   oklch(from var(--progress-tone-source) 0.77 0.11 h);
+        --progress-hint-color:   color-mix(in oklch, var(--progress-text-color) 80%, transparent);
+      }
     }
   }
 
@@ -183,7 +191,12 @@
     vertical-align: middle;
   }
   progress[data-anta][round] {
-    --anta-native-progress-radius: attr(round type(<length>), 999px);
+    --anta-native-progress-radius: 999px;
+  }
+  @supports (border-radius: attr(round type(<length>), 999px)) {
+    progress[data-anta][round] {
+      --anta-native-progress-radius: attr(round type(<length>), 999px);
+    }
   }
   progress[data-anta]::-webkit-progress-bar {
     border-radius: var(--anta-native-progress-radius);

--- a/src/elements/a-progress.css
+++ b/src/elements/a-progress.css
@@ -11,6 +11,16 @@
     );
     --progress-text-color: var(--text-2);
     --progress-hint-color: var(--text-3);
+    --progress-loading-angle: 125deg;
+    --progress-loading-x-period: calc(40px + 5cqi);
+    --progress-loading-period: calc(
+      var(--progress-loading-x-period) * cos(var(--progress-loading-angle) - 90deg)
+    );
+    --progress-loading-stripe: calc(var(--progress-loading-period) * 2 / 5);
+    --progress-loading-stripe-gap: calc(var(--progress-loading-period) * 3 / 5);
+    --progress-loading-opacity: 0.15;
+    --progress-loading-blur: clamp(8px, 2cqi, 16px);
+    --progress-loading-duration: 0.5s;
 
     display: block;
     container-type: inline-size;

--- a/src/elements/a-progress.css
+++ b/src/elements/a-progress.css
@@ -1,5 +1,5 @@
 @layer anta {
-  a-progress {
+  :where(a-progress, progress[data-anta]) {
     --progress-bg: var(--bg-4);
     --progress-border-color: var(--border-4);
     --progress-indicator-bg: var(--bg-5);
@@ -21,15 +21,36 @@
     --progress-loading-opacity: 0.15;
     --progress-loading-blur: clamp(8px, 2cqi, 16px);
     --progress-loading-duration: 0.5s;
+    --progress-padding-block: 4px;
+    --progress-padding-inline: 8px;
+    --progress-min-height: 8px;
+    --progress-label-size: 13px;
+    --progress-label-line-height: 16px;
+  }
 
+  a-progress {
     display: block;
     container-type: inline-size;
-    padding: 4px 8px;
-    min-height: 8px;
+    padding: var(--progress-padding-block) var(--progress-padding-inline);
+    min-height: var(--progress-min-height);
     background: var(--progress-bg);
 
     border: 0px solid var(--progress-border-color);
     border-radius: 0;
+  }
+
+  :where(a-progress, progress[data-anta])[size="small"] {
+    --progress-padding-block: 2px;
+    --progress-padding-inline: 6px;
+    --progress-label-size: 12px;
+    --progress-label-line-height: 14px;
+  }
+
+  :where(a-progress, progress[data-anta])[size="large"] {
+    --progress-padding-block: 6px;
+    --progress-padding-inline: 10px;
+    --progress-label-size: 15px;
+    --progress-label-line-height: 20px;
   }
 
   /* `round` → fully-round track. `:host { overflow: hidden }` (shadow) clips the
@@ -42,35 +63,35 @@
 
   /* Named tones — each re-aliases the surface/indicator/text to the matching
      theme-aware role-token tone (so dark mode is free). `neutral` is the base. */
-  a-progress[tone="brand"] {
+  :where(a-progress, progress[data-anta])[tone="brand"] {
     --progress-bg: var(--bg-4-brand);
     --progress-border-color: var(--border-4-brand);
     --progress-indicator-bg: var(--bg-5-brand);
     --progress-text-color: var(--text-2-brand);
     --progress-hint-color: var(--text-3-brand);
   }
-  a-progress[tone="info"] {
+  :where(a-progress, progress[data-anta])[tone="info"] {
     --progress-bg: var(--bg-4-info);
     --progress-border-color: var(--border-4-info);
     --progress-indicator-bg: var(--bg-5-info);
     --progress-text-color: var(--text-2-info);
     --progress-hint-color: var(--text-3-info);
   }
-  a-progress[tone="success"] {
+  :where(a-progress, progress[data-anta])[tone="success"] {
     --progress-bg: var(--bg-4-success);
     --progress-border-color: var(--border-4-success);
     --progress-indicator-bg: var(--bg-5-success);
     --progress-text-color: var(--text-2-success);
     --progress-hint-color: var(--text-3-success);
   }
-  a-progress[tone="warning"] {
+  :where(a-progress, progress[data-anta])[tone="warning"] {
     --progress-bg: var(--bg-4-warning);
     --progress-border-color: var(--border-4-warning);
     --progress-indicator-bg: var(--bg-5-warning);
     --progress-text-color: var(--text-2-warning);
     --progress-hint-color: var(--text-3-warning);
   }
-  a-progress[tone="critical"] {
+  :where(a-progress, progress[data-anta])[tone="critical"] {
     --progress-bg: var(--bg-4-critical);
     --progress-border-color: var(--border-4-critical);
     --progress-indicator-bg: var(--bg-5-critical);
@@ -78,27 +99,25 @@
     --progress-hint-color: var(--text-3-critical);
   }
 
-  /* Custom tone — any non-named tone is a literal CSS colour; the surface,
-     indicator and text are derived from it in oklch (track light, indicator
-     saturated, text deep). Mirrors the custom-tone pattern in checkbox/tag.
-     FIRST-PASS lightness values — review. */
-  a-progress[tone]:not(
+  /* Custom tone — mirror the corresponding named color roles so the track,
+     fill, and right edge retain their `bg-4` → `bg-5` → `border-4` order. */
+  :where(a-progress, progress[data-anta])[tone]:not(
       [tone=""], [tone="neutral"], [tone="brand"], [tone="info"],
       [tone="success"], [tone="warning"], [tone="critical"]) {
     --progress-tone-source: attr(tone type(<color>), transparent);
 
-    --progress-bg:             oklch(from var(--progress-tone-source) 0.95 calc(c * 0.4) h);
-    --progress-border-color:   oklch(from var(--progress-tone-source) 0.85 calc(c * 0.6) h);
-    --progress-indicator-bg:   oklch(from var(--progress-tone-source) 0.6 c h);
-    --progress-text-color:     oklch(from var(--progress-tone-source) 0.45 c h);
-    --progress-hint-color:     oklch(from var(--progress-tone-source) 0.55 c h);
+    --progress-bg:             oklch(from var(--progress-tone-source) 0.955 0.02 h);
+    --progress-border-color:   oklch(from var(--progress-tone-source) 0.9 0.04 h);
+    --progress-indicator-bg:   oklch(from var(--progress-tone-source) 0.935 0.03 h);
+    --progress-text-color:     oklch(from var(--progress-tone-source) 0.43 0.15 h);
+    --progress-hint-color:     color-mix(in oklch, var(--progress-text-color) 82%, transparent);
 
     .dark & {
-      --progress-bg:           oklch(from var(--progress-tone-source) 0.28 calc(c * 0.5) h);
-      --progress-border-color: oklch(from var(--progress-tone-source) 0.4 calc(c * 0.6) h);
-      --progress-indicator-bg: oklch(from var(--progress-tone-source) 0.6 c h);
-      --progress-text-color:   oklch(from var(--progress-tone-source) 0.85 c h);
-      --progress-hint-color:   oklch(from var(--progress-tone-source) 0.75 c h);
+      --progress-bg:           oklch(from var(--progress-tone-source) 0.185 0.05 h);
+      --progress-border-color: oklch(from var(--progress-tone-source) 0.26 0.06 h);
+      --progress-indicator-bg: oklch(from var(--progress-tone-source) 0.205 0.055 h);
+      --progress-text-color:   oklch(from var(--progress-tone-source) 0.77 0.11 h);
+      --progress-hint-color:   color-mix(in oklch, var(--progress-text-color) 80%, transparent);
     }
   }
 
@@ -109,8 +128,8 @@
     font-variant-numeric: lining-nums tabular-nums;
     font-feature-settings: 'ss02', 'ss05';
     letter-spacing: 0.03em;
-    font-size: 13px;
-    line-height: 16px;
+    font-size: var(--progress-label-size);
+    line-height: var(--progress-label-line-height);
   }
 
   a-progress-number {
@@ -130,10 +149,88 @@
     color: var(--progress-hint-color);
   }
 
+  /* Native progress keeps its browser-owned semantics. The determinate track
+     and fill use its engine-specific parts; an indeterminate state gets a
+     host-level overlay, as native value parts are not consistently exposed
+     while the browser is animating them. */
+  progress[data-anta] {
+    --anta-native-progress-height: calc(
+      var(--progress-min-height) + var(--progress-padding-block) + var(--progress-padding-block)
+    );
+    --anta-native-progress-radius: 0px;
+    --anta-native-progress-fill: linear-gradient(
+      90deg,
+      var(--progress-indicator-bg) 0%,
+      var(--progress-indicator-bg) calc(100% - 90px),
+      var(--progress-border-color) 100%
+    );
+
+    box-sizing: border-box;
+    display: block;
+    position: relative;
+    container-type: inline-size;
+    inline-size: 100%;
+    block-size: var(--anta-native-progress-height);
+    margin: 0;
+    padding: 0;
+    border: 0;
+    border-radius: var(--anta-native-progress-radius);
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background: var(--progress-bg);
+    overflow: hidden;
+    vertical-align: middle;
+  }
+  progress[data-anta][round] {
+    --anta-native-progress-radius: attr(round type(<length>), 999px);
+  }
+  progress[data-anta]::-webkit-progress-bar {
+    border-radius: var(--anta-native-progress-radius);
+    background: var(--progress-bg);
+  }
+  progress[data-anta]::-webkit-progress-value {
+    border-radius: var(--anta-native-progress-radius);
+    background: var(--anta-native-progress-fill);
+  }
+  progress[data-anta]::-moz-progress-bar {
+    border: 0;
+    border-radius: var(--anta-native-progress-radius);
+    background: var(--anta-native-progress-fill);
+  }
+  progress[data-anta]:not([value])::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: calc(0px - var(--progress-loading-x-period));
+    width: calc(100% + var(--progress-loading-x-period));
+    pointer-events: none;
+    background: repeating-linear-gradient(
+      var(--progress-loading-angle),
+      transparent 0,
+      transparent var(--progress-loading-stripe-gap),
+      var(--progress-text-color) var(--progress-loading-stripe-gap),
+      var(--progress-text-color) calc(var(--progress-loading-stripe-gap) + var(--progress-loading-stripe))
+    );
+    filter: blur(var(--progress-loading-blur));
+    opacity: var(--progress-loading-opacity);
+    will-change: transform;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    progress[data-anta]:not([value])::before {
+      animation: progress-native-loading-slide var(--progress-loading-duration) linear infinite;
+      animation-delay: -9999s;
+    }
+  }
+  @keyframes progress-native-loading-slide {
+    to { transform: translateX(var(--progress-loading-x-period)); }
+  }
+
   /* The track stays a Canvas surface with a dotted edge. Light forced-colour
      palettes use the selected-item pair for the completed part. */
   @media (forced-colors: active) {
-    a-progress {
+    :where(a-progress, progress[data-anta]) {
       forced-color-adjust: none;
       --progress-bg: Canvas !important;
       --progress-border-color: CanvasText !important;
@@ -148,7 +245,7 @@
     /* Dark palettes use the text-selection pair for the completed part. The
        class covers Anta's explicit theme; the media query covers a system-dark
        forced-colours palette without that class. */
-    .dark a-progress {
+    .dark :where(a-progress, progress[data-anta]) {
       --progress-indicator-bg: Highlight !important;
       --progress-indicator-edge: Highlight !important;
       --progress-indicator-edge-border: 1px solid HighlightText !important;
@@ -156,7 +253,7 @@
   }
 
   @media (forced-colors: active) and (prefers-color-scheme: dark) {
-    a-progress {
+    :where(a-progress, progress[data-anta]) {
       --progress-indicator-bg: Highlight !important;
       --progress-indicator-edge: Highlight !important;
       --progress-indicator-edge-border: 1px solid HighlightText !important;

--- a/src/elements/a-progress.ts
+++ b/src/elements/a-progress.ts
@@ -49,6 +49,31 @@ export class AProgressElement extends HTMLElementBase {
         background: var(--progress-indicator-edge);
         border-right: var(--progress-indicator-edge-border, none);
       }
+      :host(:not([value])) .indicator {
+        left: calc(0px - var(--progress-loading-x-period));
+        width: calc(100% + var(--progress-loading-x-period));
+        background: repeating-linear-gradient(
+          var(--progress-loading-angle),
+          transparent 0,
+          transparent var(--progress-loading-stripe-gap),
+          var(--progress-text-color) var(--progress-loading-stripe-gap),
+          var(--progress-text-color) calc(var(--progress-loading-stripe-gap) + var(--progress-loading-stripe))
+        );
+        filter: blur(var(--progress-loading-blur));
+        opacity: var(--progress-loading-opacity);
+        transition: none;
+      }
+      :host(:not([value])) .indicator::after { display: none; }
+      @media (prefers-reduced-motion: no-preference) {
+        :host(:not([value])) .indicator {
+          will-change: transform;
+          animation: progress-loading-slide var(--progress-loading-duration) linear infinite;
+          animation-delay: -9999s;
+        }
+      }
+      @keyframes progress-loading-slide {
+        to { transform: translateX(var(--progress-loading-x-period)); }
+      }
       slot {
         display: block;
         position: relative;
@@ -76,9 +101,16 @@ export class AProgressElement extends HTMLElementBase {
   }
 
   update() {
-    const value = Number(this.getAttribute('value') ?? 0)
+    const valueAttr = this.getAttribute('value')
+    if (valueAttr == null) {
+      this.indicator.style.removeProperty('--_percent')
+      return
+    }
+    const value = Number(valueAttr)
     const max = Number(this.getAttribute('max') ?? 100)
-    const percent = max > 0 ? Math.min(100, Math.max(0, (value / max) * 100)) : 0
+    const percent = Number.isFinite(value) && Number.isFinite(max) && max > 0
+      ? Math.min(100, Math.max(0, (value / max) * 100))
+      : 0
     this.indicator.style.setProperty('--_percent', `${percent}%`)
   }
 }

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -14,6 +14,7 @@
  * `customElements` (SSR), but there's no reason to load it server-side.
  */
 export { AProgressElement, register_a_progress } from './a-progress'
+export { ALoaderElement, register_a_loader } from './a-loader'
 export { ATextElement, register_a_text } from './a-text'
 export { AIconElement, register_a_icon } from './a-icon'
 export { AButtonElement, register_a_button } from './a-button'

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -188,6 +188,28 @@ export interface AProgressAttributes extends BaseAttributes {
 }
 
 /**
+ * Attributes for the `<a-loader>` custom element. For the JSX wrapper with
+ * cross-browser sizing and accessible progress semantics, use `Loader` from
+ * `@antadesign/anta`.
+ */
+export interface ALoaderAttributes extends BaseAttributes {
+  /** Presence selects the static, determinate gradient. Set `--loader-value`
+   * in `style` to its percentage. Omit this attribute for the rotating
+   * indeterminate gradient. */
+  value?: number | string | false
+  /** ARIA accessible name. */
+  'aria-label'?: string
+  /** Hides a decorative loader from screen readers. */
+  'aria-hidden'?: 'true' | 'false' | boolean
+  /** ARIA value-now for determinate progress. */
+  'aria-valuenow'?: number | string
+  /** ARIA value-min. */
+  'aria-valuemin'?: number | string
+  /** ARIA value-max. */
+  'aria-valuemax'?: number | string
+}
+
+/**
  * Attributes for the `<a-text>` custom element.
  *
  * Low-level web component attributes; for the JSX wrapper use `Text`

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -163,8 +163,8 @@ export interface BaseAttributes extends DOMEventHandlers {
  * typed props and computed labels, use `Progress` from `@antadesign/anta`.
  */
 export interface AProgressAttributes extends BaseAttributes {
-  /** Current progress value. */
-  value?: number | string
+  /** Current progress value. Omit this attribute for indeterminate progress. */
+  value?: number | string | false
   /** Maximum value. Defaults to 100. */
   max?: number | string
   /** Colour variant, or any literal CSS colour for a custom tone (derived in

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -170,6 +170,8 @@ export interface AProgressAttributes extends BaseAttributes {
   /** Colour variant, or any literal CSS colour for a custom tone (derived in
    *  oklch). Named tones track light/dark automatically. */
   tone?: 'neutral' | 'brand' | 'info' | 'success' | 'warning' | 'critical' | (string & {})
+  /** Size variant. `medium` is the default. */
+  size?: 'small' | 'medium' | 'large'
   /** Fully-round track (`border-radius: 999px`), or a custom radius via a length
    *  value (`round="6px"`). Presence-based for the boolean form. */
   round?: boolean | number | string

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@
  */
 export { Progress } from './components/Progress'
 export type { ProgressProps } from './components/Progress'
+export { Loader } from './components/Loader'
+export type { LoaderProps } from './components/Loader'
 export { Text } from './components/Text'
 export type { TextProps, ExpandMode } from './components/Text'
 export { Title } from './components/Title'
@@ -152,7 +154,11 @@ export type { AntaIntrinsicElements } from './jsx-runtime'
  * Seed interface for the icon shape registry. The generated
  * `a-icon.shapes.d.ts` augments this interface with one key per
  * available shape; consumers can do the same with their own generated
- * .d.ts files (TypeScript merges them by interface name).
+ * .d.ts files (TypeScript merges them by interface name). `loader` is the
+ * animated string-shape alias; its CSS lives with the Loader component rather
+ * than the generated static SVG set.
  */
-export interface IconShapes {}
+export interface IconShapes {
+  loader: true
+}
 export type IconShape = keyof IconShapes

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -104,7 +104,7 @@ export function jsxs(type: ComponentType, props: Record<string, unknown> | null,
 
 export { _Fragment as Fragment }
 
-import type { AProgressAttributes, ATextAttributes, ATitleAttributes, ATagAttributes, AExpanderAttributes, AIconAttributes, AButtonAttributes, ACopyAttributes, ACheckboxAttributes, ASwitchAttributes, ATooltipAttributes, AInputAttributes, ASliderAttributes, AInputTimeAttributes, ACalendarAttributes, ARadioAttributes, ARadioGroupAttributes, AMenuAttributes, AMenuItemAttributes, AMenuGroupAttributes, ATabsAttributes, ATabAttributes, ATabpanelAttributes, ADialogAttributes, ACardAttributes, ABannerAttributes, AToasterAttributes, AToastAttributes, BaseAttributes } from './general_types'
+import type { AProgressAttributes, ALoaderAttributes, ATextAttributes, ATitleAttributes, ATagAttributes, AExpanderAttributes, AIconAttributes, AButtonAttributes, ACopyAttributes, ACheckboxAttributes, ASwitchAttributes, ATooltipAttributes, AInputAttributes, ASliderAttributes, AInputTimeAttributes, ACalendarAttributes, ARadioAttributes, ARadioGroupAttributes, AMenuAttributes, AMenuItemAttributes, AMenuGroupAttributes, ATabsAttributes, ATabAttributes, ATabpanelAttributes, ADialogAttributes, ACardAttributes, ABannerAttributes, AToasterAttributes, AToastAttributes, BaseAttributes } from './general_types'
 
 // Declared as an `interface` (not a type alias) so downstream companion
 // packages — e.g. `@antadesign/stickers` — can augment it with their own
@@ -120,6 +120,7 @@ export namespace JSX {
 
 export interface AntaIntrinsicElements {
   'a-progress': AProgressAttributes
+  'a-loader': ALoaderAttributes
   'a-progress-label': BaseAttributes
   'a-progress-number': BaseAttributes
   'a-progress-text': BaseAttributes

--- a/src/reset.css
+++ b/src/reset.css
@@ -37,6 +37,14 @@
     font: inherit;
   }
 
+  /* Give plain, keyboard-focusable HTML the same focus colour and hairline as
+     Anta controls. Component rules are more specific, so an <a-*> element or
+     an opt-in native control keeps its own focus geometry and offset. */
+  :focus-visible {
+    outline: 1px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
+
   /* Wrap long words rather than overflow; `text-wrap: pretty`
      balances widows on paragraphs, `text-wrap: balance` evens
      headlines across lines. */

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -12,7 +12,7 @@
  *
  * Two parts, layered differently on purpose:
  *
- * (1) The global role scale (`--text-*` / `--bg-*` / `--border-*`, below) is
+ * (1) The global role scale (`--text-*` / `--bg-*` / `--border-*` / `--focus-ring`, below) is
  *     UNLAYERED (so it beats the components' `@layer anta` seed-derived tokens and
  *     replaces the role scale wholesale) and uses DOUBLED `:root:root` / `.light.light`
  *     / `.dark.dark` selectors, so it out-SPECIFIES tokens.css's equally-unlayered
@@ -164,6 +164,8 @@
   --border-3-info: #bad6f3;
   --border-4-info: #cfe3f7;
   --border-5-info: #e1eefa;
+
+  --focus-ring: var(--text-2-brand);
 }
 
 /* Doubled `.dark.dark` — mirrors tokens.css's `.dark` (any scoped dark region)
@@ -289,6 +291,8 @@
   --border-3-info: hsl(208.04deg 69.93% 21%);
   --border-4-info: hsl(208.52deg 62.89% 14%);
   --border-5-info: hsl(207.78deg 65.85% 10.5%);
+
+  --focus-ring: var(--text-2-brand);
 }
 
 /* ── 2. Bespoke component ramps — hand-tuned literals ─────────────────────── */

--- a/stickers/src/StickerAnimated.tsx
+++ b/stickers/src/StickerAnimated.tsx
@@ -38,8 +38,9 @@ export const StickerAnimated = ({
   label,
   ...rest
 }: StickerAnimatedInternalProps) => {
+  const canReplay = playOnce && replayOnClick;
   const a11y: StickerA11y | { role: 'button'; 'aria-label': string; tabIndex: number } =
-    replayOnClick
+    canReplay
       ? { role: 'button', 'aria-label': label ?? 'Replay animation', tabIndex: 0 }
       : label != null
         ? { role: "img", "aria-label": label }
@@ -68,7 +69,7 @@ export const StickerAnimated = ({
       paused={pausedAttr}
       delay={delayAttr}
       play-once={playOnce ? '' : undefined}
-      replay-on-click={replayOnClick ? '' : undefined}
+      replay-on-click={canReplay ? '' : undefined}
       {...a11y}
       {...rest}
       style={style}

--- a/stickers/src/StickerAnimated.tsx
+++ b/stickers/src/StickerAnimated.tsx
@@ -1,11 +1,17 @@
 import type { StickerA11y, StickerProps } from "./Sticker";
 
-/** Public props for animated stickers — extends `StickerProps` with
- *  `paused`. The static `Sticker` variant doesn't accept `paused`. */
+/** Public props for animated stickers. The static `Sticker` variant does not
+ *  accept playback props. */
 export interface StickerAnimatedProps extends StickerProps {
   /** `true` freezes the animation at the current frame; a number freezes
    *  at that time in seconds; omit (or `false`) to play. */
-  paused?: boolean | number;
+  paused?: boolean | number
+  /** Seconds to wait at the first frame before playing. */
+  delay?: number
+  /** Play once and hold the final frame instead of looping. */
+  playOnce?: boolean
+  /** With `playOnce`, restart the animation when the sticker is activated. */
+  replayOnClick?: boolean
 }
 
 /** Internal — the bound Lottie animation is supplied by the generated
@@ -26,13 +32,18 @@ export const StickerAnimated = ({
   animation,
   size,
   paused,
+  delay,
+  playOnce,
+  replayOnClick,
   label,
   ...rest
 }: StickerAnimatedInternalProps) => {
-  const a11y: StickerA11y =
-    label != null
-      ? { role: "img", "aria-label": label }
-      : { "aria-hidden": "true" };
+  const a11y: StickerA11y | { role: 'button'; 'aria-label': string; tabIndex: number } =
+    replayOnClick
+      ? { role: 'button', 'aria-label': label ?? 'Replay animation', tabIndex: 0 }
+      : label != null
+        ? { role: "img", "aria-label": label }
+        : { "aria-hidden": "true" };
   // `paused` semantics:
   //   undefined / false → omit attribute (plays)
   //   true              → empty string (freeze at current frame)
@@ -42,7 +53,8 @@ export const StickerAnimated = ({
       ? ""
       : typeof paused === "number"
         ? String(paused)
-        : undefined;
+        : undefined
+  const delayAttr = typeof delay === 'number' && delay > 0 ? String(delay) : undefined
   const style =
     size != null
       ? ({
@@ -54,6 +66,9 @@ export const StickerAnimated = ({
     <a-sticker-animated
       animation={animation}
       paused={pausedAttr}
+      delay={delayAttr}
+      play-once={playOnce ? '' : undefined}
+      replay-on-click={replayOnClick ? '' : undefined}
       {...a11y}
       {...rest}
       style={style}

--- a/stickers/src/elements/a-sticker-animated.css
+++ b/stickers/src/elements/a-sticker-animated.css
@@ -6,4 +6,13 @@
     width: var(--sticker-size);
     height: var(--sticker-size);
   }
+
+  a-sticker-animated[replay-on-click] {
+    cursor: pointer;
+  }
+
+  a-sticker-animated[replay-on-click]:focus-visible {
+    outline: 1px solid var(--focus-ring);
+    outline-offset: 2px;
+  }
 }

--- a/stickers/src/elements/a-sticker-animated.ts
+++ b/stickers/src/elements/a-sticker-animated.ts
@@ -18,6 +18,10 @@ import './a-sticker-animated.css'
  *    tears the player down.
  *  - `paused` — present: freeze at current frame. Numeric value
  *    (seconds): seek to that time, then freeze. Absent: play.
+ *  - `delay` — seconds to wait at the first frame before playing.
+ *  - `play-once` — present: play once, then hold the final frame.
+ *  - `replay-on-click` — present with `play-once`: clicking or pressing
+ *    Enter/Space restarts the animation from its first frame.
  *
  * The shadow container is sized from `--sticker-size` (set by the JSX
  * wrapper's `size` prop or the consumer), with a 256px fallback — see
@@ -26,11 +30,22 @@ import './a-sticker-animated.css'
  * The static counterpart is `<a-sticker>`.
  */
 export class AStickerAnimatedElement extends HTMLElementBase {
-  static observedAttributes = ['animation', 'paused']
+  static observedAttributes = ['animation', 'paused', 'delay', 'play-once', 'replay-on-click']
 
   container: HTMLDivElement
   player: AnimationItem | null = null
   _animation: Record<string, unknown> | null = null
+  #startTimer: ReturnType<typeof setTimeout> | null = null
+  #replay = () => {
+    if (!this.player || !this.hasAttribute('play-once') || !this.hasAttribute('replay-on-click')) return
+    this.#clearStartTimer()
+    this.player.goToAndPlay(0, true)
+  }
+  #onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    this.#replay()
+  }
 
   constructor() {
     super()
@@ -49,10 +64,14 @@ export class AStickerAnimatedElement extends HTMLElementBase {
   }
 
   connectedCallback() {
+    this.addEventListener('click', this.#replay)
+    this.addEventListener('keydown', this.#onKeyDown)
     if (this._animation != null && this.player == null) this.rebuild()
   }
 
   disconnectedCallback() {
+    this.removeEventListener('click', this.#replay)
+    this.removeEventListener('keydown', this.#onKeyDown)
     this.teardown()
   }
 
@@ -61,8 +80,10 @@ export class AStickerAnimatedElement extends HTMLElementBase {
       const value = this.getAttribute('animation')
       this._animation = value ? JSON.parse(value) : null
       if (this.isConnected) this.rebuild()
-    } else if (name === 'paused') {
-      this.applyPaused()
+    } else if (name === 'play-once') {
+      if (this.isConnected) this.rebuild()
+    } else if (name !== 'replay-on-click') {
+      this.syncPlayback()
     }
   }
 
@@ -73,22 +94,34 @@ export class AStickerAnimatedElement extends HTMLElementBase {
     this.player = lottie.loadAnimation({
       container: this.container,
       renderer: 'svg',
-      loop: true,
-      autoplay: !this.hasAttribute('paused'),
+      loop: !this.hasAttribute('play-once'),
+      autoplay: false,
       animationData: this._animation,
     })
 
-    // Apply any pre-existing `paused` value as soon as the player is
-    // constructed. `lottie-web` accepts play / pause / goToAndStop
-    // calls immediately; they're queued until DOM is ready.
-    this.applyPaused()
+    this.player.addEventListener('complete', () => {
+      if (this.hasAttribute('play-once')) {
+        this.player?.goToAndStop(this.player.totalFrames - 1, true)
+      }
+    })
+    this.syncPlayback()
   }
 
-  applyPaused() {
+  syncPlayback() {
+    this.#clearStartTimer()
     if (!this.player) return
     const attr = this.getAttribute('paused')
     if (attr === null) {
-      this.player.play()
+      const delay = Number(this.getAttribute('delay'))
+      if (Number.isFinite(delay) && delay > 0) {
+        this.player.goToAndStop(0, true)
+        this.#startTimer = setTimeout(() => {
+          this.#startTimer = null
+          if (!this.hasAttribute('paused')) this.player?.play()
+        }, delay * 1000)
+      } else {
+        this.player.play()
+      }
       return
     }
     const seconds = Number(attr)
@@ -101,7 +134,15 @@ export class AStickerAnimatedElement extends HTMLElementBase {
     }
   }
 
+  #clearStartTimer() {
+    if (this.#startTimer != null) {
+      clearTimeout(this.#startTimer)
+      this.#startTimer = null
+    }
+  }
+
   teardown() {
+    this.#clearStartTimer()
     if (this.player) {
       this.player.destroy()
       this.player = null

--- a/stickers/src/jsx.ts
+++ b/stickers/src/jsx.ts
@@ -26,7 +26,8 @@ export interface AStickerAttributes extends BaseAttributes {
  * `lottie-web` player (SVG renderer) inside its shadow DOM. The JSX
  * wrapper (`Sticker{Name}Animated`) sets it from the per-sticker
  * module's inlined JSON. Sizing comes from the `--sticker-size` CSS
- * variable; `paused` controls playback.
+ * variable; `paused`, `delay`, `play-once`, and `replay-on-click` control
+ * playback.
  */
 export interface AStickerAnimatedAttributes extends BaseAttributes {
   /** Lottie payload as a JSON string. The element parses it once on
@@ -36,6 +37,12 @@ export interface AStickerAnimatedAttributes extends BaseAttributes {
    *  A numeric string is parsed as seconds and the player seeks to
    *  that time before pausing. Omit to play. */
   paused?: string | boolean | number
+  /** Seconds to wait at the first frame before playing. */
+  delay?: string | number
+  /** Present: play once, then hold the final frame. */
+  'play-once'?: boolean | ''
+  /** With `play-once`: activate the sticker to replay its animation. */
+  'replay-on-click'?: boolean | ''
   role?: string
   'aria-label'?: string
   'aria-hidden'?: 'true' | 'false' | boolean


### PR DESCRIPTION
## What changed

- Add the CSS-only `<a-loader>` component, with determinate and indeterminate circular fields.
- Add `loader` as an icon-shape alias, including support in buttons, tags, and trailing input actions.
- Document Loader beside Icon, move Progress below it, and add styling recipes for custom colours, gradient fields, and a known-surface hollow treatment.
- Add a Button styling recipe that replaces the default loading stripes with a subtle animated loader field.

## Why

Loader is a stateful animated replacement for an icon, distinct from Progress while still allowing a determinate circular value. The dedicated component keeps the animation CSS-driven and gives consumers a consistent visual language across controls.

## Impact

Consumers can import and use `a-loader` directly or render the `loader` icon shape where an animated status affordance is useful. The documentation now explains both standalone and embedded use.

## Validation

- `pnpm run build`
- `pnpm --filter anta-site build`
- `pnpm --filter anta-site lint:css`
- `git diff --check`