### PR TITLE
Fix duplicate choice control focus outlines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Fixed
+
+- Checkbox, Radio, and Switch now show one focus ring around their visual control.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/src/elements/a-checkbox.css
+++ b/src/elements/a-checkbox.css
@@ -159,6 +159,7 @@
       mask-image: var(--checkbox-mask-indeterminate);
     }
 
+    &:focus-visible { outline: none; }
     &:focus-visible::before {
       outline: 1px solid var(--focus-ring);
       outline-offset: 1px;

--- a/src/elements/a-radio.css
+++ b/src/elements/a-radio.css
@@ -138,6 +138,7 @@
 
     /* Focus ring, roving-tabindex mode (the JSX wrapper path): real focus lands
        on the radio itself. See a-radio-group.ts for the two focus models. */
+    &:focus-visible { outline: none; }
     &:focus-visible::before {
       outline: 1px solid var(--focus-ring);
       outline-offset: 1px;

--- a/src/elements/a-switch.css
+++ b/src/elements/a-switch.css
@@ -142,6 +142,7 @@
     }
     &:not(:disabled):active:state(checked)::before { background: var(--switch-track-on-active); }
 
+    &:focus-visible { outline: none; }
     &:focus-visible::before {
       outline: 1px solid var(--focus-ring);
       outline-offset: 1px;


### PR DESCRIPTION
## Summary
- suppress the reset focus outline on focused Checkbox, Radio, and Switch hosts
- retain each component’s existing focus ring around its visual control

The global reset applies `:focus-visible` to every focused element. These three controls also draw a component-level ring on `::before`, yielding a large row outline plus the intended control outline. Slider already suppresses the host outline at focus specificity; this applies the same pattern to the remaining choice controls.

## Screenshots
<img width="303" height="171" alt="Screenshot 2026-08-13 at 10 44 08 AM" src="https://github.com/user-attachments/assets/86e339bc-399a-41db-9421-ae9023078ac2" />
<img width="254" height="77" alt="Screenshot 2026-08-13 at 10 44 34 AM" src="https://github.com/user-attachments/assets/ea8e1b1c-9528-4e6a-95e4-4f787d8bab92" />
<img width="189" height="59" alt="Screenshot 2026-08-13 at 10 44 49 AM" src="https://github.com/user-attachments/assets/10a8f410-b3ee-471e-aec6-f650ffaaff85" />

The supplied before screenshots show the duplicate row and control outlines for Radio, Switch, and Checkbox. Add them as native PR attachments in GitHub’s editor; they are intentionally not committed as repository assets.

## Validation
- `pnpm run build:dev`
- `pnpm run typecheck`