### PR TITLE
Release 0.3.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
+## 0.3.18 — August 1, 2026
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

- Bump `@antadesign/anta` from `0.3.17` to `0.3.18`.
- Date the changelog entry for the Loader and Progress release as August 1, 2026.

## Why

This prepares the merged Loader, Progress, and native-progress updates for today’s patch release.

## Impact

Publishing this branch makes `0.3.18` the release version documented by the changelog. The docs sidebar reads the npm `latest` tag at build time and will show the published version automatically.

## Validation

- `pnpm run build`
- Root development server rebuilt Anta, Stickers, and docs successfully.