### PR TITLE
Fix three review findings in Checkbox and Box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ changes are not listed.
 - `Box` removes its per-window store only when that store is the one still
   registered, so a page that mounts and unmounts boxes repeatedly keeps one
   document-wide class observer instead of accumulating them.
+- `Box` ships its TSDoc in `dist/components/Box.d.ts`, so editors show the
+  description and example on hover.
 
 ## 0.3.26 — September 4, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## 0.3.27 — September 4, 2026
+
+### Fixed
+
+- `Checkbox` sets its ARIA state and form value in Safari 16.4-17.3 and Firefox
+  93-125, where `ElementInternals` lacks `CustomStateSet`.
+
 ## 0.3.26 — September 4, 2026
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ changes are not listed.
 
 - `Checkbox` sets its ARIA state and form value in Safari 16.4-17.3 and Firefox
   93-125, where `ElementInternals` lacks `CustomStateSet`.
+- `Box` removes its per-window store only when that store is the one still
+  registered, so a page that mounts and unmounts boxes repeatedly keeps one
+  document-wide class observer instead of accumulating them.
 
 ## 0.3.26 — September 4, 2026
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,6 +12,8 @@ changes are not listed.
 - `Box` removes its per-window store only when that store is the one still
   registered, so a page that mounts and unmounts boxes repeatedly keeps one
   document-wide class observer instead of accumulating them.
+- `Box` ships its TSDoc in `dist/components/Box.d.ts`, so editors show the
+  description and example on hover.
 
 ## 0.3.26 — September 4, 2026
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,6 +3,13 @@
 This page tracks changes that ship in `@antadesign/anta`. Documentation-only
 changes are not listed.
 
+## 0.3.27 — September 4, 2026
+
+### Fixed
+
+- `Checkbox` sets its ARIA state and form value in Safari 16.4-17.3 and Firefox
+  93-125, where `ElementInternals` lacks `CustomStateSet`.
+
 ## 0.3.26 — September 4, 2026
 
 ### Added

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ changes are not listed.
 
 - `Checkbox` sets its ARIA state and form value in Safari 16.4-17.3 and Firefox
   93-125, where `ElementInternals` lacks `CustomStateSet`.
+- `Box` removes its per-window store only when that store is the one still
+  registered, so a page that mounts and unmounts boxes repeatedly keeps one
+  document-wide class observer instead of accumulating them.
 
 ## 0.3.26 — September 4, 2026
 

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -54,6 +54,20 @@ export interface BoxProps extends BaseProps {
   ) => void
 }
 
+/** Merges the `observe` prop with the halves the handlers imply. */
+function observeAttr(
+  observe: 'size' | 'context' | 'all' | undefined,
+  onMeasureChange: unknown,
+  onContextChange: unknown,
+): 'size' | 'context' | 'all' | undefined {
+  const size = observe === 'size' || observe === 'all' || onMeasureChange != null
+  const context = observe === 'context' || observe === 'all' || onContextChange != null
+  if (size && context) return 'all'
+  if (size) return 'size'
+  if (context) return 'context'
+  return undefined
+}
+
 /**
  * A light-DOM CSS box with browser-owned observation. `Box` is deliberately a
  * thin JSX projection: it never holds a DOM ref. The element measures itself,
@@ -69,20 +83,6 @@ export interface BoxProps extends BaseProps {
  * </Box>
  * ```
  */
