### PR TITLE
Improve input truncation and menu behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ changes are not listed.
 
 - JSX `Input` now truncates overflowing single-line values by default. Pass
   `truncate={false}` to show the full value.
-- Clicks inside a `Menu` no longer bubble to ancestor or document handlers.
-- Open menus now follow their trigger as it moves or resizes.
+- Selecting a `Menu` item no longer bubbles the click to ancestor handlers (e.g. a
+  clickable row the menu sits in). Set `stopPropagation` to contain more event types.
+- Open menus follow their trigger vertically as it scrolls or shifts, keeping the
+  side chosen at open.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ changes are not listed.
 
 ## Unreleased
 
+### Changed
+
+- JSX `Input` now truncates overflowing single-line values by default. Pass
+  `truncate={false}` to show the full value.
+- Clicks inside a `Menu` no longer bubble to ancestor or document handlers.
+- Open menus now follow their trigger as it moves or resizes.
+
 ### Fixed
 
 - Checkbox, Radio, and Switch now show one focus ring around their visual control.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,21 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## Unreleased
+
+### Changed
+
+- JSX `Input` now truncates overflowing single-line values by default. Pass
+  `truncate={false}` to show the full value.
+- Selecting a `Menu` item no longer bubbles the click to ancestor handlers (e.g. a
+  clickable row the menu sits in). Set `stopPropagation` to contain more event types.
+- Open menus follow their trigger vertically as it scrolls or shifts, keeping the
+  side chosen at open.
+
+### Fixed
+
+- Checkbox, Radio, and Switch now show one focus ring around their visual control.
+
 ## 0.3.21 — August 11, 2026
 
 ### Added

--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -513,8 +513,8 @@ wraps to fewer columns as it narrows. Resize the preview to see it reflow.
  other controls' custom-tone knob; a `status` still overrides for validation. |
 | `trailing?` | ReactNode | — | Content pinned to the end of the field (e.g. icons, buttons), after the
  clear button when `clearable`. |
-| `truncate?` | boolean | — | Ellipsize an overflowing single-line value. Read-only inputs already do
-this; use `truncate` when an editable field should keep the same treatment. |
+| `truncate?` | boolean | true | Ellipsize an overflowing single-line value. Read-only inputs already do
+this; pass `false` when an editable field should show the full value. |
 | `type?` | 'text' \| 'search' \| 'email' \| 'password' \| 'tel' \| 'url' \| 'number' | text | Single-line input type. Ignored when `multiline`. `search` is a
  **wrapper-only** shorthand: it defaults a leading search icon and a clear
  button (both overridable — pass your own `leading`, or `clearable={false}`)

--- a/docs/components/menu.md
+++ b/docs/components/menu.md
@@ -240,6 +240,11 @@ run off the UI thread. Walking out from the click, the nearest marker wins:
   element (or a "Done" button inside a `data-menu-open` region) can dismiss the
   menu without being a `MenuItem`.
 
+Selecting an item won't also click the region the menu sits in — the activation
+click stops at the surface, so a `<Menu>` inside a clickable row or card is safe.
+Other events still bubble; pass `stopPropagation` (`true` for clicks, or event
+names like `"click pointerdown"`) to contain those too.
+
 For programmatic open/close from app state, drive the `open` prop (the `state`
 attribute, `"open"` / `"closed"`) and react via `onStateChange`, or keep a `ref`
 and call `.open()` / `.close()` / `.toggle()`.

