### PR TITLE
Remove selected Button inset border

### DIFF
--- a/src/elements/a-button.css
+++ b/src/elements/a-button.css
@@ -541,9 +541,6 @@
       }
     }
 
-    &[selected] {
-      box-shadow: inset 0 0 0 0.5px currentColor;
-    }
 
     &[disabled] {
       background-color: var(--bg-secondary-disabled);


### PR DESCRIPTION

<img width="195" height="92" alt="Screenshot 2026-08-12 at 7 47 02 PM" src="https://github.com/user-attachments/assets/163eee4b-db31-45fe-9617-b23722546103" />

<img width="310" height="88" alt="Screenshot 2026-08-12 at 7 47 22 PM" src="https://github.com/user-attachments/assets/5cdfe0d0-3b9e-4070-bc50-655bc5672876" />

## Summary
- remove the selected Button inset box shadow
- keep selected state aligned with the documented active-state treatment: its foreground/background change by priority

The Button docs describe `selected` as a toggled-on visual that “shares the active state’s look.” The extra inset `currentColor` shadow adds a visible inner border that active Buttons do not have.

## Validation
- `pnpm run build:dev`
- `pnpm run typecheck`