### PR TITLE
Fix disabled Button links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Fixed
+
+- Disabled and loading Buttons with `href` now use the disabled palette and block activation.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -167,6 +167,7 @@ export const Button = ({
   disabled,
   selected,
   round,
+  onClick,
   href,
   target,
   rel,
@@ -183,6 +184,7 @@ export const Button = ({
   // Don't emit a bare `tone=""` (it matched the custom-tone branch and
   // resolved to a `transparent` source, rendering an invisible button).
   const toneAttr = tone || undefined
+  const unavailable = disabled || loading
   // A non-named tone is a literal CSS color: feed it to the element's oklch
   // derivation via the inline custom property (shared helper — see anta_helpers).
   const computedStyle = roundStyle(round, '--button-round', toneStyle(toneAttr, '--button-tone-source', style))
@@ -219,8 +221,8 @@ export const Button = ({
     // Disabled AND loading both leave the keyboard tab order — a loading
     // button blocks the mouse (pointer-events), so it must block Enter/Space
     // activation too, else the loading guard would be mouse-only.
-    tabIndex: disabled || loading ? -1 : 0,
-    'aria-disabled': disabled || loading ? 'true' : undefined,
+    tabIndex: unavailable ? -1 : 0,
+    'aria-disabled': unavailable ? 'true' : undefined,
     'aria-busy': loading ? 'true' : undefined,
     'aria-pressed': selected ? 'true' : undefined,
     // Icon-only buttons get an accessible name from the icon shape. Consumer's
@@ -229,6 +231,7 @@ export const Button = ({
     'aria-label': isIconOnly ? icon : undefined,
     class: className,
     style: computedStyle,
+    onClick,
   } as const
 
   const inner = (
@@ -241,6 +244,20 @@ export const Button = ({
   )
 
   if (href != null) {
+    // A native anchor has no disabled behavior. React also drops `disabled=""`
+    // on it, so this branch uses a boolean to retain the CSS presence attribute.
+    const anchorAttrs = {
+      ...sharedAttrs,
+      disabled: unavailable || undefined,
+      onClick: (event: any) => {
+        if (unavailable) {
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        onClick?.(event)
+      },
+    }
     // type / form intentionally omitted — anchors don't submit forms.
     // `data-anta` opts this anchor into Anta's `a[role="button"]` styling.
     // The role is generic (any widget emits `role="button"`), so the CSS
@@ -257,7 +274,7 @@ export const Button = ({
         rel={rel}
         download={download}
         ping={ping}
-        {...sharedAttrs as any}
+        {...anchorAttrs as any}
         {...rest}
       >
         {inner}


### PR DESCRIPTION
## Summary
- fix disabled and loading Buttons that render as links under React
- keep the custom-element and anchor branches explicit about their different boolean-attribute behavior

## Simple explanation

A normal Button renders Anta’s custom `<a-button>` element:

```tsx
<Button disabled label="Save" />
```

```html
<a-button disabled="" aria-disabled="true" tabindex="-1">
```

Anta’s `[disabled]` CSS gives it the disabled palette and disables pointer events; the `<a-button>` delegated handler also blocks activation.

A Button with `href` must instead render a native anchor:

```tsx
<Button disabled href="#target" label="Save" />
```

```html
<a href="#target" role="button" data-anta>
```

The wrapper supplied `disabled=""` to both branches. Preact preserves that attribute on an anchor, so the docs iframe showed the expected grey disabled Button. React treats an empty string as false for the native anchor `disabled` prop and removes it.

The React DOM kept `aria-disabled="true"` and `tabindex="-1"`, but lost the actual `disabled` attribute. That means Anta’s `[disabled]` CSS did not match, so the link stayed brand-coloured and retained pointer interaction. Because it is an anchor rather than `<a-button>`, the custom element’s delegated activation guard did not apply either.

This is a React/Preact portability bug in Anta’s `href` branch: a disabled Button link looked disabled to assistive technology and was skipped by normal tab navigation, but could still be clicked.

## Fix

The custom-element branch retains Anta’s canonical empty-string presence attribute. The native-anchor branch passes a boolean so both renderers emit a present `disabled` attribute. It also prevents click activation because native anchors have no built-in disabled behavior.

## Validation
- `pnpm run build:dev`
- `pnpm run typecheck`