### PR TITLE
release: bump anta to 0.3.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antadesign/anta",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Bump `@antadesign/anta` from `0.3.26` to `0.3.27` to match the release notes already on `main` for Capture and the package fixes.

Validation: `pnpm run build`, `pnpm run lint`, and `git diff --check` passed. Confirmed the package version matches both `CHANGELOG.md` and the published `docs/changelog.md`.
