### PR TITLE
Fix explicit neutral Tag theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Fixed
+
+- Tags with an explicit `tone="neutral"` now receive the reference theme's neutral values.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -753,7 +753,8 @@ a-radio[tone="critical"],
 }
 
 /* ===== tag ===== */
-a-tag:not([tone]) {
+a-tag:not([tone]),
+a-tag[tone="neutral"] {
   --tag-tint: #44374b;
   --tag-bg-solid: #776e77;
   --tag-edge: var(--tag-tint);


### PR DESCRIPTION
## Summary
- apply the reference theme’s neutral Tag values when `tone="neutral"` is explicit

## Explanation

With the optional reference theme imported, these documented-equivalent calls should look the same:

```tsx
<Tag />
<Tag tone="neutral" />
```

Before this change, only the omitted-tone form matched the reference theme:

```css
a-tag:not([tone]) {
  --tag-tint: #44374b;
  --_tag-bg-alpha: 7%;
}
```

An explicit `tone="neutral"` therefore kept the component’s seed-derived fallback values instead, including a 10% background alpha. Neither style is invalid alone, but the documented default should not change based on whether the caller spells it explicitly.

This makes the light reference-theme rule match both forms. Dark mode already did so.

## Validation
- `pnpm run build:dev`
- `pnpm run typecheck`