### PR TITLE
Fix neutral themes and disabled Button links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ changes are not listed.
 - Disabled and loading Buttons with `href` now use the disabled palette and block
   activation.
 - Checkbox, Radio, and Switch now show one focus ring around their visual control.
+- Checkboxes without a tone now receive the Anta neutral reference values;
+  `tone="neutral"` remains equivalent.
+- Checkbox and Radio `toneSelected` now consistently overrides `tone`, including
+  explicit neutral selected tones and custom `RadioGroup` tones.
+- `a-input` and `a-input-time` now treat `status="neutral"` like their default
+  status.
 
 ## 0.3.21 — August 11, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Fixed
+
+- Buttons and Tags with an explicit `tone="neutral"` now receive the reference
+  theme's neutral values.
+- Disabled and loading Buttons with `href` now use the disabled palette and block
+  activation.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -11,6 +11,13 @@ changes are not listed.
   theme's neutral values.
 - Disabled and loading Buttons with `href` now use the disabled palette and block
   activation.
+- Checkbox, Radio, and Switch now show one focus ring around their visual control.
+- Checkboxes without a tone now receive the Anta neutral reference values;
+  `tone="neutral"` remains equivalent.
+- Checkbox and Radio `toneSelected` now consistently overrides `tone`, including
+  explicit neutral selected tones and custom `RadioGroup` tones.
+- `a-input` and `a-input-time` now treat `status="neutral"` like their default
+  status.
 
 ## 0.3.21 — August 11, 2026
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,15 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Fixed
+
+- Buttons and Tags with an explicit `tone="neutral"` now receive the reference
+  theme's neutral values.
+- Disabled and loading Buttons with `href` now use the disabled palette and block
+  activation.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -231,7 +231,7 @@ export const Button = ({
     'aria-label': isIconOnly ? icon : undefined,
     class: className,
     style: computedStyle,
-    onClick,
+    onClick: unavailable ? undefined : onClick,
   } as const
 
   const inner = (
@@ -244,19 +244,9 @@ export const Button = ({
   )
 
   if (href != null) {
-    // A native anchor has no disabled behavior. React also drops `disabled=""`
-    // on it, so this branch uses a boolean to retain the CSS presence attribute.
     const anchorAttrs = {
       ...sharedAttrs,
       disabled: unavailable || undefined,
-      onClick: (event: any) => {
-        if (unavailable) {
-          event.preventDefault()
-          event.stopPropagation()
-          return
-        }
-        onClick?.(event)
-      },
     }
     // type / form intentionally omitted — anchors don't submit forms.
     // `data-anta` opts this anchor into Anta's `a[role="button"]` styling.
@@ -268,7 +258,7 @@ export const Button = ({
     // Anta owns that tag and styles it unconditionally.
     return (
       <a
-        href={href}
+        href={unavailable ? undefined : href}
         data-anta=""
         target={target}
         rel={rel}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -167,6 +167,7 @@ export const Button = ({
   disabled,
   selected,
   round,
+  onClick,
   href,
   target,
   rel,
@@ -183,6 +184,7 @@ export const Button = ({
   // Don't emit a bare `tone=""` (it matched the custom-tone branch and
   // resolved to a `transparent` source, rendering an invisible button).
   const toneAttr = tone || undefined
+  const unavailable = disabled || loading
   // A non-named tone is a literal CSS color: feed it to the element's oklch
   // derivation via the inline custom property (shared helper — see anta_helpers).
   const computedStyle = roundStyle(round, '--button-round', toneStyle(toneAttr, '--button-tone-source', style))
@@ -219,8 +221,8 @@ export const Button = ({
     // Disabled AND loading both leave the keyboard tab order — a loading
     // button blocks the mouse (pointer-events), so it must block Enter/Space
     // activation too, else the loading guard would be mouse-only.
-    tabIndex: disabled || loading ? -1 : 0,
-    'aria-disabled': disabled || loading ? 'true' : undefined,
+    tabIndex: unavailable ? -1 : 0,
+    'aria-disabled': unavailable ? 'true' : undefined,
     'aria-busy': loading ? 'true' : undefined,
     'aria-pressed': selected ? 'true' : undefined,
     // Icon-only buttons get an accessible name from the icon shape. Consumer's
@@ -229,6 +231,7 @@ export const Button = ({
     'aria-label': isIconOnly ? icon : undefined,
     class: className,
     style: computedStyle,
+    onClick,
   } as const
 
   const inner = (
@@ -241,6 +244,20 @@ export const Button = ({
   )
 
   if (href != null) {
+    // A native anchor has no disabled behavior. React also drops `disabled=""`
+    // on it, so this branch uses a boolean to retain the CSS presence attribute.
+    const anchorAttrs = {
+      ...sharedAttrs,
+      disabled: unavailable || undefined,
+      onClick: (event: any) => {
+        if (unavailable) {
+          event.preventDefault()
+          event.stopPropagation()
+          return
+        }
+        onClick?.(event)
+      },
+    }
     // type / form intentionally omitted — anchors don't submit forms.
     // `data-anta` opts this anchor into Anta's `a[role="button"]` styling.
     // The role is generic (any widget emits `role="button"`), so the CSS
@@ -257,7 +274,7 @@ export const Button = ({
         rel={rel}
         download={download}
         ping={ping}
-        {...sharedAttrs as any}
+        {...anchorAttrs as any}
         {...rest}
       >
         {inner}

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -139,17 +139,21 @@ export const Checkbox = ({
   // publishes it off-DOM via `ElementInternals`, so it stays live through
   // uncontrolled self-toggles (a wrapper-set value would go stale there).
 
-  // A non-named tone/toneSelected is a custom CSS color — `toneStyle` hands it to the
-  // element via the shared `--checkbox-tone-source` var (both drive the same fill
-  // curve; they differ only in whether the off-state border tints, which the CSS keys
-  // off the attribute name). Chained so whichever is custom sets the source.
+  // A non-named tone/toneSelected is a custom CSS color. The normal tone owns the
+  // off-state source, while toneSelected owns the checked-fill source.
   const computedStyle = roundStyle(
     round,
     '--checkbox-round',
     toneStyle(
       toneSelected,
       '--checkbox-tone-source',
-      toneStyle(tone, '--checkbox-tone-source', style),
+      toneStyle(
+        tone,
+        '--checkbox-off-tone-source',
+        toneSelected == null
+          ? toneStyle(tone, '--checkbox-tone-source', style)
+          : style,
+      ),
     ),
   )
 
@@ -205,7 +209,9 @@ export const Checkbox = ({
       default-state={defaultStateAttr}
       disabled={disabled ? '' : undefined}
       tone={tone && tone !== 'neutral' ? tone : undefined}
-      tone-selected={toneSelected && toneSelected !== 'neutral' ? toneSelected : undefined}
+      // `toneSelected="neutral"` is an explicit reset when `tone` is colored,
+      // so it must reach the element instead of collapsing to the default.
+      tone-selected={toneSelected || undefined}
       size={size && size !== 'medium' ? size : undefined}
       round={roundAttr(round)}
       tabIndex={disabled ? -1 : (tabIndex ?? 0)}

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -217,7 +217,9 @@ export const RadioGroup = ({
       name={name}
       status={status && status !== "neutral" ? status : undefined}
       tone={tone && tone !== "neutral" ? tone : undefined}
-      tone-selected={toneSelected && toneSelected !== "neutral" ? toneSelected : undefined}
+      // Unlike the group tone, an explicit neutral selected tone can reset a
+      // colored group tone, so it remains a DOM attribute.
+      tone-selected={toneSelected || undefined}
       size={size && size !== "medium" ? size : undefined}
       disabled={disabled ? "" : undefined}
       orientation={orientation && orientation !== "vertical" ? orientation : undefined}
@@ -230,10 +232,17 @@ export const RadioGroup = ({
       onfocusin={onFocus}
       onfocusout={onBlur}
       class={className}
-      // A custom mark tone flows to children via the group's inherited
-      // `--radio-tone-source` (both `tone` and `toneSelected` feed it — chained so
-      // whichever is custom sets it); named tones cascade through the CSS instead.
-      style={toneStyle(toneSelected, "--radio-tone-source", toneStyle(tone, "--radio-tone-source", style))}
+      // Custom normal and selected tones flow to children through separate sources;
+      // named tones cascade through the CSS instead.
+      style={toneStyle(
+        toneSelected,
+        "--radio-tone-source",
+        toneStyle(
+          tone,
+          "--radio-off-tone-source",
+          toneSelected == null ? toneStyle(tone, "--radio-tone-source", style) : style,
+        ),
+      )}
     >
       {label && <a-radio-group-label id={labelId}>{label}</a-radio-group-label>}
       {hint && <a-radio-group-hint id={hintId}>{hint}</a-radio-group-hint>}
@@ -253,12 +262,24 @@ export const RadioGroup = ({
               // disabled-but-selected option (focusable-disabled). `aria-checked` is
               // NOT set here — the element publishes it off-DOM via internals.
               tabIndex={o.value === tabStopValue ? 0 : -1}
-              tone={o.tone && o.tone !== "neutral" ? o.tone : undefined}
-              tone-selected={o.toneSelected && o.toneSelected !== "neutral" ? o.toneSelected : undefined}
+              // An option's explicit neutral tone is an override of the group
+              // tone, rather than the same as an omitted option tone.
+              tone={o.tone || undefined}
+              tone-selected={o.toneSelected || undefined}
               size={o.size && o.size !== "medium" ? o.size : undefined}
               disabled={o.disabled ? "" : undefined}
               class={optionClassName}
-              style={toneStyle(o.toneSelected, "--radio-tone-source", toneStyle(o.tone, "--radio-tone-source", optionStyle))}
+              style={toneStyle(
+                o.toneSelected,
+                "--radio-tone-source",
+                toneStyle(
+                  o.tone,
+                  "--radio-off-tone-source",
+                  o.toneSelected == null
+                    ? toneStyle(o.tone, "--radio-tone-source", optionStyle)
+                    : optionStyle,
+                ),
+              )}
             >
               <a-radio-label>{o.label}</a-radio-label>
               {o.hint != null && <a-radio-hint>{o.hint}</a-radio-hint>}

--- a/src/elements/a-checkbox.css
+++ b/src/elements/a-checkbox.css
@@ -17,6 +17,7 @@
        Checkbox spec; named tones and a custom color point the source elsewhere
        (rules below). Default tone is neutral. */
     --checkbox-tone-source: var(--anta-seed-neutral);
+    --checkbox-off-tone-source: var(--anta-seed-neutral);
     --_tone-l-rest: 0.6;
     --_tone-l-hover: 0.45;
     --_tone-l-active: 0.4;
@@ -228,45 +229,58 @@
   /* `tone` and `tone-selected` both set the checked mark fill; they differ in
      the off state: `tone` tints the unselected box (rule further down),
      `tone-selected` leaves it neutral. Label + hint are never toned (recolor in
-     plain CSS via --text-N-{tone}). Both point --checkbox-tone-source at the
-     tone's seed; the fill formula in the base rule derives from it. `neutral`
-     keeps the base greys; the default omits the attribute. */
+     plain CSS via --text-N-{tone}). `tone` sets both the checked and off-state
+     sources; `tone-selected` changes only the checked source. `neutral` keeps
+     the base greys; the default omits the attribute. */
   a-checkbox[tone]:not([tone=""], [tone="neutral"]),
   a-checkbox[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]) {
     --_tone-l-rest: 0.5;
     --_tone-l-hover: 0.45;
     --_tone-l-active: 0.4;
   }
-  a-checkbox[tone="brand"],    a-checkbox[tone-selected="brand"]    { --checkbox-tone-source: var(--anta-seed-brand); }
-  a-checkbox[tone="info"],     a-checkbox[tone-selected="info"]     { --checkbox-tone-source: var(--anta-seed-info); }
-  a-checkbox[tone="success"],  a-checkbox[tone-selected="success"]  { --checkbox-tone-source: var(--anta-seed-success); }
-  a-checkbox[tone="warning"],  a-checkbox[tone-selected="warning"]  { --checkbox-tone-source: var(--anta-seed-warning); }
-  a-checkbox[tone="critical"], a-checkbox[tone-selected="critical"] { --checkbox-tone-source: var(--anta-seed-critical); }
-  a-checkbox[tone="neutral"],  a-checkbox[tone-selected="neutral"]  { --checkbox-tone-source: var(--anta-seed-neutral); }
+  a-checkbox[tone="brand"]    { --checkbox-tone-source: var(--anta-seed-brand); --checkbox-off-tone-source: var(--anta-seed-brand); }
+  a-checkbox[tone="info"]     { --checkbox-tone-source: var(--anta-seed-info); --checkbox-off-tone-source: var(--anta-seed-info); }
+  a-checkbox[tone="success"]  { --checkbox-tone-source: var(--anta-seed-success); --checkbox-off-tone-source: var(--anta-seed-success); }
+  a-checkbox[tone="warning"]  { --checkbox-tone-source: var(--anta-seed-warning); --checkbox-off-tone-source: var(--anta-seed-warning); }
+  a-checkbox[tone="critical"] { --checkbox-tone-source: var(--anta-seed-critical); --checkbox-off-tone-source: var(--anta-seed-critical); }
+  a-checkbox[tone="neutral"]  { --checkbox-tone-source: var(--anta-seed-neutral); --checkbox-off-tone-source: var(--anta-seed-neutral); }
 
   /* `tone` (not tone-selected) also derives the unselected tinted box from the
      tone in oklch: a whisper-tint fill (chroma scaled down) under a border ramp
      stepped off the fill. Named tones + custom colors reach this; neutral and
      every tone-selected keep the neutral off-box border. */
   a-checkbox[tone]:not([tone=""], [tone="neutral"]) {
-    --checkbox-bg: oklch(from var(--checkbox-tone-source) 0.99 calc(c * 0.03) h);
-    --_checkbox-border-base: color-mix(in oklch, var(--checkbox-bg-selected) 70%, var(--checkbox-border-neutral));
+    --checkbox-bg: oklch(from var(--checkbox-off-tone-source) 0.99 calc(c * 0.03) h);
+    --_checkbox-off-bg-selected: oklch(from var(--checkbox-off-tone-source) var(--_tone-l-rest) c h);
+    --_checkbox-border-base: color-mix(in oklch, var(--_checkbox-off-bg-selected) 70%, var(--checkbox-border-neutral));
     --checkbox-border:        oklch(from var(--_checkbox-border-base) calc(l + 0.17) c h);
     --checkbox-border-hover:  oklch(from var(--_checkbox-border-base) calc(l + 0.1) c h);
     --checkbox-border-active: var(--_checkbox-border-base);
   }
 
-  /* Custom mark tone — a non-named `tone` / `tone-selected` is a literal CSS color;
-     both feed the same --checkbox-tone-source and the fill curve is derived from it in
-     oklch. Every named value must be listed in the :not(): without it `info` /
-     `success` / etc would also hit this rule and attr(… type(<color>)) would fail to
-     parse them, rendering transparent. `tone` still tints the off-border via the ramp
-     rule above (keyed [tone]); `tone-selected` does not, so its tone shows only when
-     checked. The focus ring is the global --focus-ring across every tone. */
+  /* A non-named `tone` is a literal CSS color. Every named value must be listed in
+     the :not(): without it `info` / `success` / etc would hit attr(… type(<color>))
+     and render transparent. */
   a-checkbox[tone]:not(
       [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
       [tone="success"], [tone="warning"], [tone="critical"]) {
     --checkbox-tone-source: attr(tone type(<color>), transparent);
+    --checkbox-off-tone-source: attr(tone type(<color>), transparent);
+  }
+
+  /* Selected-tone mappings follow `tone`, so `tone-selected` always chooses the
+     checked fill. An explicit neutral selected tone resets a colored `tone` to the
+     neutral fill curve while leaving the off-state `tone` treatment in place. */
+  a-checkbox[tone-selected="brand"]    { --checkbox-tone-source: var(--anta-seed-brand); }
+  a-checkbox[tone-selected="info"]     { --checkbox-tone-source: var(--anta-seed-info); }
+  a-checkbox[tone-selected="success"]  { --checkbox-tone-source: var(--anta-seed-success); }
+  a-checkbox[tone-selected="warning"]  { --checkbox-tone-source: var(--anta-seed-warning); }
+  a-checkbox[tone-selected="critical"] { --checkbox-tone-source: var(--anta-seed-critical); }
+  a-checkbox[tone-selected="neutral"] {
+    --checkbox-tone-source: var(--anta-seed-neutral);
+    --_tone-l-rest: 0.6;
+    --_tone-l-hover: 0.45;
+    --_tone-l-active: 0.4;
   }
   a-checkbox[tone-selected]:not(
       [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
@@ -295,10 +309,15 @@
     --_tone-l-active: 0.57;
   }
   .dark a-checkbox[tone]:not([tone=""], [tone="neutral"]) {
-    --checkbox-bg: oklch(from var(--checkbox-tone-source) 0.15 calc(c * 0.18) h);
+    --checkbox-bg: oklch(from var(--checkbox-off-tone-source) 0.15 calc(c * 0.18) h);
     --checkbox-border:        var(--_checkbox-border-base);
     --checkbox-border-hover:  oklch(from var(--_checkbox-border-base) calc(l + 0.1) c h);
     --checkbox-border-active: oklch(from var(--_checkbox-border-base) calc(l + 0.17) c h);
+  }
+  .dark a-checkbox[tone-selected="neutral"] {
+    --_tone-l-rest: 0.42;
+    --_tone-l-hover: 0.45;
+    --_tone-l-active: 0.5;
   }
 
   /* A native checkbox can opt into the same compact control surface with
@@ -326,6 +345,7 @@
     --native-choice-border-hover: var(--border-2);
     --native-choice-border-active: var(--border-1);
     --native-choice-tone-source: var(--anta-seed-neutral);
+    --native-choice-off-tone-source: var(--anta-seed-neutral);
     --_native-choice-l-rest: 0.6;
     --_native-choice-l-hover: 0.45;
     --_native-choice-l-active: 0.4;
@@ -378,15 +398,16 @@
     --_native-choice-l-hover: 0.45;
     --_native-choice-l-active: 0.4;
   }
-  input[data-anta][type="checkbox"][tone="brand"],    input[data-anta][type="checkbox"][tone-selected="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); }
-  input[data-anta][type="checkbox"][tone="info"],     input[data-anta][type="checkbox"][tone-selected="info"]     { --native-choice-tone-source: var(--anta-seed-info); }
-  input[data-anta][type="checkbox"][tone="success"],  input[data-anta][type="checkbox"][tone-selected="success"]  { --native-choice-tone-source: var(--anta-seed-success); }
-  input[data-anta][type="checkbox"][tone="warning"],  input[data-anta][type="checkbox"][tone-selected="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); }
-  input[data-anta][type="checkbox"][tone="critical"], input[data-anta][type="checkbox"][tone-selected="critical"] { --native-choice-tone-source: var(--anta-seed-critical); }
-  input[data-anta][type="checkbox"][tone="neutral"],  input[data-anta][type="checkbox"][tone-selected="neutral"]  { --native-choice-tone-source: var(--anta-seed-neutral); }
+  input[data-anta][type="checkbox"][tone="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); --native-choice-off-tone-source: var(--anta-seed-brand); }
+  input[data-anta][type="checkbox"][tone="info"]     { --native-choice-tone-source: var(--anta-seed-info); --native-choice-off-tone-source: var(--anta-seed-info); }
+  input[data-anta][type="checkbox"][tone="success"]  { --native-choice-tone-source: var(--anta-seed-success); --native-choice-off-tone-source: var(--anta-seed-success); }
+  input[data-anta][type="checkbox"][tone="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); --native-choice-off-tone-source: var(--anta-seed-warning); }
+  input[data-anta][type="checkbox"][tone="critical"] { --native-choice-tone-source: var(--anta-seed-critical); --native-choice-off-tone-source: var(--anta-seed-critical); }
+  input[data-anta][type="checkbox"][tone="neutral"]  { --native-choice-tone-source: var(--anta-seed-neutral); --native-choice-off-tone-source: var(--anta-seed-neutral); }
   input[data-anta][type="checkbox"][tone]:not([tone=""], [tone="neutral"]) {
-    --native-choice-bg: oklch(from var(--native-choice-tone-source) 0.99 calc(c * 0.03) h);
-    --_native-choice-border-base: color-mix(in oklch, var(--native-choice-selected) 70%, var(--native-choice-border-neutral));
+    --native-choice-bg: oklch(from var(--native-choice-off-tone-source) 0.99 calc(c * 0.03) h);
+    --_native-choice-off-selected: oklch(from var(--native-choice-off-tone-source) var(--_native-choice-l-rest) c h);
+    --_native-choice-border-base: color-mix(in oklch, var(--_native-choice-off-selected) 70%, var(--native-choice-border-neutral));
     --native-choice-border: oklch(from var(--_native-choice-border-base) calc(l + 0.17) c h);
     --native-choice-border-hover: oklch(from var(--_native-choice-border-base) calc(l + 0.1) c h);
     --native-choice-border-active: var(--_native-choice-border-base);
@@ -395,6 +416,18 @@
       [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
       [tone="success"], [tone="warning"], [tone="critical"]) {
     --native-choice-tone-source: attr(tone type(<color>), var(--anta-seed-neutral));
+    --native-choice-off-tone-source: attr(tone type(<color>), var(--anta-seed-neutral));
+  }
+  input[data-anta][type="checkbox"][tone-selected="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); }
+  input[data-anta][type="checkbox"][tone-selected="info"]     { --native-choice-tone-source: var(--anta-seed-info); }
+  input[data-anta][type="checkbox"][tone-selected="success"]  { --native-choice-tone-source: var(--anta-seed-success); }
+  input[data-anta][type="checkbox"][tone-selected="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); }
+  input[data-anta][type="checkbox"][tone-selected="critical"] { --native-choice-tone-source: var(--anta-seed-critical); }
+  input[data-anta][type="checkbox"][tone-selected="neutral"] {
+    --native-choice-tone-source: var(--anta-seed-neutral);
+    --_native-choice-l-rest: 0.6;
+    --_native-choice-l-hover: 0.45;
+    --_native-choice-l-active: 0.4;
   }
   input[data-anta][type="checkbox"][tone-selected]:not(
       [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
@@ -451,10 +484,15 @@
     --_native-choice-l-active: 0.57;
   }
   .dark input[data-anta][type="checkbox"][tone]:not([tone=""], [tone="neutral"]) {
-    --native-choice-bg: oklch(from var(--native-choice-tone-source) 0.15 calc(c * 0.18) h);
+    --native-choice-bg: oklch(from var(--native-choice-off-tone-source) 0.15 calc(c * 0.18) h);
     --native-choice-border: var(--_native-choice-border-base);
     --native-choice-border-hover: oklch(from var(--_native-choice-border-base) calc(l + 0.1) c h);
     --native-choice-border-active: oklch(from var(--_native-choice-border-base) calc(l + 0.17) c h);
+  }
+  .dark input[data-anta][type="checkbox"][tone-selected="neutral"] {
+    --_native-choice-l-rest: 0.42;
+    --_native-choice-l-hover: 0.45;
+    --_native-choice-l-active: 0.5;
   }
 
   /* The custom checkmark is a mask painted by ::after. In forced colors, pair

--- a/src/elements/a-input-time.css
+++ b/src/elements/a-input-time.css
@@ -138,11 +138,11 @@
   a-input-time[status="success"]  { --input-time-tone-source: var(--anta-seed-success);  --input-time-bg: var(--bg-2-success);  --input-time-hint: var(--text-2-success); }
   a-input-time[status="info"]     { --input-time-tone-source: var(--anta-seed-info);     --input-time-bg: var(--bg-2-info);     --input-time-hint: var(--text-2-info); }
   a-input-time[status="brand"]    { --input-time-tone-source: var(--anta-seed-brand);    --input-time-bg: var(--bg-2-brand);    --input-time-hint: var(--text-2-brand); }
-  a-input-time[status] {
+  a-input-time[status]:not([status="neutral"]) {
     --input-time-border:       oklch(from var(--input-time-tone-source) 0.58 c h);
     --input-time-border-hover: oklch(from var(--input-time-tone-source) 0.58 c h);
   }
-  .dark a-input-time[status] {
+  .dark a-input-time[status]:not([status="neutral"]) {
     --input-time-border:       oklch(from var(--input-time-tone-source) 0.52 c h);
     --input-time-border-hover: oklch(from var(--input-time-tone-source) 0.52 c h);
   }

--- a/src/elements/a-input-time.ts
+++ b/src/elements/a-input-time.ts
@@ -97,7 +97,7 @@ const SHADOW_STYLE = `
     box-shadow: inset 0 0 0 var(--_bw) var(--_bc);
     transition: box-shadow 120ms ease;
   }
-  :host([status]) .field { --_bw: 1px; }
+  :host([status]:not([status="neutral"])) .field { --_bw: 1px; }
 
   @media (hover: hover) and (pointer: fine) {
     :host(:not(:disabled)) .field:hover {

--- a/src/elements/a-input.css
+++ b/src/elements/a-input.css
@@ -206,10 +206,10 @@
   a-input[status="success"]  { --input-status-source: var(--anta-seed-success);  --input-bg: var(--bg-2-success);  --input-hint: var(--text-2-success); }
   a-input[status="info"]     { --input-status-source: var(--anta-seed-info);     --input-bg: var(--bg-2-info);     --input-hint: var(--text-2-info); }
   a-input[status="brand"]    { --input-status-source: var(--anta-seed-brand);    --input-bg: var(--bg-2-brand);    --input-hint: var(--text-2-brand); }
-  a-input[status] {
+  a-input[status]:not([status="neutral"]) {
     --input-border:       oklch(from var(--input-status-source) 0.58 c h);
   }
-  .dark a-input[status] {
+  .dark a-input[status]:not([status="neutral"]) {
     --input-border:       oklch(from var(--input-status-source) 0.52 c h);
   }
 

--- a/src/elements/a-input.ts
+++ b/src/elements/a-input.ts
@@ -201,7 +201,7 @@ const SHADOW_STYLE = `
     transition: box-shadow 120ms ease;
   }
   :host([multiline]) .field { align-items: stretch; }
-  :host([status]) .field { --_bw: 1px; }
+  :host([status]:not([status="neutral"])) .field { --_bw: 1px; }
   :host([size="small"]) { --_fs: 13px; --_lh: 16px; }
   :host([size="large"]) { --_fs: 17px; --_lh: 22px; }
   :host([size="small"]) .field { min-height: 24px; }

--- a/src/elements/a-radio.css
+++ b/src/elements/a-radio.css
@@ -22,6 +22,7 @@
        neutral grey. Mirrors a-checkbox; constants from the lab. Named tones and a
        custom color point the source elsewhere (rules below). Default is neutral. */
     --radio-tone-source: var(--anta-seed-neutral);
+    --radio-off-tone-source: var(--anta-seed-neutral);
     --_tone-l-rest: 0.6;
     --_tone-l-hover: 0.45;
     --_tone-l-active: 0.4;
@@ -211,55 +212,89 @@
      keyed [tone]), `tone-selected` leaves it neutral so the tone shows only once
      selected. Label + hint are never toned — recolor them in plain CSS via the
      theme-aware --text-N-{tone} tokens (a `color` rule on a-radio-label /
-     a-radio-hint). `neutral` keeps the base greys; the
-     default (no attribute) is untouched — the wrapper omits the neutral value. */
+     a-radio-hint). `tone` sets both the checked and off-state sources;
+     `tone-selected` changes only the checked source. `neutral` keeps the base
+     greys; the default (no attribute) is untouched. */
   /* Colored mark-fill lightnesses (standalone + group-cascaded, tone + tone-selected). */
   a-radio[tone]:not([tone=""], [tone="neutral"]),
   a-radio[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]),
-  a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone]),
-  a-radio-group[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]) a-radio:not([tone-selected]) {
+  a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone], [tone-selected]),
+  a-radio-group[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]) a-radio:not([tone], [tone-selected]) {
     --_tone-l-rest: 0.5;
     --_tone-l-hover: 0.45;
     --_tone-l-active: 0.4;
   }
-  /* Named tones → seed. */
-  a-radio[tone="brand"],    a-radio[tone-selected="brand"],    a-radio-group[tone="brand"] a-radio:not([tone]),    a-radio-group[tone-selected="brand"] a-radio:not([tone-selected])    { --radio-tone-source: var(--anta-seed-brand); }
-  a-radio[tone="info"],     a-radio[tone-selected="info"],     a-radio-group[tone="info"] a-radio:not([tone]),     a-radio-group[tone-selected="info"] a-radio:not([tone-selected])     { --radio-tone-source: var(--anta-seed-info); }
-  a-radio[tone="success"],  a-radio[tone-selected="success"],  a-radio-group[tone="success"] a-radio:not([tone]),  a-radio-group[tone-selected="success"] a-radio:not([tone-selected])  { --radio-tone-source: var(--anta-seed-success); }
-  a-radio[tone="warning"],  a-radio[tone-selected="warning"],  a-radio-group[tone="warning"] a-radio:not([tone]),  a-radio-group[tone-selected="warning"] a-radio:not([tone-selected])  { --radio-tone-source: var(--anta-seed-warning); }
-  a-radio[tone="critical"], a-radio[tone-selected="critical"], a-radio-group[tone="critical"] a-radio:not([tone]), a-radio-group[tone-selected="critical"] a-radio:not([tone-selected]) { --radio-tone-source: var(--anta-seed-critical); }
-  a-radio[tone="neutral"],  a-radio[tone-selected="neutral"],  a-radio-group[tone="neutral"] a-radio:not([tone]),  a-radio-group[tone-selected="neutral"] a-radio:not([tone-selected])  { --radio-tone-source: var(--anta-seed-neutral); }
+  /* Named normal tones → seed. */
+  a-radio[tone="brand"],    a-radio-group[tone="brand"] a-radio:not([tone], [tone-selected])    { --radio-tone-source: var(--anta-seed-brand); --radio-off-tone-source: var(--anta-seed-brand); }
+  a-radio[tone="info"],     a-radio-group[tone="info"] a-radio:not([tone], [tone-selected])     { --radio-tone-source: var(--anta-seed-info); --radio-off-tone-source: var(--anta-seed-info); }
+  a-radio[tone="success"],  a-radio-group[tone="success"] a-radio:not([tone], [tone-selected])  { --radio-tone-source: var(--anta-seed-success); --radio-off-tone-source: var(--anta-seed-success); }
+  a-radio[tone="warning"],  a-radio-group[tone="warning"] a-radio:not([tone], [tone-selected])  { --radio-tone-source: var(--anta-seed-warning); --radio-off-tone-source: var(--anta-seed-warning); }
+  a-radio[tone="critical"], a-radio-group[tone="critical"] a-radio:not([tone], [tone-selected]) { --radio-tone-source: var(--anta-seed-critical); --radio-off-tone-source: var(--anta-seed-critical); }
+  a-radio[tone="neutral"],  a-radio-group[tone="neutral"] a-radio:not([tone], [tone-selected])  { --radio-tone-source: var(--anta-seed-neutral); --radio-off-tone-source: var(--anta-seed-neutral); }
 
   /* `tone` (not tone-selected) also derives the unselected tinted ring from the
      tone in oklch: a whisper-tint fill (chroma scaled down) under a border ramp
      stepped off the fill. Named + custom, standalone + group-cascaded; neutral
      and every tone-selected keep the neutral off-ring border. */
   a-radio[tone]:not([tone=""], [tone="neutral"]),
-  a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone]) {
-    --radio-bg: oklch(from var(--radio-tone-source) 0.99 calc(c * 0.03) h);
-    --_radio-border-base: color-mix(in oklch, var(--radio-bg-selected) 70%, var(--radio-border-neutral));
+  a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone], [tone-selected]) {
+    --radio-bg: oklch(from var(--radio-off-tone-source) 0.99 calc(c * 0.03) h);
+    --_radio-off-bg-selected: oklch(from var(--radio-off-tone-source) var(--_tone-l-rest) c h);
+    --_radio-border-base: color-mix(in oklch, var(--_radio-off-bg-selected) 70%, var(--radio-border-neutral));
     --radio-border:        oklch(from var(--_radio-border-base) calc(l + 0.17) c h);
     --radio-border-hover:  oklch(from var(--_radio-border-base) calc(l + 0.1) c h);
     --radio-border-active: var(--_radio-border-base);
   }
 
-  /* Custom mark tone — a non-named `tone` / `tone-selected` is a literal CSS color;
-     both feed the same --radio-tone-source and the fill curve is derived from it in
-     oklch. Every named value must be listed in the :not(), or attr(… type(<color>))
-     would parse `info` / `success` / etc as colors and render transparent. A
-     standalone radio reads its own attr(); a group-cascaded child inherits
-     --radio-tone-source from the group (the wrapper sets it inline). `tone` still
-     tints the off-ring border (the ramp above, keyed [tone]); `tone-selected` does
-     not. Focus ring stays brand across every tone. */
+  /* A non-named `tone` is a literal CSS color. The group resolves a raw custom
+     attribute on itself and its unoverridden children explicitly inherit it. */
   a-radio[tone]:not(
       [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
       [tone="success"], [tone="warning"], [tone="critical"]) {
     --radio-tone-source: attr(tone type(<color>), transparent);
+    --radio-off-tone-source: attr(tone type(<color>), transparent);
+  }
+  a-radio-group[tone]:not(
+      [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
+      [tone="success"], [tone="warning"], [tone="critical"]) {
+    --radio-tone-source: attr(tone type(<color>), transparent);
+    --radio-off-tone-source: attr(tone type(<color>), transparent);
+  }
+  a-radio-group[tone]:where(:not(
+      [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
+      [tone="success"], [tone="warning"], [tone="critical"])) a-radio:not([tone], [tone-selected]) {
+    --radio-tone-source: inherit;
+    --radio-off-tone-source: inherit;
+  }
+
+  /* Selected-tone mappings follow `tone`, so a selected tone wins the checked
+     fill. An explicit neutral selected tone resets a colored normal tone. */
+  a-radio[tone-selected="brand"],    a-radio-group[tone-selected="brand"] a-radio:not([tone], [tone-selected])    { --radio-tone-source: var(--anta-seed-brand); }
+  a-radio[tone-selected="info"],     a-radio-group[tone-selected="info"] a-radio:not([tone], [tone-selected])     { --radio-tone-source: var(--anta-seed-info); }
+  a-radio[tone-selected="success"],  a-radio-group[tone-selected="success"] a-radio:not([tone], [tone-selected])  { --radio-tone-source: var(--anta-seed-success); }
+  a-radio[tone-selected="warning"],  a-radio-group[tone-selected="warning"] a-radio:not([tone], [tone-selected])  { --radio-tone-source: var(--anta-seed-warning); }
+  a-radio[tone-selected="critical"], a-radio-group[tone-selected="critical"] a-radio:not([tone], [tone-selected]) { --radio-tone-source: var(--anta-seed-critical); }
+  a-radio[tone-selected="neutral"],
+  a-radio-group[tone-selected="neutral"] a-radio:not([tone], [tone-selected]) {
+    --radio-tone-source: var(--anta-seed-neutral);
+    --_tone-l-rest: 0.6;
+    --_tone-l-hover: 0.45;
+    --_tone-l-active: 0.4;
   }
   a-radio[tone-selected]:not(
       [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
       [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) {
     --radio-tone-source: attr(tone-selected type(<color>), transparent);
+  }
+  a-radio-group[tone-selected]:not(
+      [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+      [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) {
+    --radio-tone-source: attr(tone-selected type(<color>), transparent);
+  }
+  a-radio-group[tone-selected]:not(
+      [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+      [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) a-radio:not([tone], [tone-selected]) {
+    --radio-tone-source: inherit;
   }
   /* Dark — neutral chrome + brighter fill/tinted-ring lightnesses. Constants from
      the lab; the fill + tinted-ring formulas (above) recompute against them. */
@@ -282,18 +317,24 @@
   }
   .dark a-radio[tone]:not([tone=""], [tone="neutral"]),
   .dark a-radio[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]),
-  .dark a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone]),
-  .dark a-radio-group[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]) a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone], [tone-selected]),
+  .dark a-radio-group[tone-selected]:not([tone-selected=""], [tone-selected="neutral"]) a-radio:not([tone], [tone-selected]) {
     --_tone-l-rest: 0.45;
     --_tone-l-hover: 0.5;
     --_tone-l-active: 0.57;
   }
   .dark a-radio[tone]:not([tone=""], [tone="neutral"]),
-  .dark a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone]) {
-    --radio-bg: oklch(from var(--radio-tone-source) 0.15 calc(c * 0.18) h);
+  .dark a-radio-group[tone]:not([tone=""], [tone="neutral"]) a-radio:not([tone], [tone-selected]) {
+    --radio-bg: oklch(from var(--radio-off-tone-source) 0.15 calc(c * 0.18) h);
     --radio-border:        var(--_radio-border-base);
     --radio-border-hover:  oklch(from var(--_radio-border-base) calc(l + 0.1) c h);
     --radio-border-active: oklch(from var(--_radio-border-base) calc(l + 0.17) c h);
+  }
+  .dark a-radio[tone-selected="neutral"],
+  .dark a-radio-group[tone-selected="neutral"] a-radio:not([tone], [tone-selected]) {
+    --_tone-l-rest: 0.42;
+    --_tone-l-hover: 0.45;
+    --_tone-l-active: 0.5;
   }
 
   /* A native radio can opt into the same compact control surface with
@@ -322,6 +363,7 @@
     --native-choice-border-hover: var(--border-2);
     --native-choice-border-active: var(--border-1);
     --native-choice-tone-source: var(--anta-seed-neutral);
+    --native-choice-off-tone-source: var(--anta-seed-neutral);
     --_native-choice-l-rest: 0.6;
     --_native-choice-l-hover: 0.45;
     --_native-choice-l-active: 0.4;
@@ -371,15 +413,16 @@
     --_native-choice-l-hover: 0.45;
     --_native-choice-l-active: 0.4;
   }
-  input[data-anta][type="radio"][tone="brand"],    input[data-anta][type="radio"][tone-selected="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); }
-  input[data-anta][type="radio"][tone="info"],     input[data-anta][type="radio"][tone-selected="info"]     { --native-choice-tone-source: var(--anta-seed-info); }
-  input[data-anta][type="radio"][tone="success"],  input[data-anta][type="radio"][tone-selected="success"]  { --native-choice-tone-source: var(--anta-seed-success); }
-  input[data-anta][type="radio"][tone="warning"],  input[data-anta][type="radio"][tone-selected="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); }
-  input[data-anta][type="radio"][tone="critical"], input[data-anta][type="radio"][tone-selected="critical"] { --native-choice-tone-source: var(--anta-seed-critical); }
-  input[data-anta][type="radio"][tone="neutral"],  input[data-anta][type="radio"][tone-selected="neutral"]  { --native-choice-tone-source: var(--anta-seed-neutral); }
+  input[data-anta][type="radio"][tone="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); --native-choice-off-tone-source: var(--anta-seed-brand); }
+  input[data-anta][type="radio"][tone="info"]     { --native-choice-tone-source: var(--anta-seed-info); --native-choice-off-tone-source: var(--anta-seed-info); }
+  input[data-anta][type="radio"][tone="success"]  { --native-choice-tone-source: var(--anta-seed-success); --native-choice-off-tone-source: var(--anta-seed-success); }
+  input[data-anta][type="radio"][tone="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); --native-choice-off-tone-source: var(--anta-seed-warning); }
+  input[data-anta][type="radio"][tone="critical"] { --native-choice-tone-source: var(--anta-seed-critical); --native-choice-off-tone-source: var(--anta-seed-critical); }
+  input[data-anta][type="radio"][tone="neutral"]  { --native-choice-tone-source: var(--anta-seed-neutral); --native-choice-off-tone-source: var(--anta-seed-neutral); }
   input[data-anta][type="radio"][tone]:not([tone=""], [tone="neutral"]) {
-    --native-choice-bg: oklch(from var(--native-choice-tone-source) 0.99 calc(c * 0.03) h);
-    --_native-choice-border-base: color-mix(in oklch, var(--native-choice-selected) 70%, var(--native-choice-border-neutral));
+    --native-choice-bg: oklch(from var(--native-choice-off-tone-source) 0.99 calc(c * 0.03) h);
+    --_native-choice-off-selected: oklch(from var(--native-choice-off-tone-source) var(--_native-choice-l-rest) c h);
+    --_native-choice-border-base: color-mix(in oklch, var(--_native-choice-off-selected) 70%, var(--native-choice-border-neutral));
     --native-choice-border: oklch(from var(--_native-choice-border-base) calc(l + 0.17) c h);
     --native-choice-border-hover: oklch(from var(--_native-choice-border-base) calc(l + 0.1) c h);
     --native-choice-border-active: var(--_native-choice-border-base);
@@ -388,6 +431,18 @@
       [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
       [tone="success"], [tone="warning"], [tone="critical"]) {
     --native-choice-tone-source: attr(tone type(<color>), var(--anta-seed-neutral));
+    --native-choice-off-tone-source: attr(tone type(<color>), var(--anta-seed-neutral));
+  }
+  input[data-anta][type="radio"][tone-selected="brand"]    { --native-choice-tone-source: var(--anta-seed-brand); }
+  input[data-anta][type="radio"][tone-selected="info"]     { --native-choice-tone-source: var(--anta-seed-info); }
+  input[data-anta][type="radio"][tone-selected="success"]  { --native-choice-tone-source: var(--anta-seed-success); }
+  input[data-anta][type="radio"][tone-selected="warning"]  { --native-choice-tone-source: var(--anta-seed-warning); }
+  input[data-anta][type="radio"][tone-selected="critical"] { --native-choice-tone-source: var(--anta-seed-critical); }
+  input[data-anta][type="radio"][tone-selected="neutral"] {
+    --native-choice-tone-source: var(--anta-seed-neutral);
+    --_native-choice-l-rest: 0.6;
+    --_native-choice-l-hover: 0.45;
+    --_native-choice-l-active: 0.4;
   }
   input[data-anta][type="radio"][tone-selected]:not(
       [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
@@ -440,10 +495,15 @@
     --_native-choice-l-active: 0.57;
   }
   .dark input[data-anta][type="radio"][tone]:not([tone=""], [tone="neutral"]) {
-    --native-choice-bg: oklch(from var(--native-choice-tone-source) 0.15 calc(c * 0.18) h);
+    --native-choice-bg: oklch(from var(--native-choice-off-tone-source) 0.15 calc(c * 0.18) h);
     --native-choice-border: var(--_native-choice-border-base);
     --native-choice-border-hover: oklch(from var(--_native-choice-border-base) calc(l + 0.1) c h);
     --native-choice-border-active: oklch(from var(--_native-choice-border-base) calc(l + 0.17) c h);
+  }
+  .dark input[data-anta][type="radio"][tone-selected="neutral"] {
+    --_native-choice-l-rest: 0.42;
+    --_native-choice-l-hover: 0.45;
+    --_native-choice-l-active: 0.5;
   }
 
   /* The selected ring and dot are author-painted pseudo-elements. Keep their

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -311,14 +311,15 @@
 @layer anta {
 
 /* Button ------------------------------------------------------------------- */
-/* Neutral base — `:not([tone])` out-specifies the element's bare `a-button` base
-   (order-independent) while a custom `tone` falls through to the element's
-   higher-specificity `[tone]:not(…named)` rule. Named tones override via their
-   own [tone="…"] rules below. */
+/* Neutral literals apply when tone is omitted or explicitly neutral. */
 a-button:not([tone]),
+a-button[tone="neutral"],
 a[role="button"][data-anta]:not([tone]),
+a[role="button"][data-anta][tone="neutral"],
 button[data-anta]:not([tone]),
-input[data-anta]:is([type="reset"], [type="submit"]):not([tone]) {
+button[data-anta][tone="neutral"],
+input[data-anta]:is([type="reset"], [type="submit"]):not([tone]),
+input[data-anta]:is([type="reset"], [type="submit"])[tone="neutral"] {
   --button-bg-primary-rest: #635b65;
   --button-bg-primary-hover: #534c57;
   --button-bg-primary-active: #49424c;
@@ -370,7 +371,7 @@ a-button[tone="warning"], a[role="button"][data-anta][tone="warning"], button[da
   --button-fg-tertiary-rest: #c37416; --button-fg-tertiary-hover: #ae6613; --button-bg-tertiary-hover: #c374161a; --button-bg-tertiary-active: #c3741633;
   --button-fg-quaternary-rest: #c37416; --button-fg-quaternary-hover: #995200;
 }
-.dark a-button:not([tone]), .dark a[role="button"][data-anta]:not([tone]), .dark button[data-anta]:not([tone]), .dark input[data-anta]:is([type="reset"], [type="submit"]):not([tone]) {
+.dark a-button:not([tone]), .dark a-button[tone="neutral"], .dark a[role="button"][data-anta]:not([tone]), .dark a[role="button"][data-anta][tone="neutral"], .dark button[data-anta]:not([tone]), .dark button[data-anta][tone="neutral"], .dark input[data-anta]:is([type="reset"], [type="submit"]):not([tone]), .dark input[data-anta]:is([type="reset"], [type="submit"])[tone="neutral"] {
   --button-bg-primary-rest: #534c57; --button-bg-primary-hover: #635b65; --button-bg-primary-active: #938d96;
   --button-bg-secondary-rest: #e4d1ef1c; --button-bg-secondary-hover: #e4d1ef24; --button-bg-secondary-active: #e4d1ef2e;
   --button-fg-secondary-rest: #c1b9c1; --button-fg-secondary-hover: #d4ced4; --button-fg-secondary-l-shift: 0;
@@ -753,7 +754,8 @@ a-radio[tone="critical"],
 }
 
 /* ===== tag ===== */
-a-tag:not([tone]) {
+a-tag:not([tone]),
+a-tag[tone="neutral"] {
   --tag-tint: #44374b;
   --tag-bg-solid: #776e77;
   --tag-edge: var(--tag-tint);

--- a/src/theme-anta.css
+++ b/src/theme-anta.css
@@ -416,38 +416,38 @@ a-button[tone="warning"], a[role="button"][data-anta][tone="warning"], button[da
 
 
 /* ===== checkbox ===== */
-a-checkbox[tone="brand"],
-  a-checkbox[tone-selected="brand"] {
-  --checkbox-bg-selected: #5f4bc3;
-  --checkbox-bg-selected-hover: #503cb4;
-  --checkbox-bg-selected-active: #483493;
-}
-a-checkbox[tone="neutral"],
-  a-checkbox[tone-selected="neutral"] {
+/* The omitted and explicit neutral tones use the same reference values. */
+a-checkbox:not([tone]):not([tone-selected]) {
   --checkbox-bg-selected: #878089;
   --checkbox-bg-selected-hover: #776e77;
   --checkbox-bg-selected-active: #635b65;
 }
-a-checkbox[tone="info"],
-  a-checkbox[tone-selected="info"] {
+a-checkbox[tone="brand"] {
+  --checkbox-bg-selected: #5f4bc3;
+  --checkbox-bg-selected-hover: #503cb4;
+  --checkbox-bg-selected-active: #483493;
+}
+a-checkbox[tone="neutral"] {
+  --checkbox-bg-selected: #878089;
+  --checkbox-bg-selected-hover: #776e77;
+  --checkbox-bg-selected-active: #635b65;
+}
+a-checkbox[tone="info"] {
   --checkbox-bg-selected: #1f6eb2;
   --checkbox-bg-selected-hover: #1a5b93;
   --checkbox-bg-selected-active: #175082;
 }
-a-checkbox[tone="success"],
-  a-checkbox[tone-selected="success"] {
+a-checkbox[tone="success"] {
   --checkbox-bg-selected: #2a7e43;
   --checkbox-bg-selected-hover: #226737;
   --checkbox-bg-selected-active: #1f5c31;
 }
-a-checkbox[tone="warning"],
-  a-checkbox[tone-selected="warning"] {
+a-checkbox[tone="warning"] {
   --checkbox-bg-selected: #c37416;
   --checkbox-bg-selected-hover: #ae6613;
   --checkbox-bg-selected-active: #995200;
 }
-a-checkbox[tone="critical"],
-  a-checkbox[tone-selected="critical"] {
+a-checkbox[tone="critical"] {
   --checkbox-bg-selected: #c9302c;
   --checkbox-bg-selected-hover: #b02120;
   --checkbox-bg-selected-active: #a01c1c;
@@ -482,6 +482,43 @@ a-checkbox[tone="critical"] {
   --checkbox-border-hover: #e87f7f;
   --checkbox-border-active: #e56c6c;
 }
+a-checkbox[tone-selected="brand"] {
+  --checkbox-bg-selected: #5f4bc3;
+  --checkbox-bg-selected-hover: #503cb4;
+  --checkbox-bg-selected-active: #483493;
+}
+a-checkbox[tone-selected="neutral"] {
+  --checkbox-bg-selected: #878089;
+  --checkbox-bg-selected-hover: #776e77;
+  --checkbox-bg-selected-active: #635b65;
+}
+a-checkbox[tone-selected="info"] {
+  --checkbox-bg-selected: #1f6eb2;
+  --checkbox-bg-selected-hover: #1a5b93;
+  --checkbox-bg-selected-active: #175082;
+}
+a-checkbox[tone-selected="success"] {
+  --checkbox-bg-selected: #2a7e43;
+  --checkbox-bg-selected-hover: #226737;
+  --checkbox-bg-selected-active: #1f5c31;
+}
+a-checkbox[tone-selected="warning"] {
+  --checkbox-bg-selected: #c37416;
+  --checkbox-bg-selected-hover: #ae6613;
+  --checkbox-bg-selected-active: #995200;
+}
+a-checkbox[tone-selected="critical"] {
+  --checkbox-bg-selected: #c9302c;
+  --checkbox-bg-selected-hover: #b02120;
+  --checkbox-bg-selected-active: #a01c1c;
+}
+a-checkbox[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) {
+  --checkbox-bg-selected: oklch(from var(--checkbox-tone-source) var(--_tone-l-rest) c h);
+  --checkbox-bg-selected-hover: oklch(from var(--checkbox-tone-source) var(--_tone-l-hover) c h);
+  --checkbox-bg-selected-active: oklch(from var(--checkbox-tone-source) var(--_tone-l-active) c h);
+}
 .dark a-checkbox:not([tone]):not([tone-selected]) {
   --checkbox-border-neutral: #49424c;
   --checkbox-border-hover: #635b65;
@@ -491,38 +528,32 @@ a-checkbox[tone="critical"] {
   --checkbox-bg-selected-active: #635b65;
   --checkbox-border-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);
 }
-.dark a-checkbox[tone="brand"],
-  .dark a-checkbox[tone-selected="brand"] {
+.dark a-checkbox[tone="brand"] {
   --checkbox-bg-selected: #503cb4;
   --checkbox-bg-selected-hover: #5f4bc3;
   --checkbox-bg-selected-active: #7460d7;
 }
-.dark a-checkbox[tone="neutral"],
-  .dark a-checkbox[tone-selected="neutral"] {
+.dark a-checkbox[tone="neutral"] {
   --checkbox-bg-selected: #49424c;
   --checkbox-bg-selected-hover: #534c57;
   --checkbox-bg-selected-active: #635b65;
 }
-.dark a-checkbox[tone="info"],
-  .dark a-checkbox[tone-selected="info"] {
+.dark a-checkbox[tone="info"] {
   --checkbox-bg-selected: #1a5b93;
   --checkbox-bg-selected-hover: #1f6eb2;
   --checkbox-bg-selected-active: #2686d9;
 }
-.dark a-checkbox[tone="success"],
-  .dark a-checkbox[tone-selected="success"] {
+.dark a-checkbox[tone="success"] {
   --checkbox-bg-selected: #226737;
   --checkbox-bg-selected-hover: #2a7e43;
   --checkbox-bg-selected-active: #329550;
 }
-.dark a-checkbox[tone="warning"],
-  .dark a-checkbox[tone-selected="warning"] {
+.dark a-checkbox[tone="warning"] {
   --checkbox-bg-selected: #7f410b;
   --checkbox-bg-selected-hover: #995200;
   --checkbox-bg-selected-active: #ae6613;
 }
-.dark a-checkbox[tone="critical"],
-  .dark a-checkbox[tone-selected="critical"] {
+.dark a-checkbox[tone="critical"] {
   --checkbox-bg-selected: #b02120;
   --checkbox-bg-selected-hover: #c9302c;
   --checkbox-bg-selected-active: #de4545;
@@ -557,15 +588,47 @@ a-checkbox[tone="critical"] {
   --checkbox-border-hover: #c9302c;
   --checkbox-border-active: #de4545;
 }
+.dark a-checkbox[tone-selected="brand"] {
+  --checkbox-bg-selected: #503cb4;
+  --checkbox-bg-selected-hover: #5f4bc3;
+  --checkbox-bg-selected-active: #7460d7;
+}
+.dark a-checkbox[tone-selected="neutral"] {
+  --checkbox-bg-selected: #49424c;
+  --checkbox-bg-selected-hover: #534c57;
+  --checkbox-bg-selected-active: #635b65;
+}
+.dark a-checkbox[tone-selected="info"] {
+  --checkbox-bg-selected: #1a5b93;
+  --checkbox-bg-selected-hover: #1f6eb2;
+  --checkbox-bg-selected-active: #2686d9;
+}
+.dark a-checkbox[tone-selected="success"] {
+  --checkbox-bg-selected: #226737;
+  --checkbox-bg-selected-hover: #2a7e43;
+  --checkbox-bg-selected-active: #329550;
+}
+.dark a-checkbox[tone-selected="warning"] {
+  --checkbox-bg-selected: #7f410b;
+  --checkbox-bg-selected-hover: #995200;
+  --checkbox-bg-selected-active: #ae6613;
+}
+.dark a-checkbox[tone-selected="critical"] {
+  --checkbox-bg-selected: #b02120;
+  --checkbox-bg-selected-hover: #c9302c;
+  --checkbox-bg-selected-active: #de4545;
+}
+.dark a-checkbox[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) {
+  --checkbox-bg-selected: oklch(from var(--checkbox-tone-source) var(--_tone-l-rest) c h);
+  --checkbox-bg-selected-hover: oklch(from var(--checkbox-tone-source) var(--_tone-l-hover) c h);
+  --checkbox-bg-selected-active: oklch(from var(--checkbox-tone-source) var(--_tone-l-active) c h);
+}
 
 /* ===== radio ===== */
-/* Neutral base — `:not([tone]):not([tone-selected])` keeps it off a DIRECT custom
-   tone (a per-option / standalone `<a-radio tone|tone-selected="#…">`), which then
-   derives via the element's own custom rule. Named-tone rows (incl. group-cascaded
-   ones) are covered by theme-anta's higher-specificity `[tone="…"]` rules below.
-   NOTE: a RadioGroup-*level* custom color doesn't reach children in any theme —
-   the element sets `--radio-tone-source` locally (a-radio.css), shadowing the
-   group's inherited value — a pre-existing limitation, separate from this theme. */
+/* Neutral base — `:not([tone]):not([tone-selected])` keeps it off a direct custom
+   tone. Named and group-cascaded tones have their own higher-specificity rows. */
 a-radio:not([tone]):not([tone-selected]) {
   --radio-border-width: 1.5px;
   --radio-bg: var(--bg-1);
@@ -579,87 +642,135 @@ a-radio:not([tone]):not([tone-selected]) {
   --radio-border-disabled: color-mix(in oklch, #44374b 10%, transparent);
 }
 a-radio[tone="brand"],
-  a-radio[tone-selected="brand"],
-  a-radio-group[tone="brand"] a-radio:not([tone]),
-  a-radio-group[tone-selected="brand"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="brand"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #5f4bc3;
   --radio-bg-selected-hover: #503cb4;
   --radio-bg-selected-active: #483493;
 }
 a-radio[tone="neutral"],
-  a-radio[tone-selected="neutral"],
-  a-radio-group[tone="neutral"] a-radio:not([tone]),
-  a-radio-group[tone-selected="neutral"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="neutral"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #878089;
   --radio-bg-selected-hover: #776e77;
   --radio-bg-selected-active: #635b65;
 }
 a-radio[tone="info"],
-  a-radio[tone-selected="info"],
-  a-radio-group[tone="info"] a-radio:not([tone]),
-  a-radio-group[tone-selected="info"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="info"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #1f6eb2;
   --radio-bg-selected-hover: #1a5b93;
   --radio-bg-selected-active: #175082;
 }
 a-radio[tone="success"],
-  a-radio[tone-selected="success"],
-  a-radio-group[tone="success"] a-radio:not([tone]),
-  a-radio-group[tone-selected="success"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="success"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #2a7e43;
   --radio-bg-selected-hover: #226737;
   --radio-bg-selected-active: #1f5c31;
 }
 a-radio[tone="warning"],
-  a-radio[tone-selected="warning"],
-  a-radio-group[tone="warning"] a-radio:not([tone]),
-  a-radio-group[tone-selected="warning"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="warning"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #c37416;
   --radio-bg-selected-hover: #ae6613;
   --radio-bg-selected-active: #995200;
 }
 a-radio[tone="critical"],
-  a-radio[tone-selected="critical"],
-  a-radio-group[tone="critical"] a-radio:not([tone]),
-  a-radio-group[tone-selected="critical"] a-radio:not([tone-selected]) {
+  a-radio-group[tone="critical"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #c9302c;
   --radio-bg-selected-hover: #b02120;
   --radio-bg-selected-active: #a01c1c;
 }
 a-radio[tone="brand"],
-  a-radio-group[tone="brand"] a-radio:not([tone]) {
+  a-radio-group[tone="brand"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #fcfcfe;
   --radio-border: #bcb1f1;
   --radio-border-hover: #9e8eeb;
   --radio-border-active: #9081df;
 }
 a-radio[tone="info"],
-  a-radio-group[tone="info"] a-radio:not([tone]) {
+  a-radio-group[tone="info"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #fbfcfe;
   --radio-border: #93c5ec;
   --radio-border-hover: #69ace5;
   --radio-border-active: #56a1e1;
 }
 a-radio[tone="success"],
-  a-radio-group[tone="success"] a-radio:not([tone]) {
+  a-radio-group[tone="success"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #f7fcf9;
   --radio-border: #88d7a0;
   --radio-border-hover: #5bc87b;
   --radio-border-active: #44c169;
 }
 a-radio[tone="warning"],
-  a-radio-group[tone="warning"] a-radio:not([tone]) {
+  a-radio-group[tone="warning"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #fefbf6;
   --radio-border: #edb25a;
   --radio-border-hover: #e09127;
   --radio-border-active: #d88118;
 }
 a-radio[tone="critical"],
-  a-radio-group[tone="critical"] a-radio:not([tone]) {
+  a-radio-group[tone="critical"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #fefbfb;
   --radio-border: #efa4a4;
   --radio-border-hover: #e87f7f;
   --radio-border-active: #e56c6c;
+}
+/* A custom group tone reaches unoverridden children through the element rule.
+   These output values keep the reference theme from restoring the neutral base. */
+a-radio-group[tone]:where(:not(
+    [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
+    [tone="success"], [tone="warning"], [tone="critical"])) a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: oklch(from var(--radio-tone-source) var(--_tone-l-rest) c h);
+  --radio-bg-selected-hover: oklch(from var(--radio-tone-source) var(--_tone-l-hover) c h);
+  --radio-bg-selected-active: oklch(from var(--radio-tone-source) var(--_tone-l-active) c h);
+  --radio-bg: oklch(from var(--radio-off-tone-source) 0.99 calc(c * 0.03) h);
+  --_radio-border-base: color-mix(in oklch, var(--_radio-off-bg-selected) 70%, var(--radio-border-neutral));
+  --radio-border: oklch(from var(--_radio-border-base) calc(l + 0.17) c h);
+  --radio-border-hover: oklch(from var(--_radio-border-base) calc(l + 0.1) c h);
+  --radio-border-active: var(--_radio-border-base);
+}
+a-radio[tone-selected="brand"],
+  a-radio-group[tone-selected="brand"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #5f4bc3;
+  --radio-bg-selected-hover: #503cb4;
+  --radio-bg-selected-active: #483493;
+}
+a-radio[tone-selected="neutral"],
+  a-radio-group[tone-selected="neutral"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #878089;
+  --radio-bg-selected-hover: #776e77;
+  --radio-bg-selected-active: #635b65;
+}
+a-radio[tone-selected="info"],
+  a-radio-group[tone-selected="info"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #1f6eb2;
+  --radio-bg-selected-hover: #1a5b93;
+  --radio-bg-selected-active: #175082;
+}
+a-radio[tone-selected="success"],
+  a-radio-group[tone-selected="success"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #2a7e43;
+  --radio-bg-selected-hover: #226737;
+  --radio-bg-selected-active: #1f5c31;
+}
+a-radio[tone-selected="warning"],
+  a-radio-group[tone-selected="warning"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #c37416;
+  --radio-bg-selected-hover: #ae6613;
+  --radio-bg-selected-active: #995200;
+}
+a-radio[tone-selected="critical"],
+  a-radio-group[tone-selected="critical"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #c9302c;
+  --radio-bg-selected-hover: #b02120;
+  --radio-bg-selected-active: #a01c1c;
+}
+a-radio[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]),
+a-radio-group[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: oklch(from var(--radio-tone-source) var(--_tone-l-rest) c h);
+  --radio-bg-selected-hover: oklch(from var(--radio-tone-source) var(--_tone-l-hover) c h);
+  --radio-bg-selected-active: oklch(from var(--radio-tone-source) var(--_tone-l-active) c h);
 }
 .dark a-radio:not([tone]):not([tone-selected]) {
   --radio-border-hover: #635b65;
@@ -670,87 +781,132 @@ a-radio[tone="critical"],
   --radio-border-disabled: color-mix(in oklch, #e4d1ef 10%, transparent);
 }
 .dark a-radio[tone="brand"],
-  .dark a-radio[tone-selected="brand"],
-  .dark a-radio-group[tone="brand"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="brand"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="brand"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #503cb4;
   --radio-bg-selected-hover: #5f4bc3;
   --radio-bg-selected-active: #7460d7;
 }
 .dark a-radio[tone="neutral"],
-  .dark a-radio[tone-selected="neutral"],
-  .dark a-radio-group[tone="neutral"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="neutral"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="neutral"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #49424c;
   --radio-bg-selected-hover: #534c57;
   --radio-bg-selected-active: #635b65;
 }
 .dark a-radio[tone="info"],
-  .dark a-radio[tone-selected="info"],
-  .dark a-radio-group[tone="info"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="info"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="info"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #1a5b93;
   --radio-bg-selected-hover: #1f6eb2;
   --radio-bg-selected-active: #2686d9;
 }
 .dark a-radio[tone="success"],
-  .dark a-radio[tone-selected="success"],
-  .dark a-radio-group[tone="success"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="success"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="success"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #226737;
   --radio-bg-selected-hover: #2a7e43;
   --radio-bg-selected-active: #329550;
 }
 .dark a-radio[tone="warning"],
-  .dark a-radio[tone-selected="warning"],
-  .dark a-radio-group[tone="warning"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="warning"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="warning"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #7f410b;
   --radio-bg-selected-hover: #995200;
   --radio-bg-selected-active: #ae6613;
 }
 .dark a-radio[tone="critical"],
-  .dark a-radio[tone-selected="critical"],
-  .dark a-radio-group[tone="critical"] a-radio:not([tone]),
-  .dark a-radio-group[tone-selected="critical"] a-radio:not([tone-selected]) {
+  .dark a-radio-group[tone="critical"] a-radio:not([tone], [tone-selected]) {
   --radio-bg-selected: #b02120;
   --radio-bg-selected-hover: #c9302c;
   --radio-bg-selected-active: #de4545;
 }
 .dark a-radio[tone="brand"],
-  .dark a-radio-group[tone="brand"] a-radio:not([tone]) {
+  .dark a-radio-group[tone="brand"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #0b0916;
   --radio-border: #483493;
   --radio-border-hover: #5f4bc3;
   --radio-border-active: #7460d7;
 }
 .dark a-radio[tone="info"],
-  .dark a-radio-group[tone="info"] a-radio:not([tone]) {
+  .dark a-radio-group[tone="info"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #040d18;
   --radio-border: #175082;
   --radio-border-hover: #1f6eb2;
   --radio-border-active: #2686d9;
 }
 .dark a-radio[tone="success"],
-  .dark a-radio-group[tone="success"] a-radio:not([tone]) {
+  .dark a-radio-group[tone="success"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #041008;
   --radio-border: #1f5c31;
   --radio-border-hover: #2a7e43;
   --radio-border-active: #329550;
 }
 .dark a-radio[tone="warning"],
-  .dark a-radio-group[tone="warning"] a-radio:not([tone]) {
+  .dark a-radio-group[tone="warning"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #120a03;
   --radio-border: #6a3b0c;
   --radio-border-hover: #995200;
   --radio-border-active: #ae6613;
 }
 .dark a-radio[tone="critical"],
-  .dark a-radio-group[tone="critical"] a-radio:not([tone]) {
+  .dark a-radio-group[tone="critical"] a-radio:not([tone], [tone-selected]) {
   --radio-bg: #190405;
   --radio-border: #a01c1c;
   --radio-border-hover: #c9302c;
   --radio-border-active: #de4545;
+}
+.dark a-radio-group[tone]:where(:not(
+    [tone=""], [tone="brand"], [tone="neutral"], [tone="info"],
+    [tone="success"], [tone="warning"], [tone="critical"])) a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: oklch(from var(--radio-tone-source) var(--_tone-l-rest) c h);
+  --radio-bg-selected-hover: oklch(from var(--radio-tone-source) var(--_tone-l-hover) c h);
+  --radio-bg-selected-active: oklch(from var(--radio-tone-source) var(--_tone-l-active) c h);
+  --radio-bg: oklch(from var(--radio-off-tone-source) 0.15 calc(c * 0.18) h);
+  --radio-border: var(--_radio-border-base);
+  --radio-border-hover: oklch(from var(--_radio-border-base) calc(l + 0.1) c h);
+  --radio-border-active: oklch(from var(--_radio-border-base) calc(l + 0.17) c h);
+}
+.dark a-radio[tone-selected="brand"],
+  .dark a-radio-group[tone-selected="brand"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #503cb4;
+  --radio-bg-selected-hover: #5f4bc3;
+  --radio-bg-selected-active: #7460d7;
+}
+.dark a-radio[tone-selected="neutral"],
+  .dark a-radio-group[tone-selected="neutral"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #49424c;
+  --radio-bg-selected-hover: #534c57;
+  --radio-bg-selected-active: #635b65;
+}
+.dark a-radio[tone-selected="info"],
+  .dark a-radio-group[tone-selected="info"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #1a5b93;
+  --radio-bg-selected-hover: #1f6eb2;
+  --radio-bg-selected-active: #2686d9;
+}
+.dark a-radio[tone-selected="success"],
+  .dark a-radio-group[tone-selected="success"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #226737;
+  --radio-bg-selected-hover: #2a7e43;
+  --radio-bg-selected-active: #329550;
+}
+.dark a-radio[tone-selected="warning"],
+  .dark a-radio-group[tone-selected="warning"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #7f410b;
+  --radio-bg-selected-hover: #995200;
+  --radio-bg-selected-active: #ae6613;
+}
+.dark a-radio[tone-selected="critical"],
+  .dark a-radio-group[tone-selected="critical"] a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: #b02120;
+  --radio-bg-selected-hover: #c9302c;
+  --radio-bg-selected-active: #de4545;
+}
+.dark a-radio[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]),
+.dark a-radio-group[tone-selected]:not(
+    [tone-selected=""], [tone-selected="brand"], [tone-selected="neutral"], [tone-selected="info"],
+    [tone-selected="success"], [tone-selected="warning"], [tone-selected="critical"]) a-radio:not([tone], [tone-selected]) {
+  --radio-bg-selected: oklch(from var(--radio-tone-source) var(--_tone-l-rest) c h);
+  --radio-bg-selected-hover: oklch(from var(--radio-tone-source) var(--_tone-l-hover) c h);
+  --radio-bg-selected-active: oklch(from var(--radio-tone-source) var(--_tone-l-active) c h);
 }
 
 /* ===== tag ===== */


### PR DESCRIPTION
## Summary

- apply the reference theme's neutral Button values when `tone="neutral"` is explicit, in light and dark modes
- apply the reference theme's neutral Tag values when `tone="neutral"` is explicit
- keep disabled and loading Button links styled as unavailable and block their activation under React and Preact
- consolidate #147, #149, and #150 into one conflict-free change based on `main`

## Neutral-tone audit

The reference-theme overrides were checked for the same omitted-versus-explicit neutral mismatch. Checkbox and Radio already have explicit neutral rules; Input's `tone` is the custom-color channel. Button and Tag were the missing named-neutral cases addressed here.

## Disabled Button DOM

A Button without `href` continues to use the custom element:

```tsx
<Button disabled label="Save" />
```

```html
<a-button disabled="" aria-disabled="true" tabindex="-1">
```

A Button with `href` uses a native anchor. Before this fix, React removed the empty-string `disabled` prop:

```tsx
<Button disabled href="#target" label="Save" />
```

```html
<a href="#target" role="button" data-anta aria-disabled="true" tabindex="-1">
```

The anchor branch now passes a boolean presence prop and guards activation:

```html
<a href="#target" role="button" data-anta disabled="" aria-disabled="true" tabindex="-1">
```

<img width="542" height="136" alt="Screenshot 2026-08-17 at 2 33 20 PM" src="https://github.com/user-attachments/assets/ca2e8e34-860f-46d5-b60c-ed44d401953c" />
<img width="72" height="45" alt="Screenshot 2026-08-17 at 2 33 27 PM" src="https://github.com/user-attachments/assets/7024ab54-fff6-4cf8-89d7-6f3c0122bef2" />



```html
<a href="#" data-anta="" role="button" priority="primary" tabindex="-1" aria-disabled="true"><a-button-label>anan</a-button-label></a>
```

## Validation

- `pnpm run build:dev`
- `pnpm run typecheck`