-/** Merges the `observe` prop with the halves the handlers imply. */
-function observeAttr(
-  observe: 'size' | 'context' | 'all' | undefined,
-  onMeasureChange: unknown,
-  onContextChange: unknown,
-): 'size' | 'context' | 'all' | undefined {
-  const size = observe === 'size' || observe === 'all' || onMeasureChange != null
-  const context = observe === 'context' || observe === 'all' || onContextChange != null
-  if (size && context) return 'all'
-  if (size) return 'size'
-  if (context) return 'context'
-  return undefined
-}
-
 export const Box = ({
   display,
   round,

--- a/src/elements/a-box.ts
+++ b/src/elements/a-box.ts
@@ -172,8 +172,15 @@ class BoxWindowStore {
     this.#classObserver = undefined
   }
 
+  /* Only the store the map currently points at may remove that entry. A box
+     that was connected while its store went empty keeps a direct reference to
+     it, so an evicted store can be re-subscribed and later empty again — by
+     which time the map holds a live store with its own document observer.
+     Deleting blind would drop that live store and leave its observer running
+     while the next connect built a second one. */
   #collect() {
-    if (this.#contextBoxes.size === 0 && this.#observedBoxes.size === 0) stores.delete(this.view)
+    if (this.#contextBoxes.size > 0 || this.#observedBoxes.size > 0) return
+    if (stores.get(this.view) === this) stores.delete(this.view)
   }
 
   /* Only `dark` and `light` change what a box reports. Every other class toggle

--- a/src/elements/a-checkbox.ts
+++ b/src/elements/a-checkbox.ts
@@ -155,10 +155,13 @@ export class ACheckboxElement extends HTMLElementBase {
   private paint() {
     const i = this.internals;
     if (!i) return;
-    i.states.delete("checked");
-    i.states.delete("indeterminate");
-    if (this.currentState === "indeterminate") i.states.add("indeterminate");
-    else if (this.currentState === "checked") i.states.add("checked");
+    // `?.` on `states` guards engines with ElementInternals but no CustomStateSet
+    // (`.states` undefined), where a throw here would abort paint() — and, on the
+    // first connect, the rest of connectedCallback with it.
+    i.states?.delete("checked");
+    i.states?.delete("indeterminate");
+    if (this.currentState === "indeterminate") i.states?.add("indeterminate");
+    else if (this.currentState === "checked") i.states?.add("checked");
     // Publish aria-checked off-DOM via ElementInternals (like a-radio), so it stays
     // live as the element self-toggles in *uncontrolled* mode — a wrapper-set
     // aria-checked would go stale there (it only re-renders for controlled changes).


### PR DESCRIPTION
Three findings from the review of the merged Box work. One commit each.

## Guard the Checkbox custom-state writes

`a-checkbox.ts` was missed by the 0.3.26 `CustomStateSet` sweep. `paint()` read `i.states.delete` directly, so Safari 16.4-17.3 and Firefox 93-125, which ship `ElementInternals` with `states` undefined, threw on the first property access.

`paint()` runs from `connectedCallback`, so the throw skipped everything after it: `aria-checked` was never published, the form value was never set, and `alive` stayed false, which left the element silent on every later controlled `state` change.

Four `?.` match `a-banner`, `a-switch` and `a-box`. The checkmark still does not paint on those engines, because `a-checkbox.css` keys off `:state()` and that selector is missing there too. Screen readers and form submission work now.

## Evict the Box window store only when it is the registered one

`BoxWindowStore#collect()` ran `stores.delete(this.view)` as soon as both refcount sets emptied, without asking whether the map still pointed at itself. A box holds its store in `#store` from connect to disconnect, so a store can outlive its map entry and come back:

1. `A` connects without `observe`, never subscribes, keeps store `S`.
2. `B` connects, subscribes; `S` starts the document class observer.
3. `B` leaves. `S` empties, stops its observer, removes itself from the map. `A` still holds it.
4. `C` connects. A second store `S2` is built and starts a second observer.
5. `A` gains `observe` and subscribes to the orphaned `S`, which starts a third observer.
6. `A` leaves. `S` empties again and deletes the map entry, which is now `S2`. `S2` keeps running its observer for `C`, unreachable through the map.
7. The next connect builds another store. Each cycle adds a document-wide, subtree-wide `MutationObserver` that nothing disconnects.

The identity check breaks step 6. An orphan can still start one extra observer while it holds subscribers, which is bounded and tears itself down.

## Reattach the Box TSDoc to the Box export

`observeAttr` sat between Box's docstring and `export const Box`, so the comment documented the helper. `dist/components/Box.d.ts` emitted no comment above `export declare const Box`, and `site/src/api.json` carried no signature comment for `Box`, unlike `Card`, `Text` and `Avatar`. Moving the helper above the docstring restores adjacency; both outputs now carry the description and the example.

## Verification

- `pnpm run lint`, `pnpm run typecheck`, `pnpm run build` pass.
- Stickers build and site CSS lint pass.
- Production site build passes: 41 pages.
- Confirmed `dist/components/Box.d.ts` and `site/src/api.json` now carry the Box comment.

Changelog entries land under a `0.3.27` heading for the release commit to stamp.
