### PR TITLE
Fix aria-expanded role on Select/InputDate triggers; release 0.3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ changes are not listed.
 
 ### Fixed
 
+- `Select` and `InputDate` triggers carry a `combobox` role, so their
+  `aria-expanded` is valid (WCAG 4.1.2 / `aria-allowed-attr`) — it was previously
+  set on an element with no supporting role.
 - Checkbox, Radio, and Switch now show one focus ring around their visual control.
 
 ## 0.3.21 — August 11, 2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
+## 0.3.22 — August 20, 2026
 
 ### Changed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,9 @@ changes are not listed.
 
 ### Fixed
 
+- `Select` and `InputDate` triggers carry a `combobox` role, so their
+  `aria-expanded` is valid (WCAG 4.1.2 / `aria-allowed-attr`) — it was previously
+  set on an element with no supporting role.
 - Checkbox, Radio, and Switch now show one focus ring around their visual control.
 
 ## 0.3.21 — August 11, 2026

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,7 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
+## 0.3.22 — August 20, 2026
 
 ### Changed
 

--- a/docs/components/select-faceted.md
+++ b/docs/components/select-faceted.md
@@ -381,8 +381,10 @@ const recency: SelectFacetCustom<Recency> = {
  Receives a `SelectFacetedTriggerState`. Return exactly one focusable element:
  the menu is positioned relative to that element and opens when it is clicked.
  Add `aria-haspopup="menu"` and `aria-expanded={state.open}` to the returned
- element. `className`, `style`, and other trigger props apply only to the
- default Button, so add styling and attributes to the returned element. |
+ element, on a role that supports them (an Anta `Button` already carries
+ `role="button"`; otherwise add `role="combobox"`). `className`, `style`, and
+ other trigger props apply only to the default Button, so add styling and
+ attributes to the returned element. |
 | `searchable?` | boolean | — | Adds a search field at the top of the root menu. It searches the options of
  every `single` and `multiple` facet in one list. For example, "alice" can
  appear under application-defined Assignee and Owner facets. `text` and

--- a/docs/components/select.md
+++ b/docs/components/select.md
@@ -702,7 +702,9 @@ scannable list instead of hiding matches behind flyouts.
  one focusable element, such as an Anta `Button`. The menu is positioned
  relative to that element and opens when it is clicked. Do not return a
  fragment, multiple siblings, or a non-focusable wrapper. Add
- `aria-haspopup="menu"` and `aria-expanded={state.open}` to the element.
+ `aria-haspopup="menu"` and `aria-expanded={state.open}` to the element, on a
+ role that supports them (an Anta `Button` already carries `role="button"`;
+ otherwise add `role="combobox"`).
  Field props (`label`, `hint`, `size`, `status`, `placeholder`, and `round`) and
  `className` / `style` apply only to the default field. Add styling and
  attributes to the returned element instead. |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -424,10 +424,11 @@ export const SYSTEMS: System[] = [
     pros: [
       'A broad React Aria component set copied into your repo without a runtime dependency.',
       'Tailwind v4 styling and a synced Figma kit keep design and code aligned.',
-      'The MIT core covers base components; charts and toasts use Recharts and Sonner.',
+      'Charts use Recharts rather than native chart components.',
     ],
     cons: [
       'React-only, with React 19 and Tailwind CSS 4 required.',
+      'Tables render as regular HTML tables with horizontal scrolling, not virtualized data grids.',
       'Full-page examples, extra icon styles, and the Figma kit require paid tiers.',
       'You own consistency and upgrades across copied files.',
     ],
@@ -562,9 +563,9 @@ export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
   untitledui: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes',
     choice: 'yes', slider: 'yes', datetime: 'yes', tabs: 'yes', menu: 'yes',
-    tooltip: 'yes', dialog: 'yes', toast: 'yes', accordion: 'yes',
+    tooltip: 'yes', dialog: 'yes', toast: 'paid', accordion: 'paid',
     table: 'yes', tag: 'yes', progress: 'yes', avatar: 'yes', card: 'partial',
-    steps: 'yes', nav: 'yes', icons: 'yes', typography: 'yes', charts: 'yes',
+    steps: 'paid', nav: 'paid', icons: 'yes', typography: 'yes', charts: 'yes',
   },
   gravity: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'partial',

--- a/src/components/InputDate.tsx
+++ b/src/components/InputDate.tsx
@@ -284,6 +284,9 @@ export const InputDate = ({
         placeholder={pattern}
         inputMode={time ? 'text' : 'numeric'}
         autoComplete="off"
+        // `combobox` role keeps `aria-expanded` valid on the field (it isn't a global
+        // attr); it pops the calendar dialog — the APG date-picker-combobox pattern.
+        role="combobox"
         aria-haspopup="dialog"
         aria-expanded={open ? 'true' : 'false'}
         onInput={(e: any) => {

--- a/src/components/Select.tsx
+++ b/src/components/Select.tsx
@@ -277,7 +277,9 @@ export interface SelectCommonProps<V extends OptionValue = string> extends Omit<
    *  one focusable element, such as an Anta `Button`. The menu is positioned
    *  relative to that element and opens when it is clicked. Do not return a
    *  fragment, multiple siblings, or a non-focusable wrapper. Add
-   *  `aria-haspopup="menu"` and `aria-expanded={state.open}` to the element.
+   *  `aria-haspopup="menu"` and `aria-expanded={state.open}` to the element, on a
+   *  role that supports them (an Anta `Button` already carries `role="button"`;
+   *  otherwise add `role="combobox"`).
    *  Field props (`label`, `hint`, `size`, `status`, `placeholder`, and `round`) and
    *  `className` / `style` apply only to the default field. Add styling and
    *  attributes to the returned element instead. */
@@ -782,6 +784,10 @@ export const Select = <V extends OptionValue = string>(props: SelectProps<V>) =>
         status={status}
         statusIcon={statusIcon}
         round={round}
+        // `combobox` role keeps `aria-expanded` valid here (it isn't a global attr);
+        // `button` would make a-menu treat the trigger as self-activating and drop
+        // the keyboard-open this read-only field relies on.
+        role="combobox"
         aria-haspopup="menu"
         aria-expanded={open ? 'true' : 'false'}
         // <a-menu> handles Enter, Space, and ArrowDown on this read-only field by

--- a/src/components/SelectFaceted.tsx
+++ b/src/components/SelectFaceted.tsx
@@ -202,8 +202,10 @@ export interface SelectFacetedProps extends Omit<BaseProps, 'children'> {
    *  Receives a `SelectFacetedTriggerState`. Return exactly one focusable element:
    *  the menu is positioned relative to that element and opens when it is clicked.
    *  Add `aria-haspopup="menu"` and `aria-expanded={state.open}` to the returned
-   *  element. `className`, `style`, and other trigger props apply only to the
-   *  default Button, so add styling and attributes to the returned element. */
+   *  element, on a role that supports them (an Anta `Button` already carries
+   *  `role="button"`; otherwise add `role="combobox"`). `className`, `style`, and
+   *  other trigger props apply only to the default Button, so add styling and
+   *  attributes to the returned element. */
   renderTrigger?: (state: SelectFacetedTriggerState) => React.ReactNode
 }
 


### PR DESCRIPTION
## Summary

- Give the `Select` and `InputDate` triggers `role="combobox"` so their `aria-expanded` sits on an element whose role supports it. It was previously on the roleless `<a-input>` host, which fails WCAG 4.1.2 / axe `aria-allowed-attr` (`aria-expanded` is not a global ARIA attribute).
- `SelectFaceted`'s default trigger needed no change — it's a `Button`, which already carries `role="button"`. Its `renderTrigger` doc (and `Select`'s) now notes the role requirement for custom triggers.
- Prepare the **0.3.22** release: bump `package.json` and roll the `## Unreleased` changelog section to `## 0.3.22 — August 20, 2026` (bundles the already-merged menu/input changes from #153 plus this a11y fix).
- Minor docs: clarify Untitled UI comparison coverage (`comparison-data.ts`).

## Why

- `aria-expanded` is a supported-on-specific-roles state, not a global attribute. On a roleless custom-element host it's disallowed and functionally inert (the focused control is the shadow `<input>`).
- **`combobox` rather than `button`:** `a-menu` treats a `[role="button"]` trigger as self-activating and skips its keyboard-open binding, but a read-only `<a-input>` never fires a click on Enter — so `button` would silently drop Enter/Arrow-to-open. `combobox` keeps keyboard-open working. This matches `InputAutocomplete`.

## Validation

- `pnpm run typecheck`, `pnpm run lint`, `pnpm run build`
- Verified in Chrome with **axe-core 4.13**: the `aria-allowed-attr` finding is cleared, and keyboard-open (Enter / ArrowDown) still opens the menu with `role="combobox"` (a `button` role does not).

## Not included

- `aria-required-children` on `<a-menu role="menu">`: did not reproduce with axe-core 4.13 (checked open and closed on the main page), so no change was made.