### PR TITLE
docs: prepare 0.3.23 dev release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
-
-## 0.3.23 — August 23, 2026
+## 0.3.23-dev.0 — August 23, 2026
 
 ### Removed
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,9 +3,7 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
-## Unreleased
-
-## 0.3.23 — August 23, 2026
+## 0.3.23-dev.0 — August 23, 2026
 
 ### Removed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.23",
+  "version": "0.3.23-dev.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/site/src/changelog-summary.md
+++ b/site/src/changelog-summary.md
@@ -1,14 +1,3 @@
-## 0.3.23 — August 23, 2026
-
-- `Avatar` renders an image, generated placeholder, or initials, with
-  `generator`, `badge`, and `round` options.
-- `Steps` provides controlled and uncontrolled process navigation with panels,
-  states, markers, hints, tones, and horizontal or vertical layouts.
-- `Loader`, `Progress`, and the full `bundle` entry expand the package's
-  loading and import options.
-- Tabs and Steps can fill their available width, and Slider thumbs use smaller
-  defaults.
-
 ## 0.2.0 — June 9, 2026
 
 This stable release combines the final prereleases. See [Dev releases](/changelog/dev/)

--- a/site/src/components/ComparisonMatrix.astro
+++ b/site/src/components/ComparisonMatrix.astro
@@ -1,12 +1,12 @@
 ---
 // At-a-glance matrix for the /comparison page: one row per system, columns
 // for the facts that decide adoption (frameworks, styling, license). The
-// Anta row is highlighted. Full-bleed + horizontal scroll so the wide table
-// never forces the page body to scroll sideways.
+// Anta row is highlighted. Horizontal scrolling stays inside the matrix on
+// compact screens.
 import { SYSTEMS } from './comparison-data'
 ---
 
-<div class="full-bleed matrix-scroll">
+<div class="matrix-scroll">
   <table class="matrix">
     <thead>
       <tr>
@@ -65,7 +65,9 @@ import { SYSTEMS } from './comparison-data'
   .matrix {
     border-collapse: separate;
     border-spacing: 0;
-    width: 100%;
+    /* Keep the comparison readable without letting it consume all of the
+       available desktop track. The scroll container handles smaller viewports. */
+    width: 720px;
     min-width: 720px;
     font-size: 13px;
     line-height: 1.4;

--- a/site/src/components/CoverageMatrix.astro
+++ b/site/src/components/CoverageMatrix.astro
@@ -42,7 +42,7 @@ const ANTA_SLUG: Record<string, string> = {
   button: 'button', textinput: 'input', select: 'select', combobox: 'input-autocomplete',
   choice: 'checkbox', slider: 'slider',
   datetime: 'input-date', tabs: 'tabs', menu: 'menu', tooltip: 'tooltip',
-  dialog: 'dialog', toast: 'toaster', accordion: 'expander', table: 'table', tag: 'tag', card: 'card', progress: 'progress', steps: 'steps',
+  dialog: 'dialog', toast: 'toaster', accordion: 'expander', table: 'table', tag: 'tag', avatar: 'avatar', card: 'card', progress: 'progress', steps: 'steps',
   icons: 'icon', typography: 'text',
 }
 

--- a/site/src/components/comparison-data.ts
+++ b/site/src/components/comparison-data.ts
@@ -94,7 +94,7 @@ export const SYSTEMS: System[] = [
       'Per-element imports register only the component you use. Lottie lives in the separate stickers package.',
     ],
     cons: [
-      'Young and small: about 20 components, with no avatar yet.',
+      'Young and small: about 20 components.',
       'Table and plotting libraries are planned companion packages.',
       'A 0.x release from one organization has a shorter track record than established systems.',
     ],
@@ -474,7 +474,7 @@ export const COVERAGE: Record<string, Partial<Record<string, Mark>>> = {
   anta: {
     button: 'yes', textinput: 'yes', select: 'yes', combobox: 'yes', choice: 'yes', slider: 'yes',
     datetime: 'yes', tabs: 'yes', menu: 'yes', tooltip: 'yes', dialog: 'yes', toast: 'yes',
-    accordion: 'yes', table: 'partial', tag: 'yes', card: 'yes', progress: 'yes', steps: 'yes',
+    accordion: 'yes', table: 'partial', tag: 'yes', avatar: 'yes', card: 'yes', progress: 'yes', steps: 'yes',
     icons: 'yes', typography: 'yes',
   },
   webawesome: {


### PR DESCRIPTION
## Summary
- mark the package and detailed changelog entry as 0.3.23-dev.0
- keep the prerelease on the Dev releases page, not Main releases
- remove the empty Unreleased section
- keep the at-a-glance comparison matrix at its readable 720px width
- mark Avatar as included in Anta's component coverage and link its checkmark to the Avatar page

## Validation
- pnpm --filter anta-site lint:css
- cd site && ./node_modules/.bin/astro build
- npm pack --dry-run --ignore-scripts