--- a/site/src/components/MenuContainmentDemo.tsx
+++ b/site/src/components/MenuContainmentDemo.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'preact/hooks'
+import { Menu, MenuItem, MenuSeparator, Button, Text } from '@antadesign/anta'
+
+/**
+ * Live demo for the Menu docs: a whole row is clickable (it "opens" the file),
+ * with a kebab Menu in the corner. Selecting an item never fires the row's
+ * `onClick` — the activation click is contained at the menu surface — so the
+ * in-row counter only moves when the row itself is clicked. The props-driven
+ * playground can't express an ancestor `onClick`, so this is a hydrated island.
+ */
+export default function MenuContainmentDemo() {
+  const [rowClicks, setRowClicks] = useState(0)
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => setRowClicks((n) => n + 1)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        padding: '10px 12px',
+        border: '1px solid var(--border-3)',
+        borderRadius: '10px',
+        background: 'var(--bg-2)',
+        cursor: 'pointer',
+      }}
+    >
+      <span style={{ flex: '1' }}>Quarterly report.pdf</span>
+      <Text size="small" style={{ color: 'var(--text-4)' }}>
+        Click row: {rowClicks}
+      </Text>
+      {/* The trigger is an ordinary button inside the row, so its own click
+          bubbles — stop it so opening the menu isn't counted as a row click.
+          The menu items need no such handling; the menu contains them. */}
+      <Button
+        priority="tertiary"
+        icon="dots-vertical"
+        aria-label="File actions"
+        onClick={(e: any) => e.stopPropagation()}
+      />
+      <Menu>
+        <MenuItem icon="edit" label="Rename" />
+        <MenuItem icon="copy" label="Duplicate" />
+        <MenuSeparator />
+        <MenuItem icon="trash" tone="critical" label="Delete" />
+      </Menu>
+    </div>
+  )
+}

--- a/site/src/pages/menu.mdx
+++ b/site/src/pages/menu.mdx
@@ -11,6 +11,7 @@ import Col from '../components/Col.astro'
 import menuDemoCode from './menu.demo.ts'
 import MenuNestedDemo from '../components/MenuNestedDemo'
 import MenuCopyDemo from '../components/MenuCopyDemo'
+import MenuContainmentDemo from '../components/MenuContainmentDemo'
 import { Menu, MenuItem, MenuSeparator, MenuGroup, Button, Input, Tag } from '@antadesign/anta'
 
 # Menu
@@ -441,6 +442,11 @@ run off the UI thread. Walking out from the click, the nearest marker wins:
   element (or a "Done" button inside a `data-menu-open` region) can dismiss the
   menu without being a `MenuItem`.
 
+Selecting an item won't also click the region the menu sits in — the activation
+click stops at the surface, so a `<Menu>` inside a clickable row or card is safe.
+Other events still bubble; pass `stopPropagation` (`true` for clicks, or event
+names like `"click pointerdown"`) to contain those too.
+
 For programmatic open/close from app state, drive the `open` prop (the `state`
 attribute, `"open"` / `"closed"`) and react via `onStateChange`, or keep a `ref`
 and call `.open()` / `.close()` / `.toggle()`.
@@ -477,6 +483,47 @@ and call `.open()` / `.close()` / `.toggle()`.
     <button data-menu-close>Done</button>
   </div>
 </Menu>
