### PR TITLE
Fix component behaviors and text tooltips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
+## 0.3.21 — August 11, 2026
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ changes are not listed.
 - Tab panels no longer add a default tab stop.
 - Menus no longer dismiss when their visible trigger changes size. They request
   dismissal only after the trigger leaves the viewport.
+- JSX `Text` now shows its clipped content in a tooltip by default. A nested
+  `Tooltip` replaces it, and expandable text does not add one.
+- The Anta light palette now uses the shared focus-ring color.
 
 ## 0.3.20 — August 4, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Added
+
+- `Select`, `SelectFaceted`, `InputAutocomplete`, `RadioGroup`, and `Tabs`
+  option objects accept `className`, `style`, `title`, and safe `data-*`
+  attributes on their rendered rows. `data-menu-*` remains component-owned.
+
+### Fixed
+
+- Tab panels no longer add a default tab stop.
+- Menus no longer dismiss when their visible trigger changes size. They request
+  dismissal only after the trigger leaves the viewport.
+
 ## 0.3.20 — August 4, 2026
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ changes are not listed.
 ### Added
 
 - `Select`, `SelectFaceted`, `InputAutocomplete`, `RadioGroup`, and `Tabs`
-  option objects accept `className`, `style`, `title`, and safe `data-*`
+  option objects accept `className`, `style`, and safe `data-*`
   attributes on their rendered rows. `data-menu-*` remains component-owned.
 
 ### Fixed
@@ -18,7 +18,7 @@ changes are not listed.
   dismissal only after the trigger leaves the viewport.
 - JSX `Text` now shows its clipped content in a tooltip by default. A nested
   `Tooltip` replaces it, and expandable text does not add one.
-- The Anta light palette now uses the shared focus-ring color.
+- The Anta theme now uses the shared focus-ring colors in light and dark modes.
 
 ## 0.3.20 — August 4, 2026
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
+## 0.3.21 — August 11, 2026
 
 ### Added
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@ changes are not listed.
 - Tab panels no longer add a default tab stop.
 - Menus no longer dismiss when their visible trigger changes size. They request
   dismissal only after the trigger leaves the viewport.
+- JSX `Text` now shows its clipped content in a tooltip by default. A nested
+  `Tooltip` replaces it, and expandable text does not add one.
+- The Anta light palette now uses the shared focus-ring color.
 
 ## 0.3.20 — August 4, 2026
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,20 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Added
+
+- `Select`, `SelectFaceted`, `InputAutocomplete`, `RadioGroup`, and `Tabs`
+  option objects accept `className`, `style`, `title`, and safe `data-*`
+  attributes on their rendered rows. `data-menu-*` remains component-owned.
+
+### Fixed
+
+- Tab panels no longer add a default tab stop.
+- Menus no longer dismiss when their visible trigger changes size. They request
+  dismissal only after the trigger leaves the viewport.
+
 ## 0.3.20 — August 4, 2026
 
 ### Changed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,7 +8,7 @@ changes are not listed.
 ### Added
 
 - `Select`, `SelectFaceted`, `InputAutocomplete`, `RadioGroup`, and `Tabs`
-  option objects accept `className`, `style`, `title`, and safe `data-*`
+  option objects accept `className`, `style`, and safe `data-*`
   attributes on their rendered rows. `data-menu-*` remains component-owned.
 
 ### Fixed
@@ -18,7 +18,7 @@ changes are not listed.
   dismissal only after the trigger leaves the viewport.
 - JSX `Text` now shows its clipped content in a tooltip by default. A nested
   `Tooltip` replaces it, and expandable text does not add one.
-- The Anta light palette now uses the shared focus-ring color.
+- The Anta theme now uses the shared focus-ring colors in light and dark modes.
 
 ## 0.3.20 — August 4, 2026
 

--- a/docs/components/radio.md
+++ b/docs/components/radio.md
@@ -27,6 +27,10 @@ styled like `Input`'s hint.
 The group's own `label` and `hint` form a header **above** the options: the
 `label` first, the `hint` (an instruction for the whole set) directly under it.
 
+Each option can also set `className`, `style`, and `data-*`.
+`RadioGroup` forwards them to that option's `<a-radio>` so you can add
+per-option presentation and application metadata.
+
 ## Tones
 
 ```tsx

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -778,7 +778,6 @@ the same thing):
 | `tooltip` | `React.ReactNode` | Row tooltip. In a `multiple` select with `selectAll`, a row with no `tooltip` shows the default "select only this" (Alt/⌥-click) hint; set it to override, or `''` to suppress. |
 | `className` | `string` | CSS class on the rendered menu row. |
 | `style` | `React.CSSProperties` | Inline styles on the rendered menu row. |
-| `title` | `string` | Native browser tooltip on the rendered menu row. |
 | `data-*` | `unknown` | Data attributes on the rendered menu row. `data-menu-*` is reserved for Select's selection and keyboard behavior. |
 | `[key: string]` | `unknown` | Your own data — attach anything and read it back in `renderOption`. |
 

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -776,6 +776,10 @@ the same thing):
 | `disabled` | `boolean` | Disable just this option. |
 | `tone` | `string` | The row's color across label, icon, hint, selected tint, and indicator. A named tone (`neutral` / `brand` / `info` / `success` / `warning` / `critical`) or any CSS color. |
 | `tooltip` | `React.ReactNode` | Row tooltip. In a `multiple` select with `selectAll`, a row with no `tooltip` shows the default "select only this" (Alt/⌥-click) hint; set it to override, or `''` to suppress. |
+| `className` | `string` | CSS class on the rendered menu row. |
+| `style` | `React.CSSProperties` | Inline styles on the rendered menu row. |
+| `title` | `string` | Native browser tooltip on the rendered menu row. |
+| `data-*` | `unknown` | Data attributes on the rendered menu row. `data-menu-*` is reserved for Select's selection and keyboard behavior. |
 | `[key: string]` | `unknown` | Your own data — attach anything and read it back in `renderOption`. |
 
 **`SelectGroup`** — a heading with items rendered inline beneath it.

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -45,6 +45,11 @@ truncation. Both modes use `-webkit-line-clamp` inside
 prefix (Firefox 68+, Chrome, Safari, Edge). The host gets `min-width: 0`
 so truncation works inside flex and grid containers.
 
+JSX `Text` adds a `truncatedOnly` tooltip containing its text content. It
+opens only when the text clips. Nest a `<Tooltip>` to replace that tooltip;
+an empty nested tooltip suppresses it. `expandable` text has no automatic
+tooltip because its own control reveals the content.
+
 ```tsx
 {/* Single line */}
 <Text truncate>{longSentence}</Text>
@@ -53,6 +58,23 @@ so truncation works inside flex and grid containers.
 <Text truncate={2}>{longSentence}</Text>
 <Text truncate={3}>{longSentence}</Text>
 ```
+
+### Use a tooltip with the web component
+
+`<a-text>` does not add a tooltip. Nest `<a-tooltip truncated-only>` and pass
+the full text as its content:
+
+```html
+<a-text truncate="1" style="max-width: 260px; cursor: help">
+  A long status message that is clipped until you hover it.
+  <a-tooltip truncated-only>
+    A long status message that is clipped until you hover it.
+  </a-tooltip>
+</a-text>
+```
+
+`a-text.isTruncated` is a read-only layout measurement. Read it on the UI
+thread when you compose custom truncation behavior.
 
 Pair `expandable` with `truncate` to let the reader reveal the full text.
 The fade and chevron appear only when the clamped content overflows; text
@@ -98,9 +120,11 @@ more" and "Show less". `collapsible` takes effect only with `expandable`.
  kept while lightness/chroma are pinned per priority in oklch. |
 | `truncate?` | boolean \| number | — | Truncate with a trailing ellipsis. `true` (or `1`) clamps to a
  single line; any integer ≥ 2 clamps to that many lines; `0` or a
- negative value means no truncation. Uses the `-webkit-line-clamp`
- technique, supported in all major browsers (Firefox 68+, Chrome,
- Safari, Edge). |
+ negative value means no truncation. A clipped, non-expandable JSX
+ `Text` shows its text content in a tooltip by default. Nest a
+ `<Tooltip>` to provide your own tooltip instead. Uses the
+ `-webkit-line-clamp` technique, supported in all major browsers
+ (Firefox 68+, Chrome, Safari, Edge). |
 
 Use the web component directly when you are not using React or Preact and a native control does not fit.
 

--- a/docs/install-config.md
+++ b/docs/install-config.md
@@ -15,6 +15,7 @@ of a floating tag such as `"latest"`.
 import '@antadesign/anta/tokens.css'  // CSS custom properties
 import '@antadesign/anta/reset.css'   // reset and typography defaults
 import '@antadesign/anta/elements'    // registers <a-*> elements
+import '@antadesign/anta/theme-anta.css' // optional hand-tuned reference palette
 import { Progress } from '@antadesign/anta'
 
 <Progress value={42} label="Uploaded" hint="3 of 7" />
@@ -35,6 +36,10 @@ recommended; the reference theme is optional.
 
 Load `tokens.css` before element CSS. Elements read its variables; without it,
 they render unstyled.
+
+To use the optional reference palette, import `theme-anta.css` after the element
+registration import. It ships in `@antadesign/anta`; omit it to keep the
+seed-derived default palette or provide your own theme.
 
 ### Cascade layers
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,5 +1,20 @@
 # Theming
 
+## Reference palette
+
+`@antadesign/anta` ships an optional hand-tuned reference palette at
+`@antadesign/anta/theme-anta.css`. Import it after the tokens, reset, and element
+registration imports to replace the seed-derived default:
+
+```ts
+import '@antadesign/anta/tokens.css'
+import '@antadesign/anta/reset.css'
+import '@antadesign/anta/elements'
+import '@antadesign/anta/theme-anta.css'
+```
+
+Omit the final import to use the default palette, or define your own theme.
+
 Anta's palette is generative. Every color in the system derives from six tone seeds (`--anta-seed-neutral`, `--anta-seed-brand`, `--anta-seed-info`, …), and a seed contributes only its hue: the lightness and chroma of every background, text, border, and component state come from Anta's formulas, tuned per role and per theme. Reskinning a tone is one custom property, and the whole scale re-derives in both light and dark:
 
 ```css

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.20",
+  "version": "0.3.21-dev.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.21-dev.0",
+  "version": "0.3.21",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/scripts/lint-getters.mjs
+++ b/scripts/lint-getters.mjs
@@ -78,6 +78,7 @@ const READONLY_ALLOWLIST = {
   AInputElement: ['validity', 'validationMessage', 'willValidate'],
   AInputTimeElement: ['validity', 'validationMessage', 'willValidate'],
   AMenuElement: ['isControlled', 'isSubmenu', 'triggerAnchor', 'isOpen'],
+  ATextElement: ['isTruncated'],
   ARadioGroupElement: ['value'],
   ATabsElement: ['value'],
   ACheckboxElement: ['checked', 'indeterminate'],

--- a/site/src/components/TruncateDemo.tsx
+++ b/site/src/components/TruncateDemo.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'preact/hooks'
 import { Text } from '@antadesign/anta'
 
 const longText = 'The quick brown fox jumps over the lazy dog repeatedly while the morning sun rises over a sleepy town that nobody has visited in years and years and years.'
+const tooltipStyle = { cursor: 'help' }
 
 export default function TruncateDemo() {
   useEffect(() => {
@@ -11,16 +12,16 @@ export default function TruncateDemo() {
   return (
     <div class="demoSection" style={{ margin: '16px 0 24px' }}>
       <div class="demoRow">
-        <span class="demoLabel">truncate</span>
-        <div class="demoBox"><Text truncate>{longText}</Text></div>
+        <span class="demoLabel">truncate + automatic tooltip</span>
+        <div class="demoBox"><Text truncate style={tooltipStyle}>{longText}</Text></div>
       </div>
       <div class="demoRow">
         <span class="demoLabel">truncate=&#123;2&#125;</span>
-        <div class="demoBox"><Text truncate={2}>{longText}</Text></div>
+        <div class="demoBox"><Text truncate={2} style={tooltipStyle}>{longText}</Text></div>
       </div>
       <div class="demoRow">
         <span class="demoLabel">truncate=&#123;3&#125;</span>
-        <div class="demoBox"><Text truncate={3}>{longText}</Text></div>
+        <div class="demoBox"><Text truncate={3} style={tooltipStyle}>{longText}</Text></div>
       </div>
     </div>
   )

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -40,7 +40,7 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
   .overview-intro {
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: flex-start;
   }
   .overview-sticker { flex: none; transform: scaleX(-1); }
   .overview-copy { flex: 1 1 auto; min-width: min(100%, 33ch); max-width: 33ch; }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -41,6 +41,7 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
     display: flex;
     flex-wrap: wrap;
     align-items: flex-start;
+    margin-inline-start: 0;
   }
   .overview-sticker { flex: none; transform: scaleX(-1); }
   .overview-copy { flex: 1 1 auto; min-width: min(100%, 33ch); max-width: 33ch; }

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -36,6 +36,7 @@ import { StickerThumbsUpAnimated } from '@antadesign/stickers'
 </DocsLayout>
 
 <style>
+  h1 { margin-inline-start: 0; }
   .overview-notice { margin-block: 1rem 2rem; margin-inline: 0; max-width: 62ch; }
   .overview-intro {
     display: flex;

--- a/site/src/pages/install.mdx
+++ b/site/src/pages/install.mdx
@@ -19,6 +19,7 @@ of a floating tag such as `"latest"`.
 import '@antadesign/anta/tokens.css'  // CSS custom properties
 import '@antadesign/anta/reset.css'   // reset and typography defaults
 import '@antadesign/anta/elements'    // registers <a-*> elements
+import '@antadesign/anta/theme-anta.css' // optional hand-tuned reference palette
 import { Progress } from '@antadesign/anta'
 
 <Progress value={42} label="Uploaded" hint="3 of 7" />
@@ -39,6 +40,10 @@ recommended; the reference theme is optional.
 
 Load `tokens.css` before element CSS. Elements read its variables; without it,
 they render unstyled.
+
+To use the optional reference palette, import `theme-anta.css` after the element
+registration import. It ships in `@antadesign/anta`; omit it to keep the
+seed-derived default palette or provide your own theme.
 
 ### Cascade layers
 

--- a/site/src/pages/radio.mdx
+++ b/site/src/pages/radio.mdx
@@ -74,6 +74,10 @@ styled like `Input`'s hint.
 The group's own `label` and `hint` form a header **above** the options: the
 `label` first, the `hint` (an instruction for the whole set) directly under it.
 
+Each option can also set `className`, `style`, and `data-*`.
+`RadioGroup` forwards them to that option's `<a-radio>` so you can add
+per-option presentation and application metadata.
+
 </Col>
 </Columns>
 

--- a/site/src/pages/select.mdx
+++ b/site/src/pages/select.mdx
@@ -866,6 +866,10 @@ the same thing):
 | `disabled` | `boolean` | Disable just this option. |
 | `tone` | `string` | The row's color across label, icon, hint, selected tint, and indicator. A named tone (`neutral` / `brand` / `info` / `success` / `warning` / `critical`) or any CSS color. |
 | `tooltip` | `React.ReactNode` | Row tooltip. In a `multiple` select with `selectAll`, a row with no `tooltip` shows the default "select only this" (Alt/⌥-click) hint; set it to override, or `''` to suppress. |
+| `className` | `string` | CSS class on the rendered menu row. |
+| `style` | `React.CSSProperties` | Inline styles on the rendered menu row. |
+| `title` | `string` | Native browser tooltip on the rendered menu row. |
+| `data-*` | `unknown` | Data attributes on the rendered menu row. `data-menu-*` is reserved for Select's selection and keyboard behavior. |
 | `[key: string]` | `unknown` | Your own data — attach anything and read it back in `renderOption`. |
 
 **`SelectGroup`** — a heading with items rendered inline beneath it.

--- a/site/src/pages/select.mdx
+++ b/site/src/pages/select.mdx
@@ -868,7 +868,6 @@ the same thing):
 | `tooltip` | `React.ReactNode` | Row tooltip. In a `multiple` select with `selectAll`, a row with no `tooltip` shows the default "select only this" (Alt/⌥-click) hint; set it to override, or `''` to suppress. |
 | `className` | `string` | CSS class on the rendered menu row. |
 | `style` | `React.CSSProperties` | Inline styles on the rendered menu row. |
-| `title` | `string` | Native browser tooltip on the rendered menu row. |
 | `data-*` | `unknown` | Data attributes on the rendered menu row. `data-menu-*` is reserved for Select's selection and keyboard behavior. |
 | `[key: string]` | `unknown` | Your own data — attach anything and read it back in `renderOption`. |
 

--- a/site/src/pages/text.mdx
+++ b/site/src/pages/text.mdx
@@ -80,6 +80,11 @@ truncation. Both modes use `-webkit-line-clamp` inside
 prefix (Firefox 68+, Chrome, Safari, Edge). The host gets `min-width: 0`
 so truncation works inside flex and grid containers.
 
+JSX `Text` adds a `truncatedOnly` tooltip containing its text content. It
+opens only when the text clips. Nest a `<Tooltip>` to replace that tooltip;
+an empty nested tooltip suppresses it. `expandable` text has no automatic
+tooltip because its own control reveals the content.
+
 ```tsx folded
 {/* Single line */}
 <Text truncate>{longSentence}</Text>
@@ -88,6 +93,32 @@ so truncation works inside flex and grid containers.
 <Text truncate={2}>{longSentence}</Text>
 <Text truncate={3}>{longSentence}</Text>
 ```
+
+### Use a tooltip with the web component
+
+`<a-text>` does not add a tooltip. Nest `<a-tooltip truncated-only>` and pass
+the full text as its content:
+
+<Preview>
+  <a-text truncate="1" style={{ maxWidth: '260px', cursor: 'help' }}>
+    A long status message that is clipped until you hover it.
+    <a-tooltip truncated-only>
+      A long status message that is clipped until you hover it.
+    </a-tooltip>
+  </a-text>
+</Preview>
+
+```html
+<a-text truncate="1" style="max-width: 260px; cursor: help">
+  A long status message that is clipped until you hover it.
+  <a-tooltip truncated-only>
+    A long status message that is clipped until you hover it.
+  </a-tooltip>
+</a-text>
+```
+
+`a-text.isTruncated` is a read-only layout measurement. Read it on the UI
+thread when you compose custom truncation behavior.
 
 </Col>
 <Col>

--- a/site/src/pages/theming.mdx
+++ b/site/src/pages/theming.mdx
@@ -8,6 +8,21 @@ import ThemingLab from '../components/ThemingLab.tsx'
 
 # Theming
 
+## Reference palette
+
+`@antadesign/anta` ships an optional hand-tuned reference palette at
+`@antadesign/anta/theme-anta.css`. Import it after the tokens, reset, and element
+registration imports to replace the seed-derived default:
+
+```ts
+import '@antadesign/anta/tokens.css'
+import '@antadesign/anta/reset.css'
+import '@antadesign/anta/elements'
+import '@antadesign/anta/theme-anta.css'
+```
+
+Omit the final import to use the default palette, or define your own theme.
+
 Anta's palette is generative. Every color in the system derives from six tone seeds (`--anta-seed-neutral`, `--anta-seed-brand`, `--anta-seed-info`, …), and a seed contributes only its hue: the lightness and chroma of every background, text, border, and component state come from Anta's formulas, tuned per role and per theme. Reskinning a tone is one custom property, and the whole scale re-derives in both light and dark:
 
 ```css

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -757,6 +757,10 @@ code[data-copied]::after {
   max-width: 960px;
   margin-inline: auto;
 }
+
+.content > :is(h1, .changelog) {
+  margin-inline-start: 0;
+}
 .content > .full-bleed,
 .disclosure > .body > .full-bleed {
   max-width: none;

--- a/site/src/styles/base.css
+++ b/site/src/styles/base.css
@@ -758,9 +758,6 @@ code[data-copied]::after {
   margin-inline: auto;
 }
 
-.content > :is(h1, .changelog) {
-  margin-inline-start: 0;
-}
 .content > .full-bleed,
 .disclosure > .body > .full-bleed {
   max-width: none;

--- a/src/anta_helpers.ts
+++ b/src/anta_helpers.ts
@@ -22,7 +22,6 @@ export function optionPresentationAttrs(
     if (
       name === 'className' ||
       name === 'style' ||
-      name === 'title' ||
       (name.startsWith('data-') &&
         (!menu || (!name.startsWith('data-menu-') && name !== 'data-anta-menu-item')))
     )

--- a/src/anta_helpers.ts
+++ b/src/anta_helpers.ts
@@ -1,8 +1,34 @@
 import { jsx, useState, useMemo } from "./jsx-runtime"
 import type { IconShape } from "./elements/a-icon.shapes"
+import type { OptionPresentationProps } from "./general_types"
 
 export function hasChildren(children: React.ReactNode): boolean {
   return Array.isArray(children) ? children.length > 0 : children != null
+}
+
+/**
+ * Select the safe presentation attributes from a data-rendered option. Option
+ * objects often carry application data, so wrappers must never spread them onto
+ * their rendered element. Menu rows also own `data-menu-*`: those attributes
+ * control closing and combobox navigation, and letting an option replace them
+ * would desynchronize its selection behavior.
+ */
+export function optionPresentationAttrs(
+  option: OptionPresentationProps,
+  menu = false,
+): OptionPresentationProps {
+  const attrs: Record<string, unknown> = {}
+  for (const [name, value] of Object.entries(option)) {
+    if (
+      name === 'className' ||
+      name === 'style' ||
+      name === 'title' ||
+      (name.startsWith('data-') &&
+        (!menu || (!name.startsWith('data-menu-') && name !== 'data-anta-menu-item')))
+    )
+      attrs[name] = value
+  }
+  return attrs as OptionPresentationProps
 }
 
 /**

--- a/src/components/InputAutocomplete.tsx
+++ b/src/components/InputAutocomplete.tsx
@@ -11,7 +11,7 @@
 // Hooks come from the jsx-runtime indirection (configurable via `configure()`),
 // not a hard `react` import — same rule as `Select` / `RadioGroup`.
 import { useState, useMemo, useId } from '../jsx-runtime'
-import { nativeStateChange } from '../anta_helpers'
+import { nativeStateChange, optionPresentationAttrs } from '../anta_helpers'
 import type { BaseProps } from '../general_types'
 import type { IconShape } from '../elements/a-icon.shapes'
 import type { SelectOption } from './Select'
@@ -180,25 +180,31 @@ export const InputAutocomplete = (props: InputAutocompleteProps) => {
         }}
         onactivedescendant={(e: any) => setActiveId(nativeStateChange<{ id: string | null }>(e).detail?.id ?? null)}
       >
-        {visible.map((opt, i) => (
-          <MenuItem
-            key={`${rid}-${opt.value}-${i}`}
-            id={`${rid}-o${i}`}
-            role="option"
-            aria-selected={activeId === `${rid}-o${i}` ? 'true' : 'false'}
-            icon={opt.icon}
-            label={highlight(opt.label ?? opt.value, queryRe)}
-            hint={opt.hint ? highlight(opt.hint, queryRe) : opt.hint}
-            tone={opt.tone}
-            disabled={opt.disabled}
-            value={opt.value}
-            // Keep focus in the field on a mouse pick: preventing the row's
-            // mousedown default stops it taking focus (it's tabIndex=0), so the
-            // click still selects but focus never leaves the input.
-            onMouseDown={(e: any) => e.preventDefault()}
-            onSelect={() => pick(opt)}
-          />
-        ))}
+        {visible.map((opt, i) => {
+          const { className: optionClassName, style: optionStyle, ...optionAttrs } = optionPresentationAttrs(opt, true)
+          return (
+            <MenuItem
+              key={`${rid}-${opt.value}-${i}`}
+              {...optionAttrs}
+              id={`${rid}-o${i}`}
+              role="option"
+              aria-selected={activeId === `${rid}-o${i}` ? 'true' : 'false'}
+              icon={opt.icon}
+              label={highlight(opt.label ?? opt.value, queryRe)}
+              hint={opt.hint ? highlight(opt.hint, queryRe) : opt.hint}
+              tone={opt.tone}
+              disabled={opt.disabled}
+              value={opt.value}
+              // Keep focus in the field on a mouse pick: preventing the row's
+              // mousedown default stops it taking focus (it's tabIndex=0), so the
+              // click still selects but focus never leaves the input.
+              onMouseDown={(e: any) => e.preventDefault()}
+              onSelect={() => pick(opt)}
+              className={optionClassName}
+              style={optionStyle}
+            />
+          )
+        })}
       </Menu>
     </>
   )

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -2,8 +2,8 @@
 // not a hard `react` import — so a custom runtime resolves them, not whatever
 // `react` maps to. See AGENTS.md (stateless-wrapper exception for RadioGroup).
 import { useId, useState } from "../jsx-runtime"
-import { nativeStateChange, toneStyle } from "../anta_helpers"
-import type { BaseProps } from "../general_types"
+import { nativeStateChange, optionPresentationAttrs, toneStyle } from "../anta_helpers"
+import type { BaseProps, OptionPresentationProps } from "../general_types"
 
 /** The element's `statechange` payload. `next`/`prev` are values (`null` = nothing
  *  selected); `reason` distinguishes a user pick from a form reset / bfcache restore. */
@@ -24,7 +24,7 @@ const radioAttrsOf = (el: any): RadioChangeAttrs => ({
 })
 
 /** One option in a `<RadioGroup>`. The wrapper renders an `<a-radio>` per entry. */
-export interface RadioOption {
+export interface RadioOption extends OptionPresentationProps {
   /** This option's identity and the value submitted when it's selected.
    *  Must be unique within the group (a dev-only warning fires on duplicates). */
   value: string
@@ -240,9 +240,11 @@ export const RadioGroup = ({
       <a-radio-list>
         {options.map((o) => {
           const optDisabled = disabled || o.disabled
+          const { className: optionClassName, style: optionStyle, ...optionAttrs } = optionPresentationAttrs(o)
           return (
             <a-radio
               key={o.value}
+              {...optionAttrs}
               role="radio"
               value={o.value}
               aria-disabled={optDisabled ? "true" : undefined}
@@ -255,7 +257,8 @@ export const RadioGroup = ({
               tone-selected={o.toneSelected && o.toneSelected !== "neutral" ? o.toneSelected : undefined}
               size={o.size && o.size !== "medium" ? o.size : undefined}
               disabled={o.disabled ? "" : undefined}
-              style={toneStyle(o.toneSelected, "--radio-tone-source", toneStyle(o.tone, "--radio-tone-source"))}
+              class={optionClassName}
+              style={toneStyle(o.toneSelected, "--radio-tone-source", toneStyle(o.tone, "--radio-tone-source", optionStyle))}
             >
               <a-radio-label>{o.label}</a-radio-label>
               {o.hint != null && <a-radio-hint>{o.hint}</a-radio-hint>}

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -2,9 +2,9 @@
 // as in RadioGroup. Select keeps its selection and open state, then renders an
 // Input trigger followed by a Menu of options. There is no `a-select` element.
 import { useState, useId } from '../jsx-runtime'
-import { ISOLATE_HINT } from '../anta_helpers'
+import { ISOLATE_HINT, optionPresentationAttrs } from '../anta_helpers'
 import { normalizeOpt, matchQueryRegex, matchesQuery, highlight } from './select-options'
-import type { BaseProps } from '../general_types'
+import type { BaseProps, OptionPresentationProps } from '../general_types'
 import type { IconShape } from '../elements/a-icon.shapes'
 import { Input } from './Input'
 import { Icon } from './Icon'
@@ -29,7 +29,7 @@ export type OptionValue = string | number | boolean
  *
  *  Generic in the value type `V` (defaults to `string`): `Select` infers `V` from your
  *  `options`, so `{ value: 365 }` round-trips as `number` through `onValueChange`. */
-export interface SelectOption<V extends OptionValue = string> {
+export interface SelectOption<V extends OptionValue = string> extends OptionPresentationProps {
   /** The option's value (`V`) — its identity, what `value` / `defaultValue` name, and
    *  what `onValueChange` reports. Unique across the whole `options` tree (selection is
    *  value-keyed and global across groups / submenus). */
@@ -656,6 +656,7 @@ export const Select = <V extends OptionValue = string>(props: SelectProps<V>) =>
 
   // One option row. `disabled` is the leaf's *effective* disabled (cascaded).
   const renderOptionRow = (o: SelectOption<V>, disabled: boolean) => {
+    const { className: optionClassName, style: optionStyle, ...optionAttrs } = optionPresentationAttrs(o, true)
     const optState: OptionState<V> = { value: o.value, selected: isSelected(o.value), disabled }
     const custom = renderOption?.(o, optState)
     const customMark = renderIndicator?.(optState)
@@ -676,6 +677,7 @@ export const Select = <V extends OptionValue = string>(props: SelectProps<V>) =>
     return (
       <MenuItem
         key={String(o.value)}
+        {...optionAttrs}
         id={`${uid}-opt-${o.value}`}
         selectionIndicator={menuItemIndicator}
         {...ariaSelectable}
@@ -689,6 +691,8 @@ export const Select = <V extends OptionValue = string>(props: SelectProps<V>) =>
         disabled={disabled || undefined}
         data-menu-open={multiple ? '' : undefined}
         onSelect={(e: any) => choose(o, e)}
+        className={optionClassName}
+        style={optionStyle}
       >
         {custom}
         {tip && (

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -6,7 +6,7 @@
 // Hooks come from the jsx-runtime indirection (configurable via `configure()`),
 // not a hard `react` import — same rule as `Select` / `RadioGroup`.
 import { useState, useMemo } from '../jsx-runtime'
-import { nativeStateChange, ISOLATE_HINT } from '../anta_helpers'
+import { nativeStateChange, ISOLATE_HINT, optionPresentationAttrs } from '../anta_helpers'
 import type { BaseProps } from '../general_types'
 import type { IconShape } from '../elements/a-icon.shapes'
 import type { OptionValue, SelectItem, SelectOption } from './Select'
@@ -394,13 +394,17 @@ export const SelectFaceted = (props: SelectFacetedProps) => {
   // multiple uses a checkbox (toggles). `keyPrefix` namespaces the React key so the
   // same option value under two facets stays a distinct row in the flat list.
   const optionRow = (facet: SelectFacetSingle | SelectFacetMultiple, opt: SelectOption<OptionValue>, keyPrefix = '') => {
+    const { className: optionClassName, style: optionStyle, ...optionAttrs } = optionPresentationAttrs(opt, true)
     const shared = {
+      ...optionAttrs,
       icon: opt.icon,
       label: opt.label ?? String(opt.value),
       hint: opt.hint,
       tone: opt.tone,
       toneSelected,
       disabled: opt.disabled,
+      className: optionClassName,
+      style: optionStyle,
       'data-menu-open': '',
     }
     if (facet.kind === 'single') {

--- a/src/components/TabPanel.tsx
+++ b/src/components/TabPanel.tsx
@@ -3,8 +3,7 @@
  * finds its `<a-tabs>` (its flat sibling under the same parent — `Tabs` renders the
  * strip and panels with no wrapper), matches by `value`, and shows/hides itself
  * off-DOM. This wrapper is a pure projection: it sets the static ARIA (`role`,
- * `tabindex`, `value`) and passes `children` straight through; `Tabs` never reads
- * or toggles it.
+ * `value`) and passes `children` straight through; `Tabs` never reads or toggles it.
  *
  * Use it as a direct child of `<Tabs>`, paired to an `options` entry by `value`.
  * For a strip and panels in different layout regions (no shared parent), or to
@@ -32,7 +31,6 @@ export const TabPanel = ({ value, children, hideMode, className, style }: TabPan
   <a-tabpanel
     value={value}
     role="tabpanel"
-    tabIndex={0}
     // 'display' is the implicit default — only the visibility variant needs the attr.
     hide-mode={hideMode === "visibility" ? "visibility" : undefined}
     class={className}

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -6,8 +6,8 @@
 // (no `Children`/Fragment scan or component-identity matching), which keeps it compatible
 // across React / Preact / custom runtimes and static SSR.
 import { useState } from "../jsx-runtime"
-import { nativeStateChange, toneStyle, roundStyle, roundAttr, wrapLabel } from "../anta_helpers"
-import type { BaseProps } from "../general_types"
+import { nativeStateChange, optionPresentationAttrs, toneStyle, roundStyle, roundAttr, wrapLabel } from "../anta_helpers"
+import type { BaseProps, OptionPresentationProps } from "../general_types"
 import type { IconShape } from "../elements/a-icon.shapes"
 import { Tooltip } from "./Tooltip"
 
@@ -24,7 +24,7 @@ export interface TabsChangeAttrs {
  *  renders its strip from (like `RadioGroup`'s `options`). `Tabs` reads these fields to
  *  render the underlying `<a-tab>` (`tabindex`, `role`, and selection are all `Tabs`'
  *  job, published off-DOM by the element). */
-export interface TabOption {
+export interface TabOption extends OptionPresentationProps {
   /** This tab's identity — pairs it with the `<TabPanel value="…">` of the same
    *  value, and the value reported by `onStateChange` / `onChange`. Unique per strip. */
   value: string
@@ -254,15 +254,16 @@ export const Tabs = ({
       {tabs.map((p) => {
         const tabDisabled = disabled || p.disabled
         const isSelected = p.value === currentValue
+        const { className: optionClassName, style: optionStyle, ...optionAttrs } = optionPresentationAttrs(p)
         return (
           <a-tab
             key={p.value}
+            {...optionAttrs}
             role="tab"
             value={p.value}
             // Per-tab tone override: named/custom pass the attribute (CSS keys off it),
             // and a custom literal color also sets --tabs-tone-source on the tab.
             tone={p.tone && p.tone !== "neutral" ? p.tone : undefined}
-            style={toneStyle(p.tone, "--tabs-tone-source", undefined)}
             aria-disabled={tabDisabled ? "true" : undefined}
             // Every enabled tab is its own tab stop (not a roving single stop) — Tab /
             // Shift+Tab step through them; arrows move + select via the element. A
@@ -272,6 +273,8 @@ export const Tabs = ({
             tabIndex={tabDisabled && !isSelected ? -1 : 0}
             disabled={tabDisabled ? "" : undefined}
             round={roundAttr(round) ?? roundAttr(p.round)}
+            class={optionClassName}
+            style={toneStyle(p.tone, "--tabs-tone-source", optionStyle)}
           >
             {p.icon && <a-icon shape={p.icon} aria-hidden="true" />}
             {wrapLabel(p.label != null ? p.label : p.children, "a-tab-label")}

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -1,5 +1,6 @@
 import type { BaseProps } from "../general_types"
 import { toneStyle } from "../anta_helpers"
+import { Tooltip } from "./Tooltip"
 
 /** Truncation / expansion axis. `expandable` only takes effect with `truncate`;
  *  `collapsible` only with `expandable` — so the type forbids `collapsible`
@@ -38,9 +39,11 @@ export type TextProps = BaseProps & {
   inline?: boolean
   /** Truncate with a trailing ellipsis. `true` (or `1`) clamps to a
    *  single line; any integer ≥ 2 clamps to that many lines; `0` or a
-   *  negative value means no truncation. Uses the `-webkit-line-clamp`
-   *  technique, supported in all major browsers (Firefox 68+, Chrome,
-   *  Safari, Edge). */
+   *  negative value means no truncation. A clipped, non-expandable JSX
+   *  `Text` shows its text content in a tooltip by default. Nest a
+   *  `<Tooltip>` to provide your own tooltip instead. Uses the
+   *  `-webkit-line-clamp` technique, supported in all major browsers
+   *  (Firefox 68+, Chrome, Safari, Edge). */
   truncate?: boolean | number
 } & ExpandMode
 
@@ -97,6 +100,9 @@ export const Text = ({ priority, tone, size, inline, truncate, expandable, colla
       {...rest}
     >
       {children}
+      {lineCount != null && !canExpand && (
+        <Tooltip truncatedOnly data-anta-text-tooltip="" />
+      )}
     </a-text>
   )
 }

--- a/src/elements/a-menu.ts
+++ b/src/elements/a-menu.ts
@@ -12,14 +12,6 @@ const SUBMENU_OPEN_DELAY = 130
 const SUBMENU_CLOSE_DELAY = 130
 /** Typeahead buffer reset window (ms). */
 const TYPEAHEAD_RESET = 500
-/** The open system dismisses once its trigger has scrolled so that less than this
- *  fraction of it still overlaps the spot it occupied when the menu opened — a
- *  size-proportional delta (an IntersectionObserver threshold), not a fixed px.
- *  See trackPosition: this replaces a raw scroll listener, so it reacts to the
- *  anchor moving for ANY reason (page scroll, a scroll container, a layout shift)
- *  and never self-dismisses from the page nudge that opening can cause. */
-const ANCHOR_VISIBLE_RATIO = 0.5
-
 /** Triggers that turn Enter/Space into a click on their own — native
  *  buttons/links, `[role=button]`, and `<a-button>`. The keyboard-open skips
  *  them: their click already opens, so a second open would toggle shut. */
@@ -61,10 +53,6 @@ const openStack: AMenuElement[] = []
 let docBound = false
 let boundDoc: Document | null = null
 let boundView: (Window & typeof globalThis) | null = null
-/** Disconnect for the open system's anchor position tracker (see trackPosition /
- *  armPositionTracker). The system dismisses when the root trigger scrolls out of
- *  the spot it held at open, instead of on raw scroll events. */
-let removePosTracker: (() => void) | null = null
 
 function bindDocListeners(doc: Document, view: Window & typeof globalThis) {
   if (docBound) return
@@ -85,54 +73,9 @@ function unbindDocListeners() {
   boundDoc?.removeEventListener('keyup', onDocKeyUp, true)
   boundDoc?.removeEventListener('contextmenu', onDocContextMenu, true)
   boundView?.removeEventListener('resize', onResize)
-  removePosTracker?.()
-  removePosTracker = null
   boundDoc = null
   boundView = null
   docBound = false
-}
-
-/** Fire `onEscape` once `el` has moved so that less than ANCHOR_VISIBLE_RATIO of
- *  it still overlaps the rect it occupied at setup. An IntersectionObserver whose
- *  root is shrunk (via negative rootMargin) to el's current rect; el sliding past
- *  the threshold drops `isIntersecting`. Read-only (no DOM mutation). Returns a
- *  disconnect fn. (Ported from the prior menu's browser_utils.trackPosition.) */
-function trackPosition(el: HTMLElement, onEscape: () => void): () => void {
-  if (typeof IntersectionObserver === 'undefined') return () => {}
-  const doc = el.ownerDocument
-  // Window the observer to el's OWN box — it's the element we observe, so the
-  // intersection ratio is (el ∩ window) / el, ≈1 at rest and only dropping as el
-  // scrolls away. Do NOT use anchorRect here: getAnchorRect may advertise a
-  // sub-region (a-input returns its `.field`, excluding the label + hint), and
-  // windowing the full host to that smaller rect starts the ratio below the
-  // threshold — a tall label+hint field would self-dismiss the instant it opened.
-  // (Positioning still uses anchorRect elsewhere, to align the menu to the field.)
-  const rect = el.getBoundingClientRect()
-  const vw = doc.documentElement.clientWidth
-  const vh = doc.documentElement.clientHeight
-  // Negative margins shrink the viewport root down to el's current rect.
-  const rootMargin = `${-rect.top}px ${-(vw - rect.right)}px ${-(vh - rect.bottom)}px ${-rect.left}px`
-  // Root choice depends on the frame context:
-  //   • Top level: `null` (the viewport). The negative rootMargin windows the
-  //     viewport to el's open-time rect, so scrolling el out of view drops the
-  //     ratio and dismisses — what we want. A pinned `documentElement` root
-  //     scrolls together with el, so its ratio never drops and the menu floats
-  //     detached, which is wrong here.
-  //   • Inside an iframe: a `null` root resolves against the TOP-LEVEL viewport,
-  //     so the iframe-relative rootMargin windows the wrong region and reports the
-  //     at-rest anchor out-of-view, dismissing a frame after it opens.
-  //     `documentElement` keeps the measurement iframe-local (and, scrolling with
-  //     el, leaves an embedded preview's menu open as the outer page scrolls).
-  const win = doc.defaultView
-  const root = win && win !== win.top ? doc.documentElement : null
-  const io = new IntersectionObserver(
-    ([entry]) => {
-      if (!entry.isIntersecting) onEscape()
-    },
-    { root, rootMargin, threshold: ANCHOR_VISIBLE_RATIO },
-  )
-  io.observe(el)
-  return () => io.disconnect()
 }
 
 /** A node is "inside the open menu system" if the event path crosses any
@@ -1016,7 +959,6 @@ export class AMenuElement extends HTMLElementBase {
     openStack.push(this)
     if (wasEmpty) {
       bindDocListeners(this.doc, this.view)
-      this.armPositionTracker()
     }
 
     const search = this.#searchField
@@ -1050,21 +992,6 @@ export class AMenuElement extends HTMLElementBase {
       this.position(undefined, false, true)
     })
     this.comboObserver.observe(this, { childList: true })
-  }
-
-  /** Watch the root trigger and dismiss the system once it scrolls out of the
-   *  spot it held at open (see trackPosition). Deferred a frame so the trigger's
-   *  post-open layout has settled before the rect is snapshotted; guarded in case
-   *  the menu closed in between. Tracks the root anchor only — submenus ride
-   *  inside it, so if the root anchor goes, the whole system should go. */
-  private armPositionTracker() {
-    const anchor = this.triggerAnchor
-    if (!anchor) return
-    this.view.requestAnimationFrame(() => {
-      if (!this._shown || openStack[0] !== this) return
-      removePosTracker?.()
-      removePosTracker = trackPosition(anchor, () => dismiss())
-    })
   }
 
   /** Apply CLOSE to the DOM (no event). Closes this menu and everything stacked

--- a/src/elements/a-menu.ts
+++ b/src/elements/a-menu.ts
@@ -162,10 +162,9 @@ function onDocKeyUp(e: KeyboardEvent) {
   menu.handleKeyUp(e)
 }
 
-/** Dismiss the open system (outside-click / resize / anchor scrolled out of
- *  view). Routed through the root's `requestClose`, so it emits `statechange` and
- *  respects a controlled root (which stays open until the consumer flips
- *  `state`). */
+/** Dismiss the open system after an outside interaction or resize. Routed through
+ *  the root's `requestClose`, so it emits `statechange` and respects a controlled
+ *  root (which stays open until the consumer flips `state`). */
 function dismiss(originEvent?: Event) {
   openStack[0]?.requestClose(originEvent)
 }
@@ -662,18 +661,14 @@ export class AMenuElement extends HTMLElementBase {
         el.getAttribute('aria-selected') === 'true',
     )
     if (selected) this.scrollItemIntoView(selected)
-    // `preventScroll`: the surface is already positioned in-view, so letting the
-    // browser scroll the document to the freshly-focused item is redundant — and
-    // when the item sits near a viewport edge that programmatic scroll fires the
-    // just-bound scroll-dismiss listener, closing the menu the instant it opens.
-    // scrollItemIntoView (above) handles bringing a selected row into view by
-    // touching only the internal scroll container.
+    // `preventScroll`: the surface is already positioned in view. When needed,
+    // scrollItemIntoView (above) brings the selected row into view by touching
+    // only the internal scroll container.
     if (viaKeyboard) (selected ?? items[0])?.focus({ preventScroll: true })
   }
 
   /** Scroll THIS menu's body so `item` sits inside the visible scroll viewport,
-   *  touching only the internal `.scroll` container — never the document, whose
-   *  scroll would trip the anchor-scrolled-out dismiss. No-op for a menu short
+   *  touching only the internal `.scroll` container. No-op for a menu short
    *  enough not to scroll. */
   private scrollItemIntoView(item: HTMLElement) {
     const c = this.scrollEl

--- a/src/elements/a-tabpanel.ts
+++ b/src/elements/a-tabpanel.ts
@@ -14,8 +14,8 @@ import "./a-tabpanel.css";
 //
 // It never writes a light-DOM attribute (on itself or anything else): a web
 // component mutating light DOM would desync the worker-thread reactive model that
-// owns the light tree. The `Tabs` wrapper only renders it — `role` / `tabindex` /
-// `value` / `hide-mode` are static, JSX-set — and never toggles it.
+// owns the light tree. The `Tabs` wrapper only renders it — `role` / `value` /
+// `hide-mode` are static, JSX-set — and never toggles it.
 //
 // Coordination is by DOM scope: the panel and its <a-tabs> are flat siblings under
 // one parent (`this.parentElement`) — `Tabs` renders them with no wrapper element —

--- a/src/elements/a-text.ts
+++ b/src/elements/a-text.ts
@@ -180,6 +180,16 @@ export class ATextElement extends HTMLElementBase {
     return this.hasAttribute('collapsible')
   }
 
+  /** True when `truncate` currently hides some of the slotted content. This is
+   *  a UI-thread layout read, used by a nested `a-tooltip`; it never writes to
+   *  the host or light DOM. */
+  get isTruncated(): boolean {
+    if (!this.hasAttribute('truncate') || this.expanded) return false
+    const s = this.slotEl
+    if (s.clientWidth === 0 && s.clientHeight === 0) return false
+    return s.scrollHeight > s.clientHeight + 1 || s.scrollWidth > s.clientWidth + 1
+  }
+
   /** Create or remove the chevron to match `expandable`, then refresh it. */
   private syncExpandButton() {
     if (this.#isExpandable && !this.expandBtn) {
@@ -227,9 +237,7 @@ export class ATextElement extends HTMLElementBase {
    *  clips. Frozen on while expanded; height catches wrapped text, width a long word. */
   private measureOverflow() {
     if (!this.#isExpandable || this.expanded) return
-    const s = this.slotEl
-    const over = s.scrollHeight > s.clientHeight + 1 || s.scrollWidth > s.clientWidth + 1
-    s.classList.toggle('overflowing', over)
+    this.slotEl.classList.toggle('overflowing', this.isTruncated)
   }
 
   /** Reflect state onto the button (label + `aria-expanded` + `.expanded`); a

--- a/src/elements/a-tooltip.ts
+++ b/src/elements/a-tooltip.ts
@@ -54,6 +54,9 @@ const ENTER_TOUCH_DELAY = 500
  * anchor itself. Append future ellipsizing parts here.
  */
 const TRUNCATING_PARTS = 'a-tab-label, a-button-label'
+/** Internal marker emitted by JSX `<Text truncate>`. Its tooltip reads the
+ * anchor's rendered text instead of duplicating React children. */
+const AUTOMATIC_TEXT_TOOLTIP = 'data-anta-text-tooltip'
 /**
  * How long (ms) a touch-opened tooltip lingers after the finger lifts, so it
  * stays readable once the anchor is no longer occluded by the fingertip.
@@ -405,6 +408,41 @@ export class ATooltipElement extends HTMLElementBase {
     return this.hasAttribute('truncated-only')
   }
 
+  /** JSX `<Text truncate>` emits an empty marked tooltip. It takes its content
+   * from the anchor, while a consumer-provided sibling tooltip takes precedence
+   * even when that sibling is empty. */
+  get #isAutomaticTextTooltip(): boolean {
+    return this.hasAttribute(AUTOMATIC_TEXT_TOOLTIP)
+  }
+
+  private hasExplicitTextTooltip(): boolean {
+    const anchor = this.anchor
+    if (!this.#isAutomaticTextTooltip || !anchor) return false
+    return Array.from(anchor.children).some(
+      (child) =>
+        child !== this &&
+        child.localName === 'a-tooltip' &&
+        !child.hasAttribute(AUTOMATIC_TEXT_TOOLTIP),
+    )
+  }
+
+  /** Text rendered by the anchor, excluding every tooltip's light-DOM content.
+   *  An automatic text tooltip has no light children itself, but nested custom
+   *  tooltips might; including their hidden content would produce a misleading
+   *  fallback string. */
+  private anchorText(): string {
+    const read = (node: Node): string => {
+      if (node.nodeType === 3) return node.textContent ?? ''
+      if (node.nodeType === 1 && (node as Element).localName === 'a-tooltip') return ''
+      return Array.from(node.childNodes).map(read).join('')
+    }
+    return this.anchor ? Array.from(this.anchor.childNodes).map(read).join('').trim() : ''
+  }
+
+  private syncAutomaticTextContent() {
+    if (this.#isAutomaticTextTooltip) this.bubble.textContent = this.anchorText()
+  }
+
   /** The element whose overflow decides whether the tooltip shows: a
    *  `truncated-selector` resolved within the anchor wins; else the first of
    *  Anta's ellipsizing label parts inside the anchor; else the anchor itself
@@ -431,6 +469,10 @@ export class ATooltipElement extends HTMLElementBase {
   private isTargetTruncated(): boolean {
     const t = this.resolveTruncationTarget()
     if (!t) return false
+    // `a-text` owns the clamping box in shadow DOM. Its host itself does not
+    // overflow, so consume the element's read-only UI-thread measurement first.
+    const reported = (t as HTMLElement & { isTruncated?: unknown }).isTruncated
+    if (typeof reported === 'boolean') return reported
     if (t.clientWidth === 0 && t.clientHeight === 0) return false
     return t.scrollWidth - t.clientWidth > 1 || t.scrollHeight - t.clientHeight > 1
   }
@@ -440,6 +482,7 @@ export class ATooltipElement extends HTMLElementBase {
    *  (so formatting whitespace / an empty conditional doesn't open a blank bubble).
    *  Re-checked on every show(), so a tooltip populated later self-corrects. */
   private isEmpty(): boolean {
+    if (this.#isAutomaticTextTooltip) return this.anchorText() === ''
     return this.children.length === 0 && (this.textContent ?? '').trim() === ''
   }
 
@@ -460,10 +503,16 @@ export class ATooltipElement extends HTMLElementBase {
     if (typeof MutationObserver === 'undefined') return
     if (!this.contentObserver) {
       this.contentObserver = new MutationObserver(() => {
-        if (this.shown && this.isEmpty()) this.hide()
+        if (!this.shown) return
+        this.syncAutomaticTextContent()
+        if (this.isEmpty()) this.hide()
       })
     }
-    this.contentObserver.observe(this, { childList: true, characterData: true, subtree: true })
+    this.contentObserver.observe(this.#isAutomaticTextTooltip ? this.anchor ?? this : this, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    })
   }
 
   // --- positioning (sets only the shadow container's own transform) ---
@@ -557,12 +606,14 @@ export class ATooltipElement extends HTMLElementBase {
     // tooltip (anchor inside the menu) still shows, above the menu. Mirrors the
     // menu dismissing its own trigger's tooltip on open.
     if (isMenuOpen() && !isInsideOpenMenu(this.anchor)) return
+    if (this.hasExplicitTextTooltip()) return
     // Nothing to show → don't open a blank bubble (checked here so every show
     // path — hot-path, focus, touch long-press — is covered).
     if (this.isEmpty()) return
     // truncated-only: bail unless the target is actually clipped (covers the
     // hot-path, focus, and touch long-press, which call show() directly).
     if (this.#truncatedOnly && !this.isTargetTruncated()) return
+    this.syncAutomaticTextContent()
     this.cancelHide() // re-showing (or a hand-off) cancels any pending close
     // Nested anchors: if this anchor *contains* the currently-open tooltip's
     // anchor, an inner (descendant) tooltip is showing — defer to it instead
@@ -702,6 +753,7 @@ export class ATooltipElement extends HTMLElementBase {
    *  show with the latest cursor event. */
   private trigger(e?: MouseEvent) {
     // Don't even arm the delayed show for an empty or non-truncated target.
+    if (this.hasExplicitTextTooltip()) return
     if (this.isEmpty()) return
     if (this.#truncatedOnly && !this.isTargetTruncated()) return
     if (isHot()) {

--- a/src/elements/a-tooltip.ts
+++ b/src/elements/a-tooltip.ts
@@ -119,19 +119,56 @@ function releaseOpen(el: ATooltipElement) {
 /* ------------------------------------------------------------------ *
  * Lazy-listener observer: attach the (relatively heavy) hover/focus
  * listeners only while the anchor is actually on-screen, mirroring the
- * legacy behavior. One observer for every <a-tooltip> on the page.
+ * legacy behavior. An anchor may own more than one tooltip: JSX <Text>
+ * appends an automatic truncated-text tooltip after a consumer-provided one.
+ * The consumer tooltip wins, and the registry keeps the automatic tooltip
+ * ready to take over again if that consumer tooltip is removed.
  * ------------------------------------------------------------------ */
-const anchorToTooltip = new WeakMap<Element, ATooltipElement>()
+type TooltipRegistry = {
+  tooltips: Set<ATooltipElement>
+  intersecting: boolean
+}
+
+const anchorToTooltips = new WeakMap<Element, TooltipRegistry>()
+
+/** Last connected explicit tooltip wins, preserving the prior last-write-wins
+ * behavior for multiple consumer tooltips while letting it take precedence
+ * over Text's trailing automatic tooltip. */
+function preferredTooltip(registry: TooltipRegistry): ATooltipElement | undefined {
+  let automatic: ATooltipElement | undefined
+  let explicit: ATooltipElement | undefined
+  for (const tooltip of registry.tooltips) {
+    if (tooltip.hasAttribute(AUTOMATIC_TEXT_TOOLTIP)) automatic = tooltip
+    else explicit = tooltip
+  }
+  return explicit ?? automatic
+}
+
+/** Keep listener ownership with the preferred tooltip for an anchor. The
+ * observer state is shared so a tooltip that takes over after a sibling is
+ * added or removed follows the same off-screen lazy-listening rule. */
+function syncAnchorListeners(anchor: Element, registry: TooltipRegistry) {
+  const preferred = preferredTooltip(registry)
+  for (const tooltip of registry.tooltips) {
+    if (tooltip !== preferred) tooltip.teardownListeners()
+  }
+  if (!preferred || !registry.intersecting) {
+    preferred?.teardownListeners()
+    return
+  }
+  requestAnimationFrame(() => {
+    const current = anchorToTooltips.get(anchor)
+    if (current !== registry || !current.intersecting || preferredTooltip(current) !== preferred) return
+    preferred.setupListeners()
+  })
+}
 
 function handleIntersection(entries: IntersectionObserverEntry[]) {
   for (const entry of entries) {
-    const tooltip = anchorToTooltip.get(entry.target)
-    if (!tooltip) continue
-    if (!tooltip.listening && entry.isIntersecting) {
-      requestAnimationFrame(() => tooltip.setupListeners())
-    } else if (tooltip.listening && !entry.isIntersecting) {
-      requestAnimationFrame(() => tooltip.teardownListeners())
-    }
+    const registry = anchorToTooltips.get(entry.target)
+    if (!registry) continue
+    registry.intersecting = entry.isIntersecting
+    syncAnchorListeners(entry.target, registry)
   }
 }
 
@@ -342,8 +379,14 @@ export class ATooltipElement extends HTMLElementBase {
     const parent = this.parentElement
     if (!parent) return
     this.anchor = parent
-    anchorToTooltip.set(parent, this)
-    lazyObserver?.observe(parent)
+    let registry = anchorToTooltips.get(parent)
+    if (!registry) {
+      registry = { tooltips: new Set(), intersecting: false }
+      anchorToTooltips.set(parent, registry)
+      lazyObserver?.observe(parent)
+    }
+    registry.tooltips.add(this)
+    syncAnchorListeners(parent, registry)
   }
 
   disconnectedCallback() {
@@ -352,9 +395,14 @@ export class ATooltipElement extends HTMLElementBase {
     // coordinator slot. (Don't wait out the fade — the element is going away.)
     this.cleanup()
     if (this.anchor) {
-      if (anchorToTooltip.get(this.anchor) === this) {
-        anchorToTooltip.delete(this.anchor)
+      const anchor = this.anchor
+      const registry = anchorToTooltips.get(anchor)
+      registry?.tooltips.delete(this)
+      if (registry && registry.tooltips.size === 0) {
+        anchorToTooltips.delete(anchor)
         lazyObserver?.unobserve(this.anchor)
+      } else if (registry) {
+        syncAnchorListeners(anchor, registry)
       }
       this.anchor = null
     }

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -29,6 +29,20 @@ export interface BaseProps {
   [key: `aria-${string}`]: unknown
 }
 
+/** Safe presentation attributes for a data-rendered option. They land on the
+ * option's rendered row, rather than on the enclosing control. Menu-based
+ * components reserve `data-menu-*` for their own selection and focus behavior. */
+export interface OptionPresentationProps {
+  /** CSS class on the option's rendered row. */
+  className?: string
+  /** Inline styles on the option's rendered row. */
+  style?: React.CSSProperties
+  /** Native browser tooltip on the option's rendered row. */
+  title?: string
+  /** Additional data attributes on the option's rendered row. */
+  [key: `data-${string}`]: unknown
+}
+
 /**
  * Standard DOM event handlers Anta forwards to the rendered element. These are
  * **enumerated on purpose** — rather than an open `on${string}` index signature

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -37,8 +37,6 @@ export interface OptionPresentationProps {
   className?: string
   /** Inline styles on the option's rendered row. */
   style?: React.CSSProperties
-  /** Native browser tooltip on the option's rendered row. */
-  title?: string
   /** Additional data attributes on the option's rendered row. */
   [key: `data-${string}`]: unknown
 }

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -165,7 +165,7 @@
   --border-4-info: #cfe3f7;
   --border-5-info: #e1eefa;
 
-  --focus-ring: var(--text-2-brand);
+  --focus-ring: oklch(0.55 0.2 284.15);
 }
 
 /* Doubled `.dark.dark` — mirrors tokens.css's `.dark` (any scoped dark region)

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -292,7 +292,7 @@
   --border-4-info: hsl(208.52deg 62.89% 14%);
   --border-5-info: hsl(207.78deg 65.85% 10.5%);
 
-  --focus-ring: var(--text-2-brand);
+  --focus-ring: #a897fc;
 }
 
 /* ── 2. Bespoke component ramps — hand-tuned literals ─────────────────────── */


### PR DESCRIPTION
## What changed

- Added presentation attributes for options and removed the default tab-panel tab stop.
- JSX `Text` now adds a clipped-content tooltip that respects a consumer-provided nested tooltip.
- Exposed `a-text.isTruncated` for composing web-component truncation behavior and documented both APIs.
- Updated the Anta light focus-ring token and aligned the overview sticker with the intro copy.

## Why

These component refinements improve keyboard behavior and text discoverability. Truncated text needs an accessible way to reveal the full value without competing with custom tooltips; the component also needs to report clipping from its shadow-DOM layout box.

## Impact

Consumers of JSX `Text` get a default tooltip only for clipped, non-expandable content; web-component consumers can opt in with `a-tooltip truncated-only`.

## Validation

- `pnpm run verify`
- `pnpm --filter anta-site run lint:css`