+```
+
+</Col>
+</Columns>
+
+## Inside a clickable row
+
+<Columns reverse>
+<Col>
+
+A `<Menu>` can live inside a clickable row or card without its items triggering
+that row's `onClick` — selecting an item is contained at the menu surface. In the
+row below, the counter moves when you click the row, but not when you pick a menu
+item. The kebab trigger is a plain button, so its click is stopped by hand; the menu
+items need nothing. To contain more (a slotted control's clicks, say), add
+`stopPropagation` to the `<Menu>`.
+
+</Col>
+<Col>
+
+<Preview>
+  <MenuContainmentDemo client:visible />
+</Preview>
+
+```tsx folded
+<div className="row" onClick={openRow}>
+  <span>Quarterly report.pdf</span>
+  {/* the trigger is a plain button — stop its click so opening the
+      menu isn't a row click; the menu items need no handling */}
+  <Button
+    icon="dots-vertical"
+    aria-label="File actions"
+    onClick={(e) => e.stopPropagation()}
+  />
+  <Menu>
+    <MenuItem icon="edit" label="Rename" onSelect={rename} />
+    <MenuItem icon="copy" label="Duplicate" onSelect={duplicate} />
+    <MenuSeparator />
+    <MenuItem icon="trash" tone="critical" label="Delete" onSelect={confirmDelete} />
+  </Menu>
+</div>
 ```
 
 </Col>

--- a/src/components/Input.tsx
+++ b/src/components/Input.tsx
@@ -102,7 +102,8 @@ export interface InputProps extends BaseProps, DOMEventHandlers {
   /** Placeholder shown when empty. */
   placeholder?: string
   /** Ellipsize an overflowing single-line value. Read-only inputs already do
-   * this; use `truncate` when an editable field should keep the same treatment. */
+   * this; pass `false` when an editable field should show the full value.
+   * @defaultValue true */
   truncate?: boolean
   /** Disable the field. */
   disabled?: boolean
@@ -247,7 +248,7 @@ export const Input = ({
   inputMode,
   name,
   placeholder,
-  truncate,
+  truncate = true,
   disabled,
   readOnly,
   required,

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -47,6 +47,11 @@ export interface MenuProps extends BaseProps {
    *  fully round. A `number` (px) or CSS length string tunes the container radius
    *  only — items stay full pills. */
   round?: boolean | number | string
+  /** Contain events so they don't bubble out of the menu to ancestor handlers
+   *  (e.g. a clickable row the menu sits in). Selecting an item is always
+   *  contained; this extends it to whole event types. `true` contains `click`;
+   *  pass an event name or list (`"click pointerdown"`) to contain those. */
+  stopPropagation?: boolean | string | string[]
   /** Fired before the open state changes — on open, and on every dismiss (Esc,
    *  outside-click, scroll, selecting an item). `event` is the cancelable
    *  `statechange`; `detail.next`/`detail.prev` are the requested/previous open
@@ -117,6 +122,7 @@ export const Menu = ({
   open,
   onStateChange,
   round,
+  stopPropagation,
   role = 'menu',
   className,
   style,
@@ -156,6 +162,17 @@ export const Menu = ({
           : undefined
       }
       round={roundAttr(round)}
+      // `true` → bare attribute (element defaults to `click`); a string / list is
+      // passed through; omit ⇒ only the built-in menu-item containment applies.
+      stop-propagation={
+        stopPropagation === undefined || stopPropagation === false
+          ? undefined
+          : stopPropagation === true
+            ? ''
+            : Array.isArray(stopPropagation)
+              ? stopPropagation.join(' ')
+              : stopPropagation
+      }
       role={role}
       aria-orientation="vertical"
       class={className}

--- a/src/elements/a-menu.ts
+++ b/src/elements/a-menu.ts
@@ -22,6 +22,12 @@ const SELF_ACTIVATING =
  *  gesture. Read-only or non-field triggers open on Enter / Space / arrows alike. */
 const EDITABLE_FIELD =
   'input:not([readonly]), textarea:not([readonly]), a-input:not([readonly]), a-input-time:not([readonly])'
+/** Declarative triggers that fire via a document / host-level bubble listener
+ *  (`a-dialog`'s `data-dialog-open` / `-close`, `a-toast` / `a-banner`
+ *  `data-*-dismiss`). A click on one must reach that listener, so surgical click
+ *  containment lets it through even when it sits on a menu item. */
+const DECLARATIVE_TRIGGER =
+  '[data-dialog-open], [data-dialog-close], [data-toast-dismiss], [data-banner-dismiss]'
 
 type Placement =
   | 'bottom-start' | 'bottom-end' | 'top-start' | 'top-end' | 'bottom' | 'top'
@@ -232,7 +238,7 @@ const lazyObserver: IntersectionObserver | null =
  *   slotted light DOM (see `a-menu-item.css`), directly styleable.
  */
 export class AMenuElement extends HTMLElementBase {
-  static observedAttributes = ['placement', 'context', 'coord', 'offset', 'nohover', 'state']
+  static observedAttributes = ['placement', 'context', 'coord', 'offset', 'nohover', 'state', 'stop-propagation']
 
   /** Shadow-internal popover surface — the only thing we ever mutate. */
   surface!: HTMLDivElement
@@ -267,11 +273,21 @@ export class AMenuElement extends HTMLElementBase {
   // event, which the reactive layer reflects onto the field's `aria-activedescendant`.
   private activeItem: AMenuItemElement | null = null
   private comboObserver?: MutationObserver
-  // An open menu follows its anchor through scrolling, transforms, and layout
-  // shifts. Those movements do not all produce a DOM observer callback, so this
-  // frame is active only while the menu is visible.
+  // An open menu follows its anchor vertically through scrolling, transforms, and
+  // layout shifts. Those movements do not all produce a DOM observer callback, so
+  // this frame is active only while the menu is visible.
   #anchorTrackingFrame?: number
   #lastAnchorRect?: readonly number[]
+  // Vertical-follow baseline captured on each full position(): the frozen
+  // horizontal offset and the gap to the anchor's top. Tracking translates to hold
+  // this gap as the anchor moves; it never re-flips or chases the anchor sideways.
+  #followLeft?: number
+  #followGap?: number
+  // Opt-in event containment (`stop-propagation`): event types whose bubbling out
+  // of the surface is suppressed. Selecting an item is always contained (see
+  // onSurfaceClick); this is the broad, configurable lever on top of that.
+  #stopEvents = new Set<string>()
+  #stopHandler = (e: Event) => e.stopPropagation()
   // The vertical side chosen at open (true = flipped above the anchor). A re-anchor
   // (filtering changes height) keeps this side rather than re-deciding — a shrunk
   // menu shouldn't hop back under the trigger.
@@ -453,6 +469,7 @@ export class AMenuElement extends HTMLElementBase {
     // items (`<a data-anta-menu-item>`), where no `<a-menu-item>` ever upgrades
     // to install the listener itself. Idempotent per document.
     ensureMenuItemKeyListener(this.doc)
+    this.#syncStopPropagation()
     const anchor = this.triggerAnchor
     if (anchor) {
       anchorToMenu.set(anchor, this)
@@ -483,6 +500,10 @@ export class AMenuElement extends HTMLElementBase {
     // back into their own handler; that silence is what prevents a loop).
     if (name === 'state') {
       this.syncState()
+      return
+    }
+    if (name === 'stop-propagation') {
+      this.#syncStopPropagation()
       return
     }
     // Trigger-shaping attributes changed — rewire the anchor listeners.
@@ -1069,8 +1090,11 @@ export class AMenuElement extends HTMLElementBase {
 
   /* ============================ positioning ============================ */
 
-  /** Keep an anchor-positioned menu aligned as its target moves. Pointer- and
-   * keyboard-coordinate menus intentionally remain at their opening point. */
+  /** Follow an anchor-positioned menu on the vertical axis as its target moves
+   *  (scroll, transform, layout shift). The side chosen at open never flips and the
+   *  horizontal position stays put — a re-flip would fight the open-time placement,
+   *  and chasing the anchor sideways isn't wanted. Coordinate menus keep their
+   *  opening point. */
   #startAnchorTracking(coord?: [number, number]) {
     this.#stopAnchorTracking()
     if (coord || this.#isCoord) return
@@ -1092,13 +1116,24 @@ export class AMenuElement extends HTMLElementBase {
       const next = this.#anchorRectValues(currentAnchor)
       if (!this.#sameAnchorRect(next)) {
         this.#lastAnchorRect = next
-        // Re-evaluate placement as the anchor crosses an edge: a menu may need
-        // to flip to the other side of its target.
-        this.position(undefined, true)
+        this.#followVertically(currentAnchor)
       }
       this.#anchorTrackingFrame = this.view.requestAnimationFrame(track)
     }
     this.#anchorTrackingFrame = this.view.requestAnimationFrame(track)
+  }
+
+  /** Hold the vertical gap captured at the last full position() as the anchor
+   *  moves — a pure translate, so no reflow. Horizontal stays frozen and the side
+   *  never flips; the menu clamps within the viewport. */
+  #followVertically(anchor: Element) {
+    if (this.#followGap === undefined || this.#followLeft === undefined) return
+    const box = this.surface.getBoundingClientRect()
+    let top = anchorRect(anchor).top + this.#followGap
+    top = Math.min(top, this.view.innerHeight - box.height - MARGIN)
+    top = Math.max(MARGIN, top)
+    this.surface.style.transform = `translate(${this.#followLeft}px, ${Math.round(top)}px)`
+    this.updateScrollFade()
   }
 
   #stopAnchorTracking() {
@@ -1107,6 +1142,8 @@ export class AMenuElement extends HTMLElementBase {
       this.#anchorTrackingFrame = undefined
     }
     this.#lastAnchorRect = undefined
+    this.#followLeft = undefined
+    this.#followGap = undefined
   }
 
   #anchorRectValues(anchor: Element): readonly number[] {
@@ -1245,8 +1282,17 @@ export class AMenuElement extends HTMLElementBase {
         }
       }
 
-      surface.style.transform = `translate(${Math.round(left)}px, ${Math.round(top)}px)`
+      const appliedLeft = Math.round(left)
+      const appliedTop = Math.round(top)
+      surface.style.transform = `translate(${appliedLeft}px, ${appliedTop}px)`
       this.updateScrollFade()
+      // Capture the vertical-follow baseline for anchor tracking: the frozen
+      // horizontal offset and the gap to the anchor's top. Coordinate menus don't
+      // track, so they don't need it.
+      if (!coord && !this.#isCoord && this.triggerAnchor) {
+        this.#followLeft = appliedLeft
+        this.#followGap = appliedTop - anchorRect(this.triggerAnchor).top
+      }
     }
     // Sync (instant open atop an already-open menu) avoids both the rAF delay
     // and the unpositioned first frame; otherwise position next frame.
@@ -1259,9 +1305,10 @@ export class AMenuElement extends HTMLElementBase {
   /**
    * Fully declarative close contract — decided synchronously from the DOM, so
    * it never depends on the consumer's click handler (which in a worker-thread
-   * runtime can't `preventDefault` on the UI thread). The menu stops the click
-   * before it leaves its surface, but never prevents it: item handlers still run
-   * and link items retain their native navigation.
+   * runtime can't `preventDefault` on the UI thread). A menu-item / `data-menu-close`
+   * activation stops the click at the surface so it doesn't leak to an ancestor (a
+   * clickable row the menu sits in); it never prevents it, so item handlers and link
+   * navigation still run. Other clicks bubble unless `stop-propagation` opts in.
    *
    * Walk the click's composedPath outward to the surface; the NEAREST marker
    * wins:
@@ -1271,10 +1318,23 @@ export class AMenuElement extends HTMLElementBase {
    *   - nothing → keep open (plain custom content doesn't dismiss).
    */
   private onSurfaceClick = (e: MouseEvent) => {
-    // Keep menu activations contained. This runs after a clicked item's own
-    // handler, so a link can still navigate and custom content keeps its normal
-    // click behavior; only ancestor/document bubbling is suppressed.
-    e.stopPropagation()
+    // Contain the click so activating an item doesn't also register as a click on
+    // whatever the menu is nested in (a clickable row / card). Scoped to genuine
+    // `<a-menu-item>` / `[data-menu-close]` activations: their `onSelect` rides the
+    // `menuselect` event, not this click, so stopping it loses nothing. Link items
+    // and plain content keep bubbling (a link's `onSelect` IS its delegated click);
+    // the `stop-propagation` attribute contains those too when asked. A declarative
+    // trigger in the path is exempt — its own click must reach the document / host
+    // listener that acts on it, even when it rides on a menu item.
+    let contain = false
+    let exemptTrigger = false
+    for (const node of e.composedPath()) {
+      if (node === this.surface) break
+      if (!(node instanceof Element)) continue
+      if (node.matches(DECLARATIVE_TRIGGER)) exemptTrigger = true
+      if (node instanceof AMenuItemElement || node.hasAttribute('data-menu-close')) contain = true
+    }
+    if (contain && !exemptTrigger) e.stopPropagation()
 
     // Selection pass — do the "which item was actually activated?" walk HERE, on
     // the UI thread where the composed path is real, and emit a pre-filtered
@@ -1349,6 +1409,27 @@ export class AMenuElement extends HTMLElementBase {
   private closeSystem(e?: Event) {
     const root = openStack[0] ?? this
     root.requestClose(e)
+  }
+
+  /** Event types the `stop-propagation` attribute contains at the surface. A bare
+   *  or empty attribute defaults to `click`; a value is a space / comma list. */
+  #parseStopEvents(): Set<string> {
+    if (!this.hasAttribute('stop-propagation')) return new Set()
+    const raw = (this.getAttribute('stop-propagation') ?? '').trim()
+    return new Set(raw ? raw.split(/[\s,]+/) : ['click'])
+  }
+
+  /** Reconcile the surface's containment listeners with the `stop-propagation`
+   *  attribute. Each listed type gets a bubble listener that stops it at the
+   *  surface, so it never reaches an ancestor / document handler. Selecting an item
+   *  is already contained by onSurfaceClick; this is the broad, opt-in lever. */
+  #syncStopPropagation() {
+    const next = this.#parseStopEvents()
+    for (const type of this.#stopEvents)
+      if (!next.has(type)) this.surface.removeEventListener(type, this.#stopHandler)
+    for (const type of next)
+      if (!this.#stopEvents.has(type)) this.surface.addEventListener(type, this.#stopHandler)
+    this.#stopEvents = next
   }
 
   /* ============================ keyboard ============================ */

--- a/src/elements/a-menu.ts
+++ b/src/elements/a-menu.ts
@@ -267,6 +267,11 @@ export class AMenuElement extends HTMLElementBase {
   // event, which the reactive layer reflects onto the field's `aria-activedescendant`.
   private activeItem: AMenuItemElement | null = null
   private comboObserver?: MutationObserver
+  // An open menu follows its anchor through scrolling, transforms, and layout
+  // shifts. Those movements do not all produce a DOM observer callback, so this
+  // frame is active only while the menu is visible.
+  #anchorTrackingFrame?: number
+  #lastAnchorRect?: readonly number[]
   // The vertical side chosen at open (true = flipped above the anchor). A re-anchor
   // (filtering changes height) keeps this side rather than re-deciding — a shrunk
   // menu shouldn't hop back under the trigger.
@@ -1023,6 +1028,7 @@ export class AMenuElement extends HTMLElementBase {
     // now — no fade-skip needed; the CSS transition + @starting-style handle the
     // enter, and a brief fade-in over an existing menu reads fine.
     this.position(coord, instant)
+    this.#startAnchorTracking(coord)
   }
 
   /** Dismiss any tooltip on the trigger as the menu opens, so the trigger's
@@ -1038,6 +1044,7 @@ export class AMenuElement extends HTMLElementBase {
 
   /** Shadow-only hide. */
   _doHide() {
+    this.#stopAnchorTracking()
     if (this.surface.isConnected && this._shown) this.surface.hidePopover()
     this._shown = false
     this.reflectOpen(false)
@@ -1061,6 +1068,56 @@ export class AMenuElement extends HTMLElementBase {
   }
 
   /* ============================ positioning ============================ */
+
+  /** Keep an anchor-positioned menu aligned as its target moves. Pointer- and
+   * keyboard-coordinate menus intentionally remain at their opening point. */
+  #startAnchorTracking(coord?: [number, number]) {
+    this.#stopAnchorTracking()
+    if (coord || this.#isCoord) return
+
+    const anchor = this.triggerAnchor
+    if (!anchor) return
+    this.#lastAnchorRect = this.#anchorRectValues(anchor)
+
+    const track = () => {
+      if (!this._shown) {
+        this.#anchorTrackingFrame = undefined
+        return
+      }
+      const currentAnchor = this.triggerAnchor
+      if (!currentAnchor) {
+        this.#anchorTrackingFrame = undefined
+        return
+      }
+      const next = this.#anchorRectValues(currentAnchor)
+      if (!this.#sameAnchorRect(next)) {
+        this.#lastAnchorRect = next
+        // Re-evaluate placement as the anchor crosses an edge: a menu may need
+        // to flip to the other side of its target.
+        this.position(undefined, true)
+      }
+      this.#anchorTrackingFrame = this.view.requestAnimationFrame(track)
+    }
+    this.#anchorTrackingFrame = this.view.requestAnimationFrame(track)
+  }
+
+  #stopAnchorTracking() {
+    if (this.#anchorTrackingFrame !== undefined) {
+      this.view.cancelAnimationFrame(this.#anchorTrackingFrame)
+      this.#anchorTrackingFrame = undefined
+    }
+    this.#lastAnchorRect = undefined
+  }
+
+  #anchorRectValues(anchor: Element): readonly number[] {
+    const { left, top, right, bottom, width, height } = anchorRect(anchor)
+    return [left, top, right, bottom, width, height]
+  }
+
+  #sameAnchorRect(next: readonly number[]): boolean {
+    const prev = this.#lastAnchorRect
+    return !!prev && prev.length === next.length && prev.every((value, index) => value === next[index])
+  }
 
   private position(coord?: [number, number], sync = false, reanchor = false) {
     const run = () => {
@@ -1202,8 +1259,9 @@ export class AMenuElement extends HTMLElementBase {
   /**
    * Fully declarative close contract — decided synchronously from the DOM, so
    * it never depends on the consumer's click handler (which in a worker-thread
-   * runtime can't `preventDefault` on the UI thread). The menu never
-   * stops/prevents the click, so the consumer's selection handler always runs.
+   * runtime can't `preventDefault` on the UI thread). The menu stops the click
+   * before it leaves its surface, but never prevents it: item handlers still run
+   * and link items retain their native navigation.
    *
    * Walk the click's composedPath outward to the surface; the NEAREST marker
    * wins:
@@ -1213,6 +1271,11 @@ export class AMenuElement extends HTMLElementBase {
    *   - nothing → keep open (plain custom content doesn't dismiss).
    */
   private onSurfaceClick = (e: MouseEvent) => {
+    // Keep menu activations contained. This runs after a clicked item's own
+    // handler, so a link can still navigate and custom content keeps its normal
+    // click behavior; only ancestor/document bubbling is suppressed.
+    e.stopPropagation()
+
     // Selection pass — do the "which item was actually activated?" walk HERE, on
     // the UI thread where the composed path is real, and emit a pre-filtered
     // `menuselect` on that item. The `MenuItem` wrapper then reacts with a pure

--- a/src/general_types.ts
+++ b/src/general_types.ts
@@ -836,6 +836,12 @@ export interface AMenuAttributes extends BaseAttributes {
    *  layer that owns the field (e.g. `Select`) listens here and reflects it.
    *  All-lowercase so React/Preact bind it to the CustomEvent. */
   onactivedescendant?: (e: CustomEvent<{ id: string | null }>) => void
+  /** Contain events so they don't bubble out of the menu surface to ancestor /
+   *  document handlers. Space- or comma-separated event names
+   *  (`stop-propagation="click pointerdown"`); a bare / empty attribute defaults to
+   *  `click`. Menu-item / `data-menu-close` selections are always contained; this
+   *  extends containment to whole event types. */
+  'stop-propagation'?: string
   /** ARIA role — the JSX wrapper sets this to `'menu'`. */
   role?: string
   'aria-orientation'?: 'vertical' | 'horizontal'


### PR DESCRIPTION
## Summary

- Make JSX `Input` truncate overflowing single-line values by default, with `truncate={false}` as the opt-out.
- Keep clicks inside `Menu` surfaces from bubbling to ancestor and document handlers while preserving item handlers and link navigation.
- Keep open anchor-positioned menus aligned while their trigger moves or resizes, including scrolling, transforms, layout shifts, and placement flips.

## Why

Input should match the library's single-line overflow treatment by default. Menu interactions must stay contained, and an open menu must not become detached from a moved trigger.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- Browse: moved the open Actions trigger by 96×48px and confirmed its menu followed while preserving the anchor gap.