### PR TITLE
Introduction of Plot into Anta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         run: pnpm --filter @antadesign/stickers run build
       - name: Typecheck stickers
         run: pnpm --filter @antadesign/stickers run typecheck
+      - name: Build plot
+        run: pnpm --filter @antadesign/plot run build
+      - name: Typecheck plot
+        run: pnpm --filter @antadesign/plot run typecheck
+      - name: Verify plot package
+        run: pnpm --filter @antadesign/plot run check:package
       - name: Lint site CSS
         run: pnpm --filter anta-site run lint:css
       - name: Typecheck search worker

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,11 @@
 
 Anta is a portable UI component library, published as `@antadesign/anta`. It works in React, Preact through `preact/compat`, and custom JSX runtimes through `configure()`.
 
-This pnpm workspace contains two publishable packages and one private site:
+This pnpm workspace contains three publishable packages and one private site:
 
 - `@antadesign/anta` — the root package; its source is in `src/`.
 - `@antadesign/stickers` — a separate sticker package in `stickers/`, keeping `lottie-web` out of anta's dependency graph.
+- `@antadesign/plot` — the separate canvas plot package in `plot/`.
 - `site/` — the documentation site; it is not published to npm.
 
 ## Task routing
@@ -15,6 +16,7 @@ Read the closest guidance before changing a scoped area:
 - `src/AGENTS.md` — Anta component architecture, web-component and JSX-wrapper conventions, CSS rules, and component additions.
 - `site/AGENTS.md` — Astro site, interactive playground, client-router, and documentation-page conventions.
 - `stickers/AGENTS.md` — sticker package layout, generation, and publishing details. Read `src/AGENTS.md` as well before changing its elements or wrappers.
+- `plot/AGENTS.md` — plot entry points, build, and package verification.
 - `RELEASING.md` — mandatory publish order and package-manager commands.
 - `FIGMA.md`, `WRITING.md`, and `DESIGN.md` — Figma extraction, prose, and design guidance respectively.
 
@@ -65,4 +67,4 @@ Ask: would an npm consumer see this change? If not, keep the narrative in the co
 
 ## Publishing
 
-Before publishing either package, read and follow [`RELEASING.md`](RELEASING.md). The order and use of `npm` versus `pnpm` are mandatory.
+Before publishing any package, read and follow [`RELEASING.md`](RELEASING.md). The order and use of `npm` versus `pnpm` are mandatory.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,8 +1,8 @@
 # Releasing Anta packages
 
-Two packages publish from this repository: `@antadesign/anta` at the root and `@antadesign/stickers` in `stickers/`. Both are prereleases under npm's `dev` dist-tag. Version strings are immutable, so always bump before publishing.
+Three packages publish from this repository: `@antadesign/anta` at the root `@antadesign/stickers` in `stickers/`, and `@antadesign/plot` in `plot/`. All are prereleases under npm's `dev` dist-tag. Version strings are immutable, so always bump before publishing.
 
-Publish anta first, then stickers. Stickers depends on anta through `workspace:*`; pnpm writes anta's exact current version into the packed sticker dependency, so that version must already exist on npm and include every subpath stickers imports.
+Publish anta first, then the companion packages being released. Stickers and plot depend on anta through `workspace:*`; pnpm writes anta's exact current version into the packed dependency, so that version must already exist on npm and include every subpath the companion package imports.
 
 ```sh
 # 1. Publish anta from the repository root
@@ -12,10 +12,14 @@ npm publish --access public --tag dev
 # 2. Publish stickers from stickers/
 cd stickers
 pnpm publish --no-git-checks
+
+# 3. Publish plot from plot/
+cd ../plot
+pnpm publish --no-git-checks
 ```
 
-- Use `pnpm publish` for stickers, never `npm publish`: pnpm rewrites the `workspace:*` dependency to a real version.
-- `stickers/package.json` supplies `publishConfig.access` and `publishConfig.tag`; anta passes them explicitly.
-- `prepublishOnly` for anta and `prepare` for both packages rebuild `dist` before packing.
+- Use `pnpm publish` for stickers and plot, never `npm publish`: pnpm rewrites the `workspace:*` dependency to a real version.
+- `stickers/package.json` and `plot/package.json` supply `publishConfig.access` and `publishConfig.tag`; anta passes them explicitly.
+- `prepublishOnly` for anta and `prepare` for all packages rebuild `dist` before packing.
 - A manual version-field bump skips the version command's Git commit and tag; tag separately if the release requires one.
 - Append `--otp=<code>` when npm 2FA requires it.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "build:types": "tsc -p src/tsconfig.json",
     "build:docs": "pnpm --filter anta-site run docs:api && pnpm --filter anta-site run docs:pages && node scripts/generate-package-docs.mjs",
     "dev": "node scripts/dev.mjs",
-    "dev:run": "echo $$ > \"$ANTA_DEV_PID_FILE\"; trap 'rm -f \"$ANTA_DEV_PID_FILE\"' EXIT; pnpm run build:dev && pnpm --filter @antadesign/stickers run build:dev && pnpm --filter anta-site run docs && (node scripts/dev-watch.mjs & pnpm --filter anta-site run dev:server & pnpm --filter anta-site run dev:search & wait)",
+    "dev:run": "echo $$ > \"$ANTA_DEV_PID_FILE\"; trap 'rm -f \"$ANTA_DEV_PID_FILE\"' EXIT; pnpm run build:dev && pnpm --filter @antadesign/stickers run build:dev && pnpm --filter @antadesign/plot run build:dev && pnpm --filter anta-site run docs && (node scripts/dev-watch.mjs & pnpm --filter anta-site run dev:server & pnpm --filter anta-site run dev:search & wait)",
     "stop": "node scripts/dev-stop.mjs",
     "typecheck": "tsc --noEmit -p src/tsconfig.json",
     "test": "node --test tests/*.test.mjs",

--- a/plot/.gitignore
+++ b/plot/.gitignore
@@ -1,0 +1,3 @@
+/dist/
+/node_modules/
+/.build/

--- a/plot/AGENTS.md
+++ b/plot/AGENTS.md
@@ -1,0 +1,14 @@
+# @antadesign/plot
+
+Follow the root AGENTS.md. This package owns plotting code, not the notebook adapter.
+
+- `src/core/` contains series factories, composition, rendering, interactions, and presentation.
+- `src/integrations/` connects host events to the core controllers.
+- `src/browser/` implements the optional light-DOM `<a-plot>` host. Preserve its established behavior during packaging; React/Preact wrappers are deferred.
+- `src/entries/` defines the supported package exports. Keep internal imports private.
+- `scripts/build.mjs` emits JS, declarations, and CSS. Anta stays external to avoid duplicate component implementations.
+- `scripts/verify-package.mjs` checks the built package from an isolated consumer directory.
+
+Anta is a `workspace:*` dependency, matching stickers. React is a peer. Never add Star imports, notebook demos, notebook type shims, or notebook build aliases here.
+
+Build Anta before plot. Run plot's build, typecheck, and check:package scripts after changes. Read ../RELEASING.md before publishing; use pnpm so workspace dependencies are rewritten. Keep plot release notes in this package, not the root Anta changelog.

--- a/plot/README.md
+++ b/plot/README.md
@@ -1,0 +1,47 @@
+# @antadesign/plot
+
+Canvas plots with series factories, shared interaction controllers, host integration helpers, and an optional `<a-plot>` browser host. React and Preact wrappers are deferred. Anta is a regular dependency; React is a peer, as it is for stickers.
+
+```ts
+import { scatter, definePlotElement, type APlotElement } from '@antadesign/plot/browser'
+import '@antadesign/plot/plot.css'
+
+await definePlotElement()
+const plot = document.createElement('a-plot') as APlotElement
+plot.plotArgs = { series: [scatter({ data: [{ x: 1, y: 2 }, { x: 2, y: 3 }] })] }
+document.body.append(plot)
+```
+
+Use a bundler that handles CSS imports. The browser entry loads Anta elements and their styles through the Anta dependency. `plot.css` supplies the plot layout. Applications supply their Anta theme as usual.
+
+## Entry points
+
+| Import | Contents |
+| --- | --- |
+| `@antadesign/plot` | Seven series factories, controllers, and public types |
+| `@antadesign/plot/host` | Canvas, highlight, tooltip, and reset-button presentation helpers |
+| `@antadesign/plot/anta` | Box and Capture event integration |
+| `@antadesign/plot/browser` | DOM tooltip factories and explicit `definePlotElement()` registration |
+| `@antadesign/plot/auto` | Browser registration with the `plotElementReady` promise |
+| `@antadesign/plot/plot.css` | Plot layout stylesheet |
+
+The root, host, and Anta integration entries do not load Anta or React at runtime. Browser registration loads Anta elements lazily. Imports are safe during server rendering; call `definePlotElement()` only in a browser.
+
+## Build and verify
+
+From the repository root, after installing workspace dependencies:
+
+```sh
+pnpm run build:dev
+pnpm --filter @antadesign/plot run build
+pnpm --filter @antadesign/plot run typecheck
+pnpm --filter @antadesign/plot run check:package
+```
+
+The plot build emits ESM, declarations, and CSS into `dist/`. Internal plot code and its data dependencies are bundled into shared chunks. Anta and React remain external. Ship the entire `dist/` directory, including chunks. Declarations use explicit ESM paths for NodeNext consumers.
+
+`check:package` copies the built package into a temporary consumer directory and checks all seven factories, composition, interaction integration, server imports, exports, and Bundler/NodeNext declarations. It checks core declarations fully; third-party Anta declarations use `skipLibCheck`.
+
+`prepare` and `prepublishOnly` rebuild the package. `dist/` and build metadata are ignored. Follow [the release instructions](../RELEASING.md) to publish with pnpm, which rewrites `workspace:*` to the current Anta version.
+
+The notebook adapter remains in Star. Until Star adopts a published version, its migration source remains the active implementation; keep any intervening fixes synchronized.

--- a/plot/package.json
+++ b/plot/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@antadesign/plot",
+  "version": "0.1.0-dev.0",
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/types/entries/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./host": {
+      "types": "./dist/types/entries/host.d.ts",
+      "import": "./dist/host.js"
+    },
+    "./anta": {
+      "types": "./dist/types/entries/anta.d.ts",
+      "import": "./dist/anta.js"
+    },
+    "./browser": {
+      "types": "./dist/types/entries/browser.d.ts",
+      "import": "./dist/browser.js"
+    },
+    "./auto": {
+      "types": "./dist/types/entries/auto.d.ts",
+      "import": "./dist/auto.js"
+    },
+    "./plot.css": "./dist/plot.css"
+  },
+  "sideEffects": [
+    "./dist/auto.js",
+    "./dist/*.css",
+    "./dist/chunks/*.js"
+  ],
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "build:dev": "pnpm run build",
+    "typecheck": "tsc --noEmit --emitDeclarationOnly false -p tsconfig.build.json",
+    "check:package": "node scripts/verify-package.mjs",
+    "prepare": "pnpm run build",
+    "prepublishOnly": "pnpm run build"
+  },
+  "dependencies": {
+    "d3-scale": "3.2.3",
+    "chroma-js": "2.4.2",
+    "lodash": "4.18.1",
+    "@types/d3-scale": "4.0.3",
+    "@antadesign/anta": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/lodash": "4.17.25",
+    "@types/chroma-js": "2.1.4",
+    "typescript": "^5.7.0",
+    "esbuild": "^0.25.0"
+  },
+  "packageManager": "pnpm@10.11.1",
+  "main": "dist/index.js",
+  "types": "dist/types/entries/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "tag": "dev"
+  }
+}

--- a/plot/scripts/build.mjs
+++ b/plot/scripts/build.mjs
@@ -1,0 +1,83 @@
+import { build } from 'esbuild'
+import ts from 'typescript'
+import { readFile, writeFile, readdir, mkdir, rm, copyFile } from 'node:fs/promises'
+import { dirname, resolve, relative, extname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const output = resolve(root, 'dist')
+const config_path = resolve(root, 'tsconfig.build.json')
+const config = ts.readConfigFile(config_path, ts.sys.readFile)
+const parsed = ts.parseJsonConfigFileContent(config.config, ts.sys, root)
+const program = ts.createProgram(parsed.fileNames, parsed.options)
+const diagnostics = [...(config.error ? [config.error] : []), ...parsed.errors, ...ts.getPreEmitDiagnostics(program)]
+if (diagnostics.length > 0) {
+    throw new Error(ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+        getCanonicalFileName: name => name,
+        getCurrentDirectory: () => root,
+        getNewLine: () => '\n',
+    }))
+}
+
+// Only generated files below this package's dist directory are replaced.
+await rm(output, { recursive: true, force: true })
+await mkdir(output, { recursive: true })
+const emitted = program.emit()
+if (emitted.emitSkipped || emitted.diagnostics.length > 0) {
+    throw new Error('Plot declaration emission failed')
+}
+
+// Declarations retain their module layout, with explicit ESM paths for NodeNext consumers.
+async function declarations(directory) {
+    for (const item of await readdir(directory, { withFileTypes: true })) {
+        const path = resolve(directory, item.name)
+        if (item.isDirectory()) {
+            await declarations(path)
+        } else if (path.endsWith('.d.ts')) {
+            // CSS is a separate public asset, not a declaration dependency.
+            const source = (await readFile(path, 'utf8')).replace(/^import ['"][^'"]+\.css['"];?\n/gm, '')
+            const updated = source.replace(/(['"])(\.\.?\/[^'"]+)\1/g, (match, quote, specifier) => {
+                if (extname(specifier)) return match
+                const target = resolve(directory, specifier)
+                const suffix = ts.sys.fileExists(`${target}.d.ts`) ? '.js' : '/index.js'
+                if (!ts.sys.fileExists(suffix === '.js' ? `${target}.d.ts` : `${target}/index.d.ts`)) {
+                    throw new Error(`Unresolved declaration import: ${path}: ${specifier}`)
+                }
+                return `${quote}${specifier}${suffix}${quote}`
+            })
+            await writeFile(path, updated)
+        }
+    }
+}
+await declarations(resolve(output, 'types'))
+
+const result = await build({
+    absWorkingDir: root,
+    entryPoints: Object.fromEntries(['index', 'host', 'anta', 'browser', 'auto'].map(name => [name, `src/entries/${name}.ts`])),
+    outdir: output,
+    bundle: true,
+    splitting: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2022',
+    minifyWhitespace: true,
+    legalComments: 'external',
+    tsconfig: config_path,
+    external: ['@antadesign/anta', '@antadesign/anta/*', 'react', 'react/*', 'react-dom', 'react-dom/*'],
+    chunkNames: 'chunks/[name]-[hash]',
+    metafile: true,
+    logLevel: 'warning',
+})
+
+// The browser and auto entries have the same stylesheet closure; ship one public stylesheet.
+const browser_css = result.metafile.outputs['dist/browser.js'].cssBundle
+const auto_css = result.metafile.outputs['dist/auto.js'].cssBundle
+if (!browser_css || !auto_css) throw new Error('Missing browser styles')
+const css = await readFile(resolve(root, browser_css), 'utf8')
+if (css !== await readFile(resolve(root, auto_css), 'utf8')) {
+    throw new Error('Browser and auto entry styles differ; choose an explicit shared stylesheet')
+}
+await copyFile(resolve(root, browser_css), resolve(output, 'plot.css'))
+await mkdir(resolve(root, '.build'), { recursive: true })
+await writeFile(resolve(root, '.build/metafile.json'), JSON.stringify(result.metafile, null, 2) + '\n')
+console.log(`Built ${relative(process.cwd(), output)} (ESM, declarations, and plot.css)`)

--- a/plot/scripts/verify-package.mjs
+++ b/plot/scripts/verify-package.mjs
@@ -1,0 +1,178 @@
+import assert from 'node:assert/strict'
+import { cp, mkdir, mkdtemp, readFile, writeFile, rm, readdir, chmod, realpath } from 'node:fs/promises'
+import { basename, dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+import { createRequire } from 'node:module'
+import { execFileSync } from 'node:child_process'
+import ts from 'typescript'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const require = createRequire(import.meta.url)
+const manifest = JSON.parse(await readFile(resolve(root, 'package.json'), 'utf8'))
+const metadata = JSON.parse(await readFile(resolve(root, '.build/metafile.json'), 'utf8'))
+
+// Follow emitted imports, including lazy chunks, to verify each entry's actual runtime boundary.
+function inputs(entry, visited = new Set()) {
+    if (visited.has(entry)) return []
+    visited.add(entry)
+    const output = metadata.outputs[entry]
+    assert.ok(output, `Missing output ${entry}`)
+    const result = Object.keys(output.inputs)
+    for (const imported of output.imports) {
+        if (imported.external) {
+            assert.match(imported.path, /^(?:react(?:-dom)?(?:\/|$)|@antadesign\/anta(?:\/|$))/, `Unexpected external: ${imported.path}`)
+            result.push(imported.path)
+        } else {
+            result.push(...inputs(imported.path, visited))
+        }
+    }
+    return result
+}
+for (const entry of ['index', 'host', 'anta']) {
+    for (const input of inputs(`dist/${entry}.js`)) {
+        assert.doesNotMatch(input, /(?:@antadesign|(?:^|\/)react(?:\/|$)|preact|notebook_demo|shell\/)/)
+    }
+}
+for (const input of Object.keys(metadata.inputs)) {
+    assert.doesNotMatch(input, /notebook_demo|(?:^|\/)shell\/|(?:^|\/)deps\/preact/)
+    assert.ok(/^src\/(entries|core|integrations|browser)\//.test(input) || input.includes('/node_modules/'),
+        `Unexpected source outside the package: ${input}`)
+}
+inputs('dist/browser.js') // Browser dependencies may retain the declared React peer.
+
+
+const sandbox = await mkdtemp(resolve(tmpdir(), 'plot-package-'))
+try {
+    const installed = resolve(sandbox, 'node_modules/@antadesign/plot')
+    await mkdir(installed, { recursive: true })
+    await cp(resolve(root, 'dist'), resolve(installed, 'dist'), { recursive: true })
+    await writeFile(resolve(installed, 'package.json'), JSON.stringify(manifest))
+    await writeFile(resolve(sandbox, 'package.json'), '{"type":"module"}')
+
+    // Runtime imports deliberately have no source checkout, aliases, React, Anta or lodash to fall back to.
+    const runtime = `
+        import assert from 'node:assert/strict'
+        import { readFile } from 'node:fs/promises'
+        import * as plot from '@antadesign/plot'
+        import * as host from '@antadesign/plot/host'
+        import { create_anta_host } from '@antadesign/plot/anta'
+        import { definePlotElement } from '@antadesign/plot/browser'
+        import { plotElementReady } from '@antadesign/plot/auto'
+        await plotElementReady
+        await assert.rejects(definePlotElement(), /browser custom-element registry/)
+        const rows = [{x:1,y:2},{x:2,y:4},{x:3,y:3}]
+        for (const kind of ['scatter','bar','rect','line','rule','area','custom']) {
+            const args = kind === 'bar' ? {data:[{x:'a',y:2},{x:'b',y:4}]} :
+                kind === 'rule' ? {x:2} : kind === 'custom' ? {data:rows,renderer(){}} :
+                kind === 'rect' ? {data:rows,size:8} : {data:rows}
+            const controller = new plot.PlotController({series:[plot[kind](args)]})
+            const composed = controller.compose({width:600,height:300,color_theme:'light',device_pixel_ratio:1})
+            assert.ok(composed)
+            const adapter = create_anta_host({controller,on_measure(){},on_context(){},on_viewport(){},
+                on_viewport_report(){},on_hover(){},on_pointer_change(){}})
+            assert.ok(adapter.capture_props(composed, controller.interactions.committed_viewport))
+            adapter.disconnect()
+        }
+        assert.deepEqual(host.resolve_canvas_size({}, {width:200.5,height:100.5}), {width:200,height:100})
+        const controller = new plot.PlotController({series:[plot.scatter({data:rows})]})
+        controller.compose({width:600,height:300,color_theme:'light',device_pixel_ratio:1})
+        assert.equal(controller.interactions.handle_wheel({offsetX:200,offsetY:100,deltaY:-100,ctrlKey:true},controller.template.zoom_pan),true)
+        assert.notEqual(controller.interactions.staged_viewport.x,null)
+        await assert.rejects(import('@antadesign/plot/core/controller'), {code:'ERR_PACKAGE_PATH_NOT_EXPORTED'})
+        const css = await readFile(new URL(import.meta.resolve('@antadesign/plot/plot.css')), 'utf8')
+        for (const selector of ['.plot-root','a-capture']) assert.ok(css.includes(selector),selector)
+    `
+    await writeFile(resolve(sandbox, 'runtime.mjs'), runtime)
+    execFileSync(process.execPath, ['runtime.mjs'], { cwd: sandbox, stdio: 'inherit', env: { ...process.env, NODE_PATH: '' } })
+
+    // Copy only the declaration dependency closure; do not symlink the workspace node_modules tree.
+    async function writable_directories(directory) {
+        await chmod(directory, 0o755)
+        for (const item of await readdir(directory, { withFileTypes: true })) {
+            if (item.isDirectory()) await writable_directories(resolve(directory, item.name))
+        }
+    }
+    const copied = new Set()
+    async function copy_dependency(name, resolver = require) {
+        if (copied.has(name)) return
+        copied.add(name)
+        let package_path
+        for (const directory of resolver.resolve.paths(name) ?? []) {
+            const candidate = resolve(directory, name, 'package.json')
+            if (ts.sys.fileExists(candidate)) { package_path = candidate; break }
+        }
+        assert.ok(package_path, `Install declaration dependency: ${name}`)
+        // pnpm stores transitive dependencies beside the real package, not its workspace symlink.
+        package_path = await realpath(package_path)
+        const info = JSON.parse(await readFile(package_path, 'utf8'))
+        const destination = resolve(sandbox, 'node_modules', name)
+        if (name === '@antadesign/anta') {
+            // The workspace link points at the repository root; copy only its built package.
+            await mkdir(destination, { recursive: true })
+            await cp(package_path, resolve(destination, 'package.json'))
+            await cp(resolve(dirname(package_path), 'dist'), resolve(destination, 'dist'), {
+                recursive: true, dereference: true,
+            })
+        } else {
+            await cp(dirname(package_path), destination, {
+                recursive: true, dereference: true,
+                filter: path => !['node_modules', '.git'].includes(basename(path)),
+            })
+        }
+        await writable_directories(destination)
+        const child_resolver = createRequire(package_path)
+        for (const dependency of Object.keys(info.dependencies ?? {})) {
+            await copy_dependency(dependency, child_resolver)
+        }
+    }
+    for (const name of ['@types/d3-scale', '@antadesign/anta', '@types/react']) await copy_dependency(name)
+    const core_consumer = resolve(sandbox, 'core-consumer.ts')
+    await writeFile(core_consumer, `
+        import { scatter, PlotController, type PlotArgs } from '@antadesign/plot'
+        import { prepare_canvas_context } from '@antadesign/plot/host'
+        const args: PlotArgs<string> = {series:[scatter<string>({data:[{x:1,y:2}],tooltip:()=> 'text'})]}
+        const controller = new PlotController(args)
+    `)
+    const core_program = ts.createProgram([core_consumer], {
+        target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.NodeNext,
+        moduleResolution: ts.ModuleResolutionKind.NodeNext, strict: true, noEmit: true,
+        skipLibCheck: false, types: [],
+        lib: ['lib.es2022.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+    })
+    assert.equal(ts.getPreEmitDiagnostics(core_program).length, 0, 'Core declarations must pass full checking')
+    const consumer = `
+        import { scatter, PlotController, type PlotArgs, type CustomRendererFn } from '@antadesign/plot'
+        import { resolve_canvas_size, prepare_canvas_context, render_tooltip_body } from '@antadesign/plot/host'
+        import { create_anta_host, type AntaHostAdapter } from '@antadesign/plot/anta'
+        import { definePlotElement, type APlotElement } from '@antadesign/plot/browser'
+        import { plotElementReady } from '@antadesign/plot/auto'
+        const args: PlotArgs<string> = {series:[scatter<string>({data:[{x:1,y:2}],tooltip:()=> 'text'})]}
+        const controller = new PlotController(args)
+        const adapter: AntaHostAdapter<string> = create_anta_host({controller,on_measure(){},on_context(){},
+            on_viewport(){},on_viewport_report(){},on_hover(){},on_pointer_change(){}})
+        adapter.disconnect()
+        // @ts-expect-error Tooltip content must match the declared host content type.
+        const invalid: PlotArgs<string> = {series:[scatter<number>({data:[],tooltip:()=> 1})]}
+    `
+    await writeFile(resolve(sandbox, 'consumer.ts'), consumer)
+    for (const resolution of [ts.ModuleResolutionKind.Bundler, ts.ModuleResolutionKind.NodeNext]) {
+        const program = ts.createProgram([resolve(sandbox, 'consumer.ts')], {
+            target: ts.ScriptTarget.ES2022,
+            module: resolution === ts.ModuleResolutionKind.NodeNext ? ts.ModuleKind.NodeNext : ts.ModuleKind.ESNext,
+            moduleResolution: resolution,
+            strict: true,
+            noEmit: true,
+            skipLibCheck: true,
+            types: [],
+            lib: ['lib.es2022.d.ts', 'lib.dom.d.ts', 'lib.dom.iterable.d.ts'],
+        })
+        const diagnostics = ts.getPreEmitDiagnostics(program)
+        assert.equal(diagnostics.length, 0, ts.formatDiagnosticsWithColorAndContext(diagnostics, {
+            getCanonicalFileName: name => name, getCurrentDirectory: () => sandbox, getNewLine: () => '\n',
+        }))
+    }
+    console.log('PASS: isolated ESM exports, seven factories, composition, interactions, SSR imports, CSS, private paths and Bundler/NodeNext consumer types')
+} finally {
+    await rm(sandbox, { recursive: true, force: true })
+}

--- a/plot/src/browser/auto.ts
+++ b/plot/src/browser/auto.ts
@@ -1,0 +1,6 @@
+import { definePlotElement } from './index'
+
+/** Await registration in a browser; importing this entry without a registry is a no-op. */
+export const plotElementReady = typeof customElements === 'undefined'
+    ? Promise.resolve()
+    : definePlotElement()

--- a/plot/src/browser/browser_view.ts
+++ b/plot/src/browser/browser_view.ts
@@ -1,0 +1,150 @@
+import { TOOLTIP_OPTIONS } from '../core/presentation/tooltip'
+import { RESET_ZOOM_BUTTON } from '../core/presentation/reset_zoom'
+import { prepare_canvas_context } from '../core/render/canvas'
+import type { ATooltipElement } from '@antadesign/anta/elements/a-tooltip'
+import type { CaptureConfiguration } from '../core/interactions/zoom_pan'
+import type { ABoxElement } from '@antadesign/anta/elements/a-box'
+
+export type BrowserView = {
+    root: HTMLDivElement
+    box: ABoxElement
+    canvas: HTMLCanvasElement
+    capture: HTMLElement
+    highlight: HTMLCanvasElement
+    tooltip: ATooltipElement
+    reset: HTMLElement
+}
+
+// Create the light-DOM surfaces; Box and Capture must already be registered in this document.
+export function create_browser_view(doc: Document): BrowserView {
+    const root = doc.createElement('div')
+    root.className = 'plot-root'
+
+    const box = doc.createElement('a-box') as ABoxElement
+    box.setAttribute('observe', 'all')
+
+    const canvas = doc.createElement('canvas')
+    canvas.className = 'plot-canvas'
+
+    const capture = doc.createElement('a-capture')
+    capture.className = 'plot-capture'
+
+    const highlight = doc.createElement('canvas')
+    highlight.className = 'plot-highlight'
+
+    const tooltip = doc.createElement('a-tooltip') as ATooltipElement
+    tooltip.className = 'plot-tooltip'
+    if (TOOLTIP_OPTIONS.follow) {
+        tooltip.setAttribute('follow', '')
+    }
+    tooltip.setAttribute('delay', String(TOOLTIP_OPTIONS.delay))
+
+    const reset = doc.createElement('a-button')
+    reset.className = 'plot-reset'
+    reset.setAttribute('type', 'button')
+    reset.setAttribute('role', 'button')
+    reset.setAttribute('priority', RESET_ZOOM_BUTTON.priority)
+    reset.setAttribute('size', RESET_ZOOM_BUTTON.size)
+    reset.tabIndex = 0
+
+    const label = doc.createElement('a-button-label')
+    label.textContent = RESET_ZOOM_BUTTON.label
+
+    const icon = doc.createElement('a-icon')
+    icon.setAttribute('shape', RESET_ZOOM_BUTTON.iconTrailing)
+    icon.setAttribute('aria-hidden', 'true')
+    reset.append(label, icon)
+    reset.hidden = true
+
+    capture.append(tooltip)
+    root.append(box, canvas, highlight, capture, reset)
+
+    return { root, box, canvas, capture, highlight, tooltip, reset }
+}
+
+type SavedDimension = { value: string; priority: string }
+type HostDimensions = { width?: number; height?: number }
+
+// Keep the caller's inline sizing while explicit plot dimensions temporarily override it.
+const unpinned_dimensions = new WeakMap<HTMLElement, Partial<Record<'width' | 'height', SavedDimension>>>()
+
+// Pin each host dimension independently, restoring its previous CSS when that pin is removed.
+export function size_host(host: HTMLElement, dimensions: HostDimensions): void {
+    const saved = unpinned_dimensions.get(host) ?? {}
+
+    for (const axis of ['width', 'height'] as const) {
+        const size = dimensions[axis]
+
+        if (size !== undefined) {
+            saved[axis] ??= {
+                value: host.style.getPropertyValue(axis),
+                priority: host.style.getPropertyPriority(axis),
+            }
+            host.style.setProperty(axis, `${size}px`, saved[axis].priority)
+        } else if (saved[axis] !== undefined) {
+            const original = saved[axis]
+
+            if (original.value === '') {
+                host.style.removeProperty(axis)
+            } else {
+                host.style.setProperty(axis, original.value, original.priority)
+            }
+            delete saved[axis]
+        }
+    }
+
+    if (saved.width === undefined && saved.height === undefined) {
+        unpinned_dimensions.delete(host)
+    } else {
+        unpinned_dimensions.set(host, saved)
+    }
+}
+
+// Context options are fixed by the first lookup, including lookups made just to clear a canvas.
+export function get_canvas_context(canvas: HTMLCanvasElement): CanvasRenderingContext2D | null {
+    return canvas.getContext('2d', { desynchronized: true, colorSpace: 'display-p3' })
+}
+
+// Size the backing store for DPR and keep drawing coordinates in CSS pixels.
+export function prepare_canvas(
+    canvas: HTMLCanvasElement,
+    width: number,
+    height: number,
+    dpr: number,
+): CanvasRenderingContext2D {
+    canvas.style.width = `${width}px`
+    canvas.style.height = `${height}px`
+
+    const ctx = get_canvas_context(canvas)
+
+    if (ctx === null) {
+        throw new Error('plot: unable to get a 2D canvas context')
+    }
+
+    prepare_canvas_context(ctx, width, height, dpr)
+    return ctx
+}
+
+// Apply resolved gesture settings without rewriting unchanged attributes and restarting Capture state.
+export function configure_capture(capture: HTMLElement, settings: CaptureConfiguration): void {
+    const directions = settings.wheel_capture === 'both' ? 'up down' : settings.wheel_capture
+
+    set_attribute(capture, 'wheel-capture', directions)
+    set_attribute(capture, 'wheel-modifier', settings.wheel_modifier)
+    set_attribute(capture, 'wheel-activation', settings.wheel_activation)
+    set_attribute(capture, 'wheel-delay', String(settings.wheel_delay))
+    set_attribute(capture, 'wheel-tolerance', String(settings.wheel_tolerance))
+    set_attribute(capture, 'wheel-reset-on-move', settings.wheel_reset_on_move ? '' : null)
+    set_attribute(capture, 'pointer-capture', settings.pointer_capture)
+    set_attribute(capture, 'pointer-buttons', settings.pointer_buttons.join(' '))
+    set_attribute(capture, 'pointer-threshold', String(settings.pointer_threshold))
+    set_attribute(capture, 'pointer-modifier', settings.pointer_modifier)
+}
+
+function set_attribute(element: HTMLElement, name: string, value: string | null): void {
+    if (value === null) {
+        element.removeAttribute(name)
+    } else if (element.getAttribute(name) !== value) {
+        element.setAttribute(name, value)
+    }
+}

--- a/plot/src/browser/hover.ts
+++ b/plot/src/browser/hover.ts
@@ -1,0 +1,113 @@
+import { resize_canvas } from '../core/render/canvas'
+import { clear_highlights, update_highlight_canvas } from '../core/render/highlight'
+import { get_canvas_context } from './browser_view'
+import type { ATooltipElement } from '@antadesign/anta/elements/a-tooltip'
+import type { ComposedPlot } from '../core/types'
+import type { NearestPoint } from '../core/interactions/hit'
+import { render_tooltip_bodies, TOOLTIP_DIVIDER_STYLE } from '../core/presentation/tooltip'
+import type { PlotController } from '../core/controller'
+
+type HoverSnapshot = {
+    plot: ComposedPlot<Node>
+    hits: NearestPoint[]
+    dpr: number
+}
+
+const rendered_hover = new WeakMap<HTMLCanvasElement, HoverSnapshot>()
+
+// Clear visible feedback and invalidate its snapshot when a gesture, update, or leave takes ownership.
+export function clear_hover(canvas: HTMLCanvasElement, tooltip: ATooltipElement): void {
+    rendered_hover.delete(canvas)
+    tooltip.replaceChildren()
+    tooltip.hide()
+    const ctx = get_canvas_context(canvas)
+    if (ctx === null) {
+        return
+    }
+
+    clear_highlights(ctx)
+}
+
+/** Paint core highlight geometry and mount host-specific tooltip Nodes without parsing HTML. */
+export function render_hover(
+    controller: PlotController<Node>,
+    canvas: HTMLCanvasElement,
+    tooltip: ATooltipElement,
+): void {
+    const plot = controller.composed_plot
+
+    if (plot === null) {
+        return
+    }
+
+    const dpr = canvas.ownerDocument.defaultView?.devicePixelRatio ?? 1
+    const hits = controller.interactions.hovered
+    const previous = rendered_hover.get(canvas)
+
+    // The controller preserves hit-array identity until the hovered points actually change.
+    if (previous?.plot === plot && previous.hits === hits && previous.dpr === dpr) {
+        return
+    }
+
+    canvas.style.width = `${plot.layout.width}px`
+    canvas.style.height = `${plot.layout.height}px`
+
+    const ctx = get_canvas_context(canvas)
+
+    if (ctx !== null) {
+        update_highlight_canvas(ctx, plot, dpr, () => controller.interactions.resolve_highlights(hits))
+    } else {
+        resize_canvas(canvas, plot.layout.width, plot.layout.height, dpr)
+    }
+
+    const doc = tooltip.ownerDocument
+    const { bodies, hidden } = render_tooltip_bodies(controller.interactions.resolve_tooltips(hits), {
+        custom: (content: unknown) => custom_tooltip_content(content, tooltip),
+        text: (line: string) => doc.createTextNode(line),
+        line_break: () => doc.createElement('br'),
+        divider: () => {
+            const divider = doc.createElement('hr')
+            divider.className = 'plot-tooltip-divider'
+            Object.assign(divider.style, TOOLTIP_DIVIDER_STYLE)
+            return divider
+        },
+        group: (children: Node[]) => {
+            const body = doc.createElement('div')
+            body.append(...children)
+            return body
+        },
+    })
+
+    tooltip.replaceChildren(...bodies)
+
+    if (hidden) {
+        tooltip.hide()
+    }
+
+    rendered_hover.set(canvas, { plot, hits, dpr })
+}
+
+// Validate custom content at the DOM boundary, omitting invalid bodies like the notebook host does.
+function custom_tooltip_content(value: unknown, tooltip: ATooltipElement): Node | undefined {
+    // Element, Text, CDATA, ProcessingInstruction, Comment, or DocumentFragment; never an ancestor.
+    if (is_dom_node(value, tooltip) && [1, 3, 4, 7, 8, 11].includes(value.nodeType)
+        && !value.contains(tooltip)) {
+        return value
+    }
+
+    console.error(
+        'Invalid plot tooltip return value. Return a DOM Node that can be inserted into the tooltip.',
+        value,
+    )
+    return undefined
+}
+
+// Use the DOM's Node argument check so nodes from other windows or detached documents also work.
+function is_dom_node(value: unknown, tooltip: ATooltipElement): value is Node {
+    try {
+        Reflect.apply(tooltip.compareDocumentPosition, tooltip, [value])
+        return true
+    } catch {
+        return false
+    }
+}

--- a/plot/src/browser/index.ts
+++ b/plot/src/browser/index.ts
@@ -1,0 +1,68 @@
+import { create_plot_element } from './plot_element'
+import type { PlotArgs } from '../core/types'
+import { new_scatter } from '../core/series/scatter/factory'
+import { new_bar } from '../core/series/bar/factory'
+import { new_rect } from '../core/series/rect/factory'
+import { new_line } from '../core/series/line/factory'
+import { new_rule } from '../core/series/rule/factory'
+import { new_area } from '../core/series/area/factory'
+import { new_custom } from '../core/series/custom/factory'
+
+// Reuse the core factories directly, with DOM Node tooltips at the browser boundary.
+export const scatter = new_scatter<Node>
+export const bar = new_bar<Node>
+export const rect = new_rect<Node>
+export const line = new_line<Node>
+export const rule = new_rule<Node>
+export const area = new_area<Node>
+export const custom = new_custom<Node>
+
+export type ScatterArgs = Parameters<typeof scatter>[0]
+export type BarArgs = Parameters<typeof bar>[0]
+export type RectArgs = Parameters<typeof rect>[0]
+export type LineArgs = Parameters<typeof line>[0]
+export type RuleArgs = Parameters<typeof rule>[0]
+export type AreaArgs = Parameters<typeof area>[0]
+export type CustomArgs = Parameters<typeof custom>[0]
+
+/** Internal host input: all plot behavior is configured through the complete argument object. */
+export interface APlotElement extends HTMLElement {
+    plotArgs: PlotArgs<Node> | undefined
+}
+
+const implementations = new WeakSet<CustomElementConstructor>()
+
+/** Register Plot and its internal Anta elements. Safe to import without a DOM; call in the browser. */
+export async function definePlotElement(): Promise<void> {
+    if (typeof customElements === 'undefined') {
+        throw new Error('plot: definePlotElement requires a browser custom-element registry')
+    }
+    if (already_registered()) return
+    const [box, capture, button, icon, tooltip] = await Promise.all([
+        import('@antadesign/anta/elements/a-box'),
+        import('@antadesign/anta/elements/a-capture'),
+        import('@antadesign/anta/elements/a-button'),
+        import('@antadesign/anta/elements/a-icon'),
+        import('@antadesign/anta/elements/a-tooltip'),
+    ])
+    if (already_registered()) return // Another caller may have registered while imports loaded.
+    box.register_a_box()
+    capture.register_a_capture()
+    button.register_a_button()
+    icon.register_a_icon()
+    tooltip.register_a_tooltip()
+    const element = create_plot_element()
+    customElements.define('a-plot', element)
+    implementations.add(element)
+}
+
+export type { PlotArgs, Viewport, ViewportChange } from '../core/types'
+
+function already_registered(): boolean {
+    const existing = customElements.get('a-plot')
+    if (existing === undefined) return false
+    if (!implementations.has(existing)) {
+        throw new Error('plot: another implementation already registered <a-plot>')
+    }
+    return true
+}

--- a/plot/src/browser/plot.css
+++ b/plot/src/browser/plot.css
@@ -1,0 +1,51 @@
+:where(a-plot) {
+    display: block;
+    position: relative;
+    width: 100%;
+    height: 300px;
+}
+
+a-plot > .plot-root {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    /* Anta's theme classes also set typography; keep the plot's inherited font. */
+    font: inherit;
+    font-feature-settings: inherit;
+}
+
+a-plot > .plot-root > a-box {
+    display: block;
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+a-plot > .plot-root > canvas {
+    display: block;
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+a-plot > .plot-root > a-capture {
+    display: block;
+    position: absolute;
+}
+
+a-plot > .plot-root > a-capture[pointer-capture] {
+    user-select: none;
+}
+
+a-plot > .plot-root > .plot-highlight {
+    pointer-events: none;
+}
+
+a-plot > .plot-root > .plot-reset {
+    z-index: 3;
+    cursor: pointer;
+}
+
+a-plot > .plot-root [hidden] {
+    display: none !important;
+}

--- a/plot/src/browser/plot_element.ts
+++ b/plot/src/browser/plot_element.ts
@@ -1,0 +1,342 @@
+import { tooltip_wrapper_style } from '../core/presentation/tooltip'
+import { reset_zoom_presentation } from '../core/presentation/reset_zoom'
+import { create_interaction_coordinator } from '../core/interactions/coordinator'
+import { capture_pointer_input, capture_wheel_input } from '../integrations/anta_gestures'
+import { resolve_canvas_size } from '../core/compose/layout'
+import {
+    configure_capture, create_browser_view, prepare_canvas, size_host, type BrowserView,
+} from './browser_view'
+import type {
+    BoxContext, BoxContextChange, BoxMeasurement, BoxMeasurementChange,
+    CapturePointerInput, CaptureWheelInput,
+} from '@antadesign/anta'
+import { PlotController, type PlotEnvironment } from '../core/controller'
+import type { PointerOffset } from '../core/interactions/hit'
+import { plot_color_filter } from '../core/presentation/plot'
+import type { ComposedPlot, ViewportChange } from '../core/types'
+import type { APlotElement, PlotArgs } from './index'
+import { clear_hover, render_hover } from './hover'
+import { resolve_capture_configuration, zoom_pan_enabled } from '../core/interactions/zoom_pan'
+import throttle from 'lodash/throttle'
+
+import { UPDATE_INTERVAL_MS } from '../core/interactions/viewport_schedule'
+
+/** The class is created at registration time so importing this module never reads HTMLElement. */
+export function create_plot_element(): CustomElementConstructor {
+    return class PlotElement extends HTMLElement implements APlotElement {
+        #controller: PlotController<Node> | null = null
+        #args: PlotArgs<Node> | undefined
+        #pending_frame_id: number | null = null
+        #measurement: BoxMeasurement | null = null
+        #context: BoxContext | null = null
+        readonly #view: BrowserView
+
+        // Adopt the latest resize at most every 40 ms, including the final size after a burst.
+        readonly #resize = throttle((measurement: BoxMeasurement) => {
+            this.#measurement = measurement
+            this.#schedule()
+        }, UPDATE_INTERVAL_MS, { leading: false, trailing: true })
+
+        readonly #interaction_coordinator = create_interaction_coordinator({
+            controller: () => this.#controller,
+            commit_mode: 'immediate',
+            on_viewport_commit: () => {
+                this.#clear_hover()
+                this.#schedule()
+            },
+            on_viewport_report: change => this.#report_viewport(change),
+            resolve_hover: ({ event, offset }: { event: MouseEvent; offset: PointerOffset | undefined }) => {
+                if (!this.isConnected) {
+                    return null
+                }
+                return { ...(offset ?? this.#offset(event)), ctrlKey: event.ctrlKey }
+            },
+            on_hover_update: () => {
+                if (this.#controller !== null) {
+                    render_hover(this.#controller, this.#view.highlight, this.#view.tooltip)
+                }
+                this.#update_cursor()
+            },
+            on_hover_clear: () => clear_hover(this.#view.highlight, this.#view.tooltip),
+            on_pointer_change: () => this.#update_cursor(),
+            on_pan_end: () => this.#schedule(),
+        })
+
+        constructor() {
+            super()
+            this.#view = create_browser_view(this.ownerDocument)
+            this.#listen_for_events()
+        }
+
+        // Route Box notifications and Capture events to rendering and interaction handlers.
+        #listen_for_events(): void {
+            this.#view.box.addEventListener('measurechange', event => {
+                if (this.isConnected) {
+                    this.#resize((event as CustomEvent<BoxMeasurementChange>).detail.current)
+                }
+            })
+            this.#view.box.addEventListener('contextchange', event => {
+                this.#context = (event as CustomEvent<BoxContextChange>).detail.current
+                this.#schedule()
+            })
+            this.#view.reset.addEventListener('click', this.#interaction_coordinator.reset)
+            this.#view.capture.addEventListener('dblclick', this.#interaction_coordinator.handle_double_click)
+            this.#view.capture.addEventListener('wheelinput', event => {
+                const detail = (event as CustomEvent<CaptureWheelInput>).detail
+                this.#wheel(detail)
+            })
+            this.#view.capture.addEventListener('pointerinput', event => {
+                this.#pointer((event as CustomEvent<CapturePointerInput>).detail)
+            })
+            this.#view.capture.addEventListener('mousemove', event => {
+                if (!this.#controller?.interactions.pan_in_progress) {
+                    // Snapshot target-relative offsets during dispatch; measure child targets after throttling.
+                    const offset = event.target === this.#view.capture ? this.#offset(event) : undefined
+                    this.#interaction_coordinator.move({ event, offset })
+                }
+            })
+            this.#view.capture.addEventListener('mouseleave', () => this.#on_mouse_leave())
+            this.#view.capture.addEventListener('click', event => this.#on_click(event))
+        }
+
+        // Mount the view so Box starts observing, restore assigned properties, and schedule the first draw.
+        connectedCallback(): void {
+            if (this.#view.root.parentNode !== this) {
+                this.append(this.#view.root)
+            }
+            this.#restore_properties()
+            this.#attach_canvas()
+            this.#refresh_environment()
+        }
+
+        // Apply arguments assigned before custom-element registration through the normal setter.
+        #restore_properties(): void {
+            const descriptor = Object.getOwnPropertyDescriptor(this, 'plotArgs')
+            if (descriptor !== undefined) {
+                Reflect.deleteProperty(this, 'plotArgs')
+                this.plotArgs = descriptor.value
+            }
+        }
+
+        // Cancel pending drawing and release gesture state; the detached child Box stops its own observers.
+        disconnectedCallback(): void {
+            if (this.#pending_frame_id !== null) {
+                this.ownerDocument.defaultView?.cancelAnimationFrame(this.#pending_frame_id)
+            }
+            this.#pending_frame_id = null
+            this.#interaction_coordinator.disconnect()
+            this.#resize.cancel()
+            this.#controller?.set_draw_host(null)
+            clear_hover(this.#view.highlight, this.#view.tooltip)
+            this.#update_cursor()
+        }
+
+        get plotArgs(): PlotArgs<Node> | undefined {
+            return this.#args
+        }
+
+        // Apply valid plot arguments while retaining the previous configuration if templating fails.
+        set plotArgs(value: PlotArgs<Node> | undefined) {
+            if (value === undefined) {
+                return
+            }
+            if (this.#controller === null) {
+                try {
+                    this.#controller = new PlotController(value, failure => this.#emit('ploterror', failure))
+                } catch {
+                    // Constructor already reported the template error.
+                    return
+                }
+                this.#attach_canvas()
+            } else {
+                this.#controller.update_plot_args(value)
+                if (this.#controller.plot_args !== value) {
+                    return
+                }
+            }
+            this.#args = value
+            size_host(this, this.#controller.template)
+            this.#clear_hover()
+            this.#schedule()
+        }
+
+        // Read initial environment snapshots on connection; normal renders consume Box notifications.
+        #refresh_environment(): void {
+            this.#resize.cancel()
+            if (this.isConnected) {
+                this.#measurement = this.#view.box.measurement
+                this.#context = this.#view.box.context
+            }
+            this.#controller?.invalidate_draw()
+            this.#schedule()
+        }
+
+        #emit(name: string, detail: unknown): void {
+            this.dispatchEvent(new CustomEvent(name, { detail, bubbles: true, composed: true }))
+        }
+
+        #attach_canvas(): void {
+            if (!this.isConnected) {
+                return
+            }
+            this.#controller?.set_draw_host({
+                prepare: (width, height, dpr) => prepare_canvas(this.#view.canvas, width, height, dpr),
+            })
+        }
+
+        // Coalesce updates into one render before the browser’s next repaint.
+        #schedule(): void {
+            if (!this.isConnected || this.#pending_frame_id !== null) {
+                return
+            }
+            this.#pending_frame_id = this.ownerDocument.defaultView!.requestAnimationFrame(() => {
+                this.#pending_frame_id = null
+                this.#render()
+            })
+        }
+
+        // Compose from the current environment, flush drawing, and update the overlays.
+        #render(): void {
+            const controller = this.#controller
+            const measurement = this.#measurement
+            const context = this.#context
+            if (controller === null || measurement === null || context === null) {
+                return
+            }
+            const dimensions = resolve_canvas_size(controller.template, measurement)
+            if (dimensions === null || dimensions.width <= 0 || dimensions.height <= 0) {
+                return
+            }
+            const { width, height } = dimensions
+            const color_theme = context.mode
+            const plot = this.#compose({
+                width,
+                height,
+                color_theme,
+                device_pixel_ratio: context.devicePixelRatio,
+            })
+            if (plot === null) {
+                return
+            }
+            controller.flush_draw()
+            const { inner } = plot
+            Object.assign(this.#view.capture.style, tooltip_wrapper_style(inner))
+            const filter = plot_color_filter(controller.template, color_theme) ?? ''
+            this.#view.canvas.style.filter = filter
+            this.#view.highlight.style.filter = filter
+            const reset = reset_zoom_presentation(controller, inner, color_theme)
+            Object.assign(this.#view.reset.style, reset.position, reset.button.style)
+            this.#view.reset.hidden = !reset.visible
+            this.#configure_capture()
+            render_hover(controller, this.#view.highlight, this.#view.tooltip)
+            this.#update_cursor()
+        }
+
+        // Apply newly keyed argument requests and normalize the current window against fresh domains.
+        #compose(environment: PlotEnvironment): ComposedPlot<Node> | null {
+            const controller = this.#controller
+            if (controller === null) {
+                return null
+            }
+            const current = controller.interactions.committed_viewport
+            const plot = controller.compose(environment, current)
+
+            // A failed composition retains the old plot; it cannot normalize against the new domains.
+            if (plot === null || !controller.has_current_composition) {
+                return plot
+            }
+
+            const adopted = this.#interaction_coordinator.adopt_viewport(controller.template.viewport)
+            const normalized = controller.interactions.normalize_viewport()
+            if (!adopted && !normalized) {
+                return plot
+            }
+            return controller.compose(environment, controller.interactions.committed_viewport)
+        }
+
+        // Allow zoom and pan when enabled and at least one selected axis is continuous.
+        #zoom_enabled(): boolean {
+            const template = this.#controller?.template
+            return template !== undefined && zoom_pan_enabled(template)
+        }
+
+        // Configure wheel ownership and drag activation from the current plot state.
+        #configure_capture(): void {
+            const controller = this.#controller
+            if (controller === null) {
+                return
+            }
+            const enabled = this.#zoom_enabled()
+            const axes = controller.template.zoom_pan
+            const wheel_claim = controller.interactions.wheel_claim(
+                controller.composed_plot,
+                controller.interactions.committed_viewport,
+                axes,
+            )
+
+            configure_capture(
+                this.#view.capture,
+                resolve_capture_configuration(enabled, axes.modifier, wheel_claim),
+            )
+        }
+
+        // Match the old precedence: active pan, modifier-ready pan, selectable hit, then default.
+        #update_cursor(): void {
+            const controller = this.#controller
+            this.#view.capture.style.cursor = controller?.interactions.cursor_style({
+                ...controller.template.zoom_pan,
+                enabled: zoom_pan_enabled(controller.template),
+            }) ?? ''
+        }
+
+        #on_mouse_leave(): void {
+            this.#interaction_coordinator.leave()
+            this.#configure_capture()
+        }
+
+        // Select the topmost eligible hit and emit its point data.
+        #on_click(event: MouseEvent): void {
+            const controller = this.#controller
+            if (controller === null) {
+                return
+            }
+            if (controller.composed_plot === null) {
+                return
+            }
+            const offset = this.#offset(event)
+            const data = this.#interaction_coordinator.handle_click({ ...offset, ctrlKey: event.ctrlKey })
+            if (data !== undefined) {
+                this.#emit('select', data)
+            }
+        }
+
+        // Native offsets are Capture-relative only for direct targets; children need a fresh origin.
+        #offset(event: MouseEvent): PointerOffset {
+            if (event.target === this.#view.capture) {
+                return { offsetX: event.offsetX, offsetY: event.offsetY }
+            }
+            const rect = this.#view.capture.getBoundingClientRect()
+            return { offsetX: event.clientX - rect.left, offsetY: event.clientY - rect.top }
+        }
+
+        #clear_hover(): void {
+            this.#interaction_coordinator.clear_hover()
+            this.#update_cursor()
+        }
+
+        // Stage an accepted wheel zoom and publish the viewport if it changed.
+        #wheel(detail: CaptureWheelInput): void {
+            this.#interaction_coordinator.handle_wheel(capture_wheel_input(detail))
+        }
+
+        // Translate Capture start, move, end, and cancel phases into pan updates.
+        #pointer(detail: CapturePointerInput): void {
+            this.#interaction_coordinator.handle_pan(capture_pointer_input(detail))
+        }
+
+        #report_viewport(change: ViewportChange): void {
+            this.#emit('viewportchange', change)
+            this.#controller?.template.on_viewport_change?.(change)
+        }
+    }
+}

--- a/plot/src/core/compose/compose_plot.ts
+++ b/plot/src/core/compose/compose_plot.ts
@@ -1,0 +1,201 @@
+import { scaleBand, scaleLinear, scaleLog, scaleTime, scaleUtc } from "d3-scale"
+import type { AxisTemplate, ColorTheme, ComposedPlot, ComposedSeries, Domain, PlotTemplate, Scale, Series, Viewport } from "../types"
+import { resolve_plot_background, resolve_series_colors, resolve_theme_color, should_invert_color } from "../template/color"
+import { clamp_domain, LINEAR_SPACE, LOG_SPACE } from "../template/domain"
+import { series_type } from "../registry"
+import { linear_tick_count, X_TICK_PX_TARGET, Y_TICK_PX_TARGET } from "../render/axes"
+import { inner_rect, resolve_layout } from "./layout"
+
+/**
+ * Turns a PlotTemplate into a renderable Plot
+ * @param template - dimension-independent plot template
+ * @param width - canvas width in CSS pixels
+ * @param height - canvas height in CSS pixels
+ * @param color_theme - the current browser color scheme
+ * @param viewport - optional per-axis zoom/pan viewport; null on an axis uses the full domain
+ * @returns the ComposedPlot with layout, scales, and color theme resolved series
+ */
+export function compose_plot<TooltipContent = unknown>(template: PlotTemplate<TooltipContent>, width: number, height: number, color_theme: ColorTheme, viewport?: Viewport): ComposedPlot<TooltipContent> {
+    const layout = resolve_layout(
+        width,
+        height,
+        template.x.rendered,
+        template.y.rendered,
+        template.title !== undefined,
+        template.margin,
+    )
+    const x_range = pad_range([layout.margin_left, layout.width - layout.margin_right], template.x)
+    const y_range = pad_range([layout.height - layout.margin_bottom, layout.margin_top], template.y)
+
+    const x_tick_count = linear_tick_count(layout.width - layout.margin_left - layout.margin_right, X_TICK_PX_TARGET)
+    const y_tick_count = linear_tick_count(layout.height - layout.margin_top - layout.margin_bottom, Y_TICK_PX_TARGET)
+
+    const x_base_scale = build_scale(template.x, x_range, x_tick_count) // base scales are the original scalesunaffected by zoom/pan
+    const y_base_scale = build_scale(template.y, y_range, y_tick_count)
+
+    const x_full_domain = full_domain(template.x, x_base_scale)
+    const y_full_domain = full_domain(template.y, y_base_scale)
+
+    const x_override = clamp_window(viewport?.x ?? null, x_full_domain, template.x)
+    const y_override = clamp_window(viewport?.y ?? null, y_full_domain, template.y)
+    const x_scale = x_override === null ? x_base_scale : build_scale(apply_viewport(template.x, x_override), x_range, x_tick_count)
+    const y_scale = y_override === null ? y_base_scale : build_scale(apply_viewport(template.y, y_override), y_range, y_tick_count)
+
+    const chrome_theme = should_invert_color(template) ? 'light' : color_theme
+    const chrome_color = template.chrome_color === undefined ? undefined : resolve_theme_color(template.chrome_color, chrome_theme)
+
+    return {
+        layout,
+        inner: inner_rect(layout),
+        x_scale,
+        y_scale,
+        x_full_domain,
+        y_full_domain,
+        series: template.series.map(s => compose_series(s, color_theme, x_scale, y_scale)),
+        x_axis: template.x.rendered ? template.x.axis : undefined,
+        y_axis: template.y.rendered ? template.y.axis : undefined,
+        x_categories: template.x.kind === 'category' ? template.x.categories : undefined,
+        y_categories: template.y.kind === 'category' ? template.y.categories : undefined,
+        title: template.title,
+        title_size: template.title_size,
+        title_color: template.title_color,
+        border: template.border,
+        grid: template.grid,
+        background: resolve_plot_background(template.background, color_theme),
+        chrome_theme,
+        chrome_color,
+    }
+}
+
+/**
+ * Compose one series: resolve its theme colors, then let its kind precompute any pixel geometry that needs the scales.
+ * @param series - the template series
+ * @param color_theme - the browser color scheme to resolve colors against
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the composed series
+ */
+function compose_series<TooltipContent>(series: Series<TooltipContent>, color_theme: ColorTheme, x_scale: Scale, y_scale: Scale): ComposedSeries<TooltipContent> {
+    const composed = resolve_series_colors(series, color_theme)
+    const compose_layout = series_type<TooltipContent>(series.kind).compose_layout
+
+    if (compose_layout === undefined) {
+        return composed
+    }
+    return compose_layout(composed, x_scale, y_scale)
+}
+
+/**
+ * Pad a continuous axis's pixel range by its per-end padding, shrinking it toward the middle so a mark at an endpoint clears the plot border.
+ * @param range - the base pixel range [min-end, max-end] from the layout margins
+ * @param template - the resolved axis template
+ * @returns the padded range
+ */
+function pad_range(range: [number, number], template: AxisTemplate): [number, number] {
+    const span = Math.abs(range[1] - range[0])
+    let padding_min = template.padding_min
+    let padding_max = template.padding_max
+    const total = padding_min + padding_max
+
+    // keep a sliver of range so the scale can't collapse or flip on oversized padding
+    if (total > 0 && total >= span) {
+        const scale = (span * 0.9) / total
+        padding_min *= scale
+        padding_max *= scale
+    }
+    const direction = Math.sign(range[1] - range[0]) || 1
+    const padded_min = range[0] + direction * padding_min
+    const padded_max = range[1] - direction * padding_max
+
+    return [padded_min, padded_max]
+}
+
+function clamp_window(window: Domain | null, full: Domain | null, axis: AxisTemplate): Domain | null {
+    if (window === null || full === null) {
+        return null
+    }
+    const space = axis.kind === 'log' ? LOG_SPACE : LINEAR_SPACE
+    const clamped = clamp_domain([space.to(window[0]), space.to(window[1])], [space.to(full[0]), space.to(full[1])])
+
+    return clamped === null ? null : [space.from(clamped[0]), space.from(clamped[1])]
+}
+
+/**
+ * Fold a per-axis zoom/pan override into the axis template: pin the domain to the chosen window and disable nicing.
+ * Absent overrides and categorical axes pass through unchanged, so only continuous axes ever zoom or pan.
+ */
+function apply_viewport(axis: AxisTemplate, override: Domain | null | undefined): AxisTemplate {
+    if (override === null || override === undefined || axis.kind === 'category') {
+        return axis
+    }
+
+    return { ...axis, domain: override, nice_min: false, nice_max: false }
+}
+
+/**
+ * The full (unzoomed) continuous domain [min, max] of an axis, read off its full scale so nicing is included.
+ */
+function full_domain(axis: AxisTemplate, full_scale: { domain(): (number | Date)[] }): Domain | null {
+    if (axis.kind === 'category') {
+        return null
+    }
+    const domain = full_scale.domain()
+    return [Number(domain[0]), Number(domain[domain.length - 1])]
+}
+
+/**
+ * Builds the only d3 scales in the plot. Linear and log nice each auto min/max while preserving any pinned one; category uses a band scale.
+ * @param axis_template - resolved axis template with kind, domain, and padding
+ * @param range - pixel range [start, end] for the scale
+ * @returns the constructed d3 scale for the axis
+ */
+function build_scale(axis_template: AxisTemplate, range: [number, number], tick_count: number): ComposedPlot['x_scale'] {
+    if (axis_template.kind === 'linear') {
+        const scale = scaleLinear().domain(axis_template.domain).range(range)
+        nice_continuous(scale, axis_template.nice_min, axis_template.nice_max, tick_count)
+        return scale
+    }
+
+    if (axis_template.kind === 'log') {
+        const scale = scaleLog().domain(axis_template.domain).range(range)
+        nice_continuous(scale, axis_template.nice_min, axis_template.nice_max)
+        return scale
+    }
+
+    if (axis_template.kind === 'time') {
+        const construct = axis_template.utc ? scaleUtc : scaleTime
+        const scale = construct().domain(axis_template.domain).range(range)
+        nice_continuous(scale, axis_template.nice_min, axis_template.nice_max)
+        return scale
+    }
+    const indices: number[] = []
+
+    for (let i = 0; i < axis_template.categories.length; i++) {
+        indices.push(i)
+    }
+    return scaleBand<number>()
+        .domain(indices)
+        .range(range)
+}
+
+type NiceableScale<D extends number | Date> = {
+    domain(): D[]
+    domain(domain: Iterable<D>): NiceableScale<D>
+    nice(count?: number): NiceableScale<D>
+}
+
+/**
+ * Applies d3's nice() in place to round unpinned min/max to human friendly round numbers (calendar boundaries for time).
+ * @param scale - linear, log, or time scale to nice
+ * @param nice_min - whether the min endpoint may be rounded
+ * @param nice_max - whether the max endpoint may be rounded
+ */
+function nice_continuous<D extends number | Date>(scale: NiceableScale<D>, nice_min: boolean, nice_max: boolean, count?: number): void {
+    if (!nice_min && !nice_max) {
+        return
+    }
+    const [orig_min, orig_max] = scale.domain()
+    scale.nice(count)
+    const [niced_min, niced_max] = scale.domain()
+    scale.domain([nice_min ? niced_min : orig_min, nice_max ? niced_max : orig_max])
+}

--- a/plot/src/core/compose/layout.ts
+++ b/plot/src/core/compose/layout.ts
@@ -1,0 +1,135 @@
+// Canvas dimensions and per-side margin. margin is the space between the plot area and the
+// canvas edge; chrome (tick labels, axis names, title) paints inside it. Default margins apply
+// whenever the plot paints any chrome; with none (sparkbar — both axes hidden, no title) every
+// side collapses to a small bare margin so the data fills the canvas.
+
+import type { Layout, Margin, Rect, SideMargins } from "../types"
+
+export type Dimensions = { width: number; height: number }
+
+/** Prefer composed dimensions, then explicit pins, then whole CSS-pixel measurements. */
+export function resolve_canvas_size(
+    pinned: Partial<Dimensions>,
+    measured: Dimensions | null,
+    composed: Dimensions | null = null,
+): Dimensions | null {
+    const measured_width = measured === null ? undefined : Math.floor(measured.width)
+    const measured_height = measured === null ? undefined : Math.floor(measured.height)
+    const width = composed?.width ?? pinned.width ?? measured_width
+    const height = composed?.height ?? pinned.height ?? measured_height
+
+    if (width === undefined || height === undefined) {
+        return null
+    }
+    return { width, height }
+}
+
+type Side = 'top' | 'right' | 'bottom' | 'left'
+
+const DEFAULT_WIDTH = 650
+const DEFAULT_HEIGHT = 400
+const DEFAULT_MARGIN: Record<Side, number> = { top: 60, right: 60, bottom: 60, left: 60 }
+const BARE_MARGIN = 2
+
+/**
+ * Resolves canvas dimensions and per-side margins from caller args and the chrome the plot paints.
+ * @param args_width - caller-pinned width in CSS pixels, if any
+ * @param args_height - caller-pinned height in CSS pixels, if any
+ * @param x_rendered - whether the x axis paints
+ * @param y_rendered - whether the y axis paints
+ * @param title_declared - whether a title is set
+ * @param margin - caller margin override
+ * @returns the resolved Layout with dimensions and margins
+ */
+export function resolve_layout(
+    args_width: number | undefined,
+    args_height: number | undefined,
+    x_rendered: boolean,
+    y_rendered: boolean,
+    title_declared: boolean,
+    margin: Margin | undefined,
+): Layout {
+    const caller = normalize_margin(margin)
+    // any rendered axis or a title keeps the full default margins on every side
+    const has_chrome = x_rendered || y_rendered || title_declared
+
+    const layout: Layout = {
+        width: args_width ?? DEFAULT_WIDTH,
+        height: args_height ?? DEFAULT_HEIGHT,
+        margin_top: side_margin(has_chrome, 'top', caller.top),
+        margin_right: side_margin(has_chrome, 'right', caller.right),
+        margin_bottom: side_margin(has_chrome, 'bottom', caller.bottom),
+        margin_left: side_margin(has_chrome, 'left', caller.left),
+    }
+    validate_layout_room(layout)
+    return layout
+}
+
+/**
+ * Normalizes the margin arg into per-side values; a number applies to all four sides.
+ * @param margin - caller margin as a number, per-side object, or undefined
+ * @returns per-side margins, empty when unset
+ */
+function normalize_margin(margin: Margin | undefined): SideMargins {
+    if (margin === undefined) {
+        return {}
+    }
+
+    if (typeof margin === 'number') {
+        return { top: margin, right: margin, bottom: margin, left: margin }
+    }
+    return margin
+}
+
+
+/**
+ * Resolves one side's margin: caller value wins, else the chrome default, collapsing to a bare margin when chromeless.
+ * @param has_chrome - whether the plot paints any tick labels, axis names, or title
+ * @param side - which margin side to resolve
+ * @param caller - caller-pinned margin for this side, if any
+ * @returns the side margin in CSS pixels
+ */
+function side_margin(has_chrome: boolean, side: Side, caller: number | undefined): number {
+    if (caller !== undefined) {
+        return caller
+    }
+    return has_chrome ? DEFAULT_MARGIN[side] : BARE_MARGIN
+}
+
+/**
+ * Guards that the canvas and its margins leave a positive plot area, throwing a sized error otherwise.
+ * @param layout - resolved canvas dimensions and per-side margins
+ */
+function validate_layout_room(layout: Layout): void {
+    const { margin_left: left, margin_right: right, margin_top: top, margin_bottom: bottom } = layout
+
+    if (layout.width <= 0) {
+        throw new Error(`plot: canvas resolved to ${layout.width}px wide. width wasn't pinned and the parent container has no measurable width. Either pin \`width: <px>\` directly, or fix the parent's sizing (common causes: \`display: none\`, \`width: 0\`, or the parent hasn't been laid out yet).`)
+    }
+
+    if (layout.width - left - right <= 0) {
+        throw new Error(`plot: margins (left ${left}px + right ${right}px = ${left + right}px) leave no horizontal room in a ${layout.width}px-wide canvas. Pin a larger width, hide an axis, or shrink the margin.`)
+    }
+
+    if (layout.height <= 0) {
+        throw new Error(`plot: canvas resolved to ${layout.height}px tall. height wasn't pinned and the parent container has no measurable height. Either pin \`height: <px>\` directly, or fix the parent's sizing (common causes: flex column with no min-height, \`display: none\`, or the parent hasn't been laid out yet).`)
+    }
+
+    if (layout.height - top - bottom <= 0) {
+        throw new Error(`plot: margins (top ${top}px + bottom ${bottom}px = ${top + bottom}px) leave no vertical room in a ${layout.height}px-tall canvas. Pin a larger height, hide an axis/title, or shrink the margin.`)
+    }
+}
+
+/**
+ * Inner plot rect, the canvas with margins subtracted, where series and grid paint.
+ * @param layout - resolved layout
+ * @returns the inner rect in canvas pixels
+ */
+export function inner_rect(layout: Layout): Rect {
+    return {
+        left: layout.margin_left,
+        right: layout.width - layout.margin_right,
+        top: layout.margin_top,
+        bottom: layout.height - layout.margin_bottom,
+    }
+}

--- a/plot/src/core/controller.ts
+++ b/plot/src/core/controller.ts
@@ -1,0 +1,183 @@
+import { new_plot_template } from "./template/plot_template"
+import { compose_plot } from "./compose/compose_plot"
+import { draw as draw_plot } from "./render/canvas"
+import { compatible_viewport, viewport_moved } from "./interactions/viewport"
+import { PlotInteractionController } from "./interaction_controller"
+import type { CanvasContext, ColorTheme, ComposedPlot, PlotArgs, PlotTemplate, Viewport } from "./types"
+
+export type PlotLifecycleError = {
+    phase: 'template' | 'compose' | 'draw'
+    error: unknown
+}
+
+export type PlotEnvironment = {
+    width: number
+    height: number
+    device_pixel_ratio: number
+    color_theme: ColorTheme
+}
+
+export type PlotDrawHost = {
+    /** Size/configure the host canvas for the latest composition before painting. */
+    prepare(width: number, height: number, device_pixel_ratio: number): CanvasContext
+}
+
+/**
+ * Realm-independent owner of templates, composition, drawing, and interaction state.
+ * The host supplies canvas/environment inputs, scheduling, and error presentation.
+ */
+export class PlotController<TooltipContent = unknown> {
+    readonly interactions: PlotInteractionController<TooltipContent>
+    #plot_args: PlotArgs<TooltipContent>
+    #template: PlotTemplate<TooltipContent>
+    #composed_plot: ComposedPlot<TooltipContent> | null = null
+    readonly #on_error: (failure: PlotLifecycleError) => void
+    #draw_host: PlotDrawHost | null = null
+    #draw_dirty = false
+    #has_current_composition = false
+    #environment: PlotEnvironment | null = null
+    #last_composition_template: PlotTemplate<TooltipContent> | null = null
+    #last_composition_viewport: Viewport = { x: null, y: null }
+
+    constructor(plot_args: PlotArgs<TooltipContent>, on_error: (failure: PlotLifecycleError) => void = () => {}) {
+        this.#on_error = on_error
+        this.#plot_args = plot_args
+        try {
+            this.#template = new_plot_template(plot_args)
+        } catch (error) {
+            this.#on_error({ phase: 'template', error })
+            // There is no valid template to retain during initial construction.
+            throw error
+        }
+        this.interactions = new PlotInteractionController(() => this.#composed_plot, {
+            x: this.#template.viewport?.window.x ?? null,
+            y: this.#template.viewport?.window.y ?? null,
+        })
+    }
+
+    get plot_args(): PlotArgs<TooltipContent> {
+        return this.#plot_args
+    }
+
+    get template(): PlotTemplate<TooltipContent> {
+        return this.#template
+    }
+
+    get composed_plot(): ComposedPlot<TooltipContent> | null {
+        return this.#composed_plot
+    }
+
+    /** Whether the latest compose succeeded for the current template, rather than retaining an older plot. */
+    get has_current_composition(): boolean {
+        return this.#has_current_composition
+    }
+
+    /**
+     * Replace the plot_args when its reference changes and rebuild the template atomically.
+     * Failed updates report an error and retain the previous template without committing the args.
+     */
+    update_plot_args(plot_args: PlotArgs<TooltipContent>): void {
+        if (plot_args === this.#plot_args) {
+            return
+        }
+
+        let template: PlotTemplate<TooltipContent>
+        try {
+            template = new_plot_template(plot_args)
+        } catch (error) {
+            this.#on_error({ phase: 'template', error })
+            return
+        }
+        this.interactions.update_axes(this.#template, template)
+        this.#plot_args = plot_args
+        this.#template = template
+        this.#has_current_composition = false
+    }
+
+    /**
+     * Compose the current template for its host environment. A failed composition leaves the last
+     * successfully composed plot available.
+     */
+    compose(environment: PlotEnvironment, viewport: Viewport = { x: null, y: null }): ComposedPlot<TooltipContent> | null {
+        this.#has_current_composition = false
+        viewport = compatible_viewport(viewport, this.#template)
+        const previous = this.#environment
+        let composed_plot = this.#composed_plot
+        const dpr_changed = previous?.device_pixel_ratio !== environment.device_pixel_ratio
+        const recompose = this.needs_compose(environment, viewport)
+        try {
+            if (!Number.isFinite(environment.device_pixel_ratio) || environment.device_pixel_ratio <= 0) {
+                throw new Error("plot: device pixel ratio must be positive and finite")
+            }
+            if (recompose) {
+                composed_plot = compose_plot(this.#template, environment.width, environment.height, environment.color_theme, viewport)
+            }
+        } catch (error) {
+            this.#on_error({ phase: 'compose', error })
+            return this.#composed_plot
+        }
+        this.#environment = { ...environment }
+        this.#last_composition_template = this.#template
+        this.#last_composition_viewport = { x: viewport.x === null ? null : [...viewport.x], y: viewport.y === null ? null : [...viewport.y] }
+        this.#composed_plot = composed_plot
+        this.#has_current_composition = true
+        if (recompose || dpr_changed) {
+            this.invalidate_draw()
+        }
+        return composed_plot
+    }
+
+    needs_compose(environment: PlotEnvironment, viewport: Viewport): boolean {
+        viewport = compatible_viewport(viewport, this.#template)
+        const previous = this.#environment
+        const template_changed = this.#last_composition_template !== this.#template
+        const dimensions_changed = previous?.width !== environment.width || previous.height !== environment.height
+        const theme_changed = previous?.color_theme !== environment.color_theme
+        const viewport_changed = viewport_moved(this.#last_composition_viewport, viewport)
+        return template_changed || dimensions_changed || theme_changed || viewport_changed
+    }
+
+    /** Attach or replace a surface; an already composed plot needs a fresh draw. */
+    set_draw_host(host: PlotDrawHost | null): void {
+        this.#draw_host = host
+        this.invalidate_draw()
+    }
+
+    /** Mark the latest composition for drawing at the host's next flush. */
+    invalidate_draw(): void {
+        this.#draw_dirty = true
+    }
+
+    /** Draw at most once per invalidation, using the latest successful composition. */
+    flush_draw(): void {
+        const host = this.#draw_host
+        const plot = this.#composed_plot
+
+        if (!this.#draw_dirty || host === null || plot === null) {
+            return
+        }
+        // Clear before drawing so a new invalidation during drawing survives until the next flush.
+        this.#draw_dirty = false
+        let ctx: CanvasContext
+        try {
+            ctx = host.prepare(plot.layout.width, plot.layout.height, this.#environment?.device_pixel_ratio ?? 1)
+        } catch (error) {
+            this.#on_error({ phase: 'draw', error })
+            return
+        }
+        this.draw(ctx)
+    }
+
+    /** Draw directly to the host canvas. A failed draw may leave partial pixels. */
+    draw(ctx: CanvasContext): void {
+        if (this.#composed_plot === null) {
+            this.#on_error({ phase: 'draw', error: new Error("plot: cannot draw before it has been composed") })
+            return
+        }
+        try {
+            draw_plot(ctx, this.#composed_plot)
+        } catch (error) {
+            this.#on_error({ phase: 'draw', error })
+        }
+    }
+}

--- a/plot/src/core/interaction_controller.ts
+++ b/plot/src/core/interaction_controller.ts
@@ -1,0 +1,373 @@
+import { cursor_position, find_hits, resolve_point_data, same_hits, selectable_hit, type NearestPoint, type PointerOffset } from "./interactions/hit"
+import { compatible_viewport, viewport_change, viewport_moved, type ViewportAxes } from "./interactions/viewport"
+import { resolve_tooltips, type ResolvedTooltip } from "./interactions/tooltip"
+import { resolve_highlights } from "./interactions/highlight"
+import { clamp_viewport, pan_frame, pan_viewport, published_claim, wheel_claim, zoom_viewport, zoomable_views, type PanSnapshot, type WheelClaim } from "./interactions/zoom_pan"
+import type { ComposedPlot, HighlightSpec, PointData, TooltipData, Viewport, ViewportChange, ViewportRequest, ZoomPan } from "./types"
+
+export type PanInput = {
+    phase: 'start' | 'move' | 'end' | 'cancel'
+    pointer: { x: number; y: number } | null
+}
+
+export type PanUpdate = {
+    started: boolean
+    changed: boolean
+    ended: boolean
+}
+
+/** Framework-independent interaction state for one plot controller. */
+export class PlotInteractionController<TooltipContent = unknown> {
+    readonly #get_composed_plot: () => ComposedPlot<TooltipContent> | null
+    #hovered: NearestPoint[] = []
+    #staged_viewport: Viewport
+    #committed_viewport: Viewport
+    #adopted_viewport_key: string | null = null
+    #pan_snapshot: PanSnapshot | null = null
+    #zoomed_this_visit = false
+    #pan_modifier_ready = false
+
+    constructor(get_composed_plot: () => ComposedPlot<TooltipContent> | null, initial_viewport: Viewport = { x: null, y: null }) {
+        this.#get_composed_plot = get_composed_plot
+        this.#staged_viewport = initial_viewport
+        this.#committed_viewport = initial_viewport
+    }
+
+    get staged_viewport(): Viewport {
+        return this.#staged_viewport
+    }
+
+    get committed_viewport(): Viewport {
+        return this.#committed_viewport
+    }
+
+    /** Stage gesture input immediately; the host decides when to commit a render. */
+    stage_viewport(next: Viewport): void {
+        this.#staged_viewport = next
+    }
+
+    commit_viewport(): Viewport {
+        this.#committed_viewport = this.#staged_viewport
+        return this.#committed_viewport
+    }
+
+    /** Adopt a window without reporting it; the host cancels pending work first. */
+    settle_viewport(next: Viewport): Viewport {
+        this.stage_viewport(next)
+        return this.commit_viewport()
+    }
+
+    /** Reconcile retained windows and stop changed axes from using an obsolete drag coordinate system. */
+    update_axes(previous: ViewportAxes, next: ViewportAxes): void {
+        this.#staged_viewport = compatible_viewport(this.#staged_viewport, next)
+        this.#committed_viewport = compatible_viewport(this.#committed_viewport, next)
+        if (this.#pan_snapshot === null) {
+            return
+        }
+        if (previous.x.kind !== next.x.kind) {
+            this.#pan_snapshot.x_axis_frame = null
+        }
+        if (previous.y.kind !== next.y.kind) {
+            this.#pan_snapshot.y_axis_frame = null
+        }
+    }
+
+    /** Apply an argument request once per key, preserving omitted axes and deferring during a drag. */
+    adopt_viewport_request(request: ViewportRequest | undefined): boolean {
+        const plot = this.#get_composed_plot()
+        if (request === undefined || plot === null || this.pan_in_progress) {
+            return false
+        }
+        const key = request.key === undefined ? 'mount only' : `key ${request.key}`
+        if (key === this.#adopted_viewport_key) {
+            return false
+        }
+        this.#adopted_viewport_key = key
+        const current = this.#staged_viewport
+        const effective = clamp_viewport(plot, {
+            x: request.window.x === undefined ? current.x : request.window.x,
+            y: request.window.y === undefined ? current.y : request.window.y,
+        })
+        if (!viewport_moved(current, effective)) {
+            return false
+        }
+        this.settle_viewport(effective)
+        return true
+    }
+
+    /** Reconcile fresh domains; return whether the host needs another composition. */
+    normalize_viewport(): boolean {
+        const plot = this.#get_composed_plot()
+        if (plot === null) {
+            return false
+        }
+        const committed = clamp_viewport(plot, this.#committed_viewport)
+        const staged = clamp_viewport(plot, this.#staged_viewport)
+        const changed = viewport_moved(this.#committed_viewport, committed)
+        if (changed) {
+            this.#committed_viewport = committed
+        }
+        // A throttled gesture may be ahead of the rendered window; preserve that newer movement.
+        if (viewport_moved(this.#staged_viewport, staged)) {
+            this.#staged_viewport = staged
+        }
+        return changed
+    }
+
+    reset_viewport(axes: { x: boolean; y: boolean }): boolean {
+        const current = this.#staged_viewport
+        const full: Viewport = { x: axes.x ? null : current.x, y: axes.y ? null : current.y }
+
+        if (!viewport_moved(current, full)) {
+            return false
+        }
+        this.settle_viewport(full)
+        return true
+    }
+
+    is_zoomed(axes: { x: boolean; y: boolean }): boolean {
+        return (axes.x && this.#committed_viewport.x !== null) || (axes.y && this.#committed_viewport.y !== null)
+    }
+
+    /** Resolve the staged window against the latest plot's full, unpinned domains. */
+    viewport_change(): ViewportChange | null {
+        const plot = this.#get_composed_plot()
+        return plot === null ? null : viewport_change(this.#staged_viewport, plot)
+    }
+
+    get pan_in_progress(): boolean {
+        return this.#pan_snapshot !== null
+    }
+
+    /** Apply a normalized drag phase; hosts render and schedule the resulting changes. */
+    handle_pan(input: PanInput, zoom_pan: ZoomPan): PanUpdate {
+        const result: PanUpdate = { started: false, changed: false, ended: false }
+        if (input.phase === 'start') {
+            if (input.pointer !== null && this.begin_pan(input.pointer, zoom_pan)) {
+                this.#pan_modifier_ready = false
+                this.on_mouse_leave()
+                result.started = true
+            }
+            return result
+        }
+        if (!this.pan_in_progress) {
+            return result
+        }
+        if (input.phase !== 'cancel' && input.pointer !== null) {
+            result.changed = this.advance_pan(input.pointer, zoom_pan)
+        }
+        if (input.phase === 'end' || input.phase === 'cancel') {
+            this.end_pan()
+            this.update_pointer_modifier(input.phase === 'end', zoom_pan)
+            result.ended = true
+        }
+        return result
+    }
+
+    /** Ignore hover during a drag; otherwise update hits and modifier readiness together. */
+    handle_hover(event: PointerOffset & { ctrlKey: boolean }, zoom_pan: ZoomPan): boolean {
+        if (this.pan_in_progress) {
+            return false
+        }
+        const previous = this.#hovered
+        const modifier_changed = this.update_pointer_modifier(event.ctrlKey, zoom_pan)
+        this.on_mouse_move(event)
+        return modifier_changed || previous !== this.#hovered
+    }
+
+    /** An accepted zoom clears stale hover; rejected or unchanged input preserves it. */
+    handle_wheel(event: PointerOffset & { deltaY: number; ctrlKey: boolean }, zoom_pan: ZoomPan): boolean {
+        if (!zoom_pan.enabled || (zoom_pan.modifier && !event.ctrlKey)) {
+            return false
+        }
+        if (!this.on_scroll(event, zoom_pan)) {
+            return false
+        }
+        this.on_mouse_leave()
+        return true
+    }
+
+    /** Ctrl belongs to zoom when modifier gating is configured, not to selection. */
+    handle_click(event: PointerOffset & { ctrlKey: boolean }, zoom_pan: ZoomPan): PointData | undefined {
+        if (zoom_pan.modifier && event.ctrlKey) {
+            return
+        }
+        return this.on_click(event)
+    }
+
+    /** Leaving clears hover and releases both modifier readiness and wheel ownership. */
+    leave_pointer(): void {
+        this.on_mouse_leave()
+        this.release_zoom()
+    }
+
+    /** Track modifier readiness independently of the host's rendered hover snapshot. */
+    update_pointer_modifier(ctrl_key: boolean, zoom_pan: ZoomPan): boolean {
+        const ready = this.#pan_enabled(zoom_pan) && zoom_pan.modifier && ctrl_key
+        if (ready === this.#pan_modifier_ready) {
+            return false
+        }
+        this.#pan_modifier_ready = ready
+        return true
+    }
+
+    /** Resolve cursor precedence from shared interaction state. */
+    cursor_style(zoom_pan: ZoomPan): string | undefined {
+        if (this.pan_in_progress) {
+            return 'grabbing'
+        }
+        if (this.#pan_enabled(zoom_pan) && this.#pan_modifier_ready) {
+            return 'all-scroll'
+        }
+        return this.has_selectable_hover ? 'pointer' : undefined
+    }
+
+    #pan_enabled(zoom_pan: ZoomPan): boolean {
+        const plot = this.#get_composed_plot()
+        if (!zoom_pan.enabled || plot === null) {
+            return false
+        }
+        return (zoom_pan.x && plot.x_full_domain !== null) || (zoom_pan.y && plot.y_full_domain !== null)
+    }
+
+    /** Capture the scales and pointer origin for an accepted drag. */
+    begin_pan(pointer: { x: number; y: number }, axes: { x: boolean; y: boolean }): boolean {
+        const plot = this.#get_composed_plot()
+
+        if (plot === null) {
+            return false
+        }
+        this.#pan_snapshot = pan_frame(zoomable_views(plot, axes), this.#staged_viewport, pointer)
+        return true
+    }
+
+    /** Stage a drag move; the host schedules a commit and report only when it moved. */
+    advance_pan(pointer: { x: number; y: number }, axes: { x: boolean; y: boolean }): boolean {
+        const snapshot = this.#pan_snapshot
+        const plot = this.#get_composed_plot()
+
+        if (snapshot === null || plot === null) {
+            return false
+        }
+
+        const before = this.#staged_viewport
+        const panned = pan_viewport(snapshot, zoomable_views(plot, axes), before, pointer)
+
+        if (!viewport_moved(before, panned)) {
+            return false
+        }
+        this.stage_viewport(panned)
+        return true
+    }
+
+    end_pan(): void {
+        this.#pan_snapshot = null
+        this.#pan_modifier_ready = false
+    }
+
+    get zoomed_this_visit(): boolean {
+        return this.#zoomed_this_visit
+    }
+
+    /** Stage an accepted wheel event, with offsets relative to the inner overlay. */
+    on_scroll(event: PointerOffset & { deltaY: number }, axes: { x: boolean; y: boolean }): boolean {
+        const plot = this.#get_composed_plot()
+
+        if (plot === null) {
+            return false
+        }
+        const before = this.#staged_viewport
+        const zoomed = zoom_viewport(zoomable_views(plot, axes), before, cursor_position(plot, event), event.deltaY)
+
+        if (!viewport_moved(before, zoomed)) {
+            return false
+        }
+        this.#zoomed_this_visit = true
+        this.stage_viewport(zoomed)
+        return true
+    }
+
+    /** Leaving the overlay releases the wheel ownership acquired during this visit. */
+    release_zoom(): void {
+        this.#pan_modifier_ready = false
+        this.#zoomed_this_visit = false
+    }
+
+    /** Use this render's plot and committed window, not a previous composition or staged gesture. */
+    wheel_claim(
+        plot: Pick<ComposedPlot<TooltipContent>, 'x_scale' | 'y_scale' | 'x_full_domain' | 'y_full_domain'> | null,
+        rendered: Viewport,
+        axes: { x: boolean; y: boolean },
+    ): WheelClaim {
+        if (plot === null) {
+            return 'none'
+        }
+        return published_claim(wheel_claim(zoomable_views(plot, axes), rendered), this.#zoomed_this_visit)
+    }
+
+    /** Resolve tooltip data/content from the latest composition and the host's rendered hover snapshot. */
+    resolve_tooltips(hits: NearestPoint[] = this.#hovered): ResolvedTooltip<TooltipContent>[] {
+        const plot = this.#get_composed_plot()
+        return plot === null ? [] : resolve_tooltips(plot, hits)
+    }
+
+    /** Resolve canvas geometry for the topmost rendered hover hit that supports a highlight. */
+    resolve_highlights(hits: NearestPoint[] = this.#hovered): HighlightSpec[] {
+        const plot = this.#get_composed_plot()
+        return plot === null ? [] : resolve_highlights(plot, hits)
+    }
+
+    get hovered(): NearestPoint[] {
+        return this.#hovered
+    }
+
+    get has_selectable_hover(): boolean {
+        const plot = this.#get_composed_plot()
+        return plot !== null && selectable_hit(plot, this.#hovered) !== null
+    }
+
+    /** Update hover state from a pointer move relative to the plot's inner overlay. */
+    on_mouse_move(event: PointerOffset): NearestPoint[] {
+        const plot = this.#get_composed_plot()
+
+        if (plot === null) {
+            return this.on_mouse_leave()
+        }
+        const hovered = find_hits(plot, cursor_position(plot, event))
+
+        if (!same_hits(this.#hovered, hovered)) {
+            this.#hovered = hovered
+        }
+        return this.#hovered
+    }
+
+    /** Select once and return the callback's point data for a host notification, independently of hover state. */
+    on_click(event: PointerOffset): PointData | undefined {
+        const plot = this.#get_composed_plot()
+
+        if (plot === null) {
+            return
+        }
+        const hit = selectable_hit(plot, find_hits(plot, cursor_position(plot, event)))
+
+        if (hit === null) {
+            return
+        }
+        const data = resolve_point_data(plot, hit)
+        const on_select = plot.series[hit.series_index]?.on_select
+
+        if (data !== undefined && on_select !== undefined) {
+            // Column-backed series omit row; retain the callback boundary's existing payload shape.
+            on_select(data as TooltipData<any>)
+        }
+        return data
+    }
+
+    /** Clear hover state when the pointer leaves the plot or a gesture takes ownership. */
+    on_mouse_leave(): NearestPoint[] {
+        if (this.#hovered.length > 0) {
+            this.#hovered = []
+        }
+        return this.#hovered
+    }
+}

--- a/plot/src/core/interactions/coordinator.ts
+++ b/plot/src/core/interactions/coordinator.ts
@@ -1,0 +1,104 @@
+import type { PlotController } from '../controller'
+import type { PanInput } from '../interaction_controller'
+import type { PointData, Viewport, ViewportChange } from '../types'
+import type { PointerOffset } from './hit'
+import { create_hover_schedule } from './hover_schedule'
+import { create_viewport_schedule } from './viewport_schedule'
+import { zoom_pan_enabled } from './zoom_pan'
+
+type InteractionHost<T, Input> = {
+    controller(): PlotController<T> | null
+    commit_mode: 'immediate' | 'throttled'
+    resolve_hover(input: Input): (PointerOffset & { ctrlKey: boolean }) | null
+    on_viewport_commit(viewport: Viewport): void
+    on_viewport_report(change: ViewportChange): void
+    on_hover_update(changed: boolean): void
+    on_hover_clear(): void
+    on_pointer_change(): void
+    on_pan_end?(): void
+}
+
+/** Own interaction schedulers and their connections; hosts supply input conversion and visible feedback. */
+export function create_interaction_coordinator<T, Input>(host: InteractionHost<T, Input>) {
+    const viewport = create_viewport_schedule({
+        interactions: () => host.controller()?.interactions ?? null,
+        commit_mode: host.commit_mode,
+        on_commit: host.on_viewport_commit,
+        on_report: host.on_viewport_report,
+    })
+    const hover = create_hover_schedule({
+        controller: host.controller,
+        resolve: host.resolve_hover,
+        on_update: host.on_hover_update,
+    })
+    const clear_hover = () => {
+        hover.clear()
+        host.on_hover_clear()
+    }
+
+    const reset = (): void => {
+        const controller = host.controller()
+        if (controller !== null) {
+            viewport.reset(controller.template.zoom_pan)
+        }
+    }
+
+    return {
+        reset,
+        move: hover.move,
+        clear_hover,
+        adopt_viewport: viewport.adopt,
+        reconcile_rendered_viewport: viewport.reconcile_rendered_viewport,
+        // A double-click resets only when at least one configured axis can zoom.
+        handle_double_click(): void {
+            const controller = host.controller()
+            if (controller !== null && zoom_pan_enabled(controller.template)) {
+                reset()
+            }
+        },
+        handle_click(input: PointerOffset & { ctrlKey: boolean }): PointData | undefined {
+            const controller = host.controller()
+            return controller?.interactions.handle_click(input, controller.template.zoom_pan)
+        },
+        // Discard pending work and release transient input state without reporting or rendering on teardown.
+        disconnect(): void {
+            viewport.cancel()
+            host.controller()?.interactions.end_pan()
+            hover.leave()
+        },
+        handle_pan(input: PanInput): void {
+            const controller = host.controller()
+            if (controller === null) {
+                return
+            }
+            const update = viewport.handle_pan(input, controller.template.zoom_pan)
+            if (update.started) {
+                clear_hover()
+                host.on_pointer_change()
+            }
+            if (update.ended) {
+                host.on_pointer_change()
+                host.on_pan_end?.()
+            }
+        },
+        handle_wheel(input: PointerOffset & { deltaY: number; ctrlKey: boolean }): void {
+            const controller = host.controller()
+            if (controller === null || !zoom_pan_enabled(controller.template)) {
+                return
+            }
+            const update = viewport.handle_wheel(input, controller.template.zoom_pan)
+            if (!update.changed) {
+                return
+            }
+            clear_hover()
+            if (update.visit_changed) {
+                host.on_pointer_change()
+            }
+        },
+        leave(): void {
+            hover.leave()
+            host.on_hover_clear()
+            host.on_pointer_change()
+        },
+    }
+}

--- a/plot/src/core/interactions/highlight.ts
+++ b/plot/src/core/interactions/highlight.ts
@@ -1,0 +1,168 @@
+import chroma from "chroma-js"
+import type { ColorTheme, ComposedPlot, HighlightSpec, Rect } from "../types"
+import { series_type } from "../registry"
+import type { NearestPoint } from "./hit"
+
+type HighlightBox = {
+    left: number
+    top: number
+    width: number
+    height: number
+    border_radius?: string
+}
+
+// Snap rectangle edges relative to the plot's explicit inner origin.
+export function resolve_rect_highlight_box(
+    spec: Extract<HighlightSpec, { shape: 'rect' }>,
+    origin: Pick<Rect, 'left' | 'top'>,
+): HighlightBox {
+    const x = spec.x - origin.left
+    const y = spec.y - origin.top
+    const left = Math.round(x)
+    const top = Math.round(y)
+
+    // Snap each edge independently, keeping sub-pixel rectangles at least one pixel wide and tall.
+    return {
+        left,
+        top,
+        width: Math.max(1, Math.round(x + spec.width) - left),
+        height: Math.max(1, Math.round(y + spec.height) - top),
+        border_radius: spec.border_radius,
+    }
+}
+
+// Expand CSS radius shorthand into clockwise corners, preserving separate horizontal/vertical radii.
+export function resolve_highlight_corner_radii(
+    value: string | undefined,
+    width: number,
+    height: number,
+): { x: number; y: number }[] {
+    const [horizontal, vertical = horizontal] = (value ?? '0').split('/')
+    const x = radius_values(horizontal, width)
+    const y = radius_values(vertical, height)
+
+    return x.map((radius, index) => ({ x: radius, y: y[index] }))
+}
+
+// Core bars supply pixel radii; percentages are relative to the rounded box on each axis.
+function radius_values(value: string, extent: number): number[] {
+    const values = value.trim().split(/\s+/).map(token => {
+        const radius = Math.max(0, parseFloat(token) || 0)
+        return token.endsWith('%') ? radius * extent / 100 : radius
+    })
+    const [top_left, top_right = top_left, bottom_right = top_left, bottom_left = top_right] = values
+
+    return [top_left, top_right, bottom_right, bottom_left]
+}
+
+// The highlight geometry for the topmost hovered point that defines one. A kind may hand back several shapes.
+export function resolve_highlights<TooltipContent>(plot: ComposedPlot<TooltipContent>, hovered: NearestPoint[]): HighlightSpec[] {
+    for (const hit of hovered) {
+        const series = plot.series[hit.series_index]
+
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime bounds guard for stale hover state
+        if (series === undefined || hit.point_index >= series.x.length) {
+            // possible if the plot changes under the cursor
+            continue
+        }
+
+        if (series.highlight === false) {
+            continue
+        }
+        const spec = series_type<TooltipContent>(series.kind).highlight_spec?.(series, hit.point_index, plot.x_scale, plot.y_scale, plot.inner)
+
+        if (spec === undefined || spec === null) {
+            continue
+        }
+        const specs = Array.isArray(spec) ? spec : [spec]
+
+        if (specs.length > 0) {
+            return specs
+        }
+    }
+    return []
+}
+
+const HOVER_DARKEN = 0.7
+const HOVER_LIGHTEN = 0.7
+const HOVER_ALPHA = 0.4
+
+// Preserve translucent or unparseable CSS colors; shade opaque highlights for the active theme.
+export function resolve_highlight_color(color: string, theme: ColorTheme): string {
+    if (is_translucent(color)) {
+        return color
+    }
+
+    try {
+        const shifted = theme === 'dark' ? chroma(color).brighten(HOVER_LIGHTEN) : chroma(color).darken(HOVER_DARKEN)
+        return shifted.alpha(HOVER_ALPHA).css()
+    } catch {
+        return color
+    }
+}
+
+// Whether a resolved CSS color is semi-transparent (alpha < 1).
+function is_translucent(color: string): boolean {
+    const normalized = color.trim().toLowerCase()
+
+    if (normalized === 'transparent') {
+        return true
+    }
+
+    if (normalized.startsWith('#')) {
+        return hex_has_alpha(normalized)
+    }
+    return functional_alpha_below_one(normalized)
+}
+
+// Alpha test for #rgba (4 digits) and #rrggbbaa (8 digits); #rgb / #rrggbb carry none.
+function hex_has_alpha(hex: string): boolean {
+    const digits = hex.slice(1)
+
+    if (digits.length === 4) {
+        return digits[3] !== 'f'
+    }
+
+    if (digits.length === 8) {
+        return digits.slice(6) !== 'ff'
+    }
+    return false
+}
+
+// Alpha test for rgba() / hsla() / rgb() / hsl(): the 4th comma value, or the token after `/` in modern syntax.
+function functional_alpha_below_one(color: string): boolean {
+    const open = color.indexOf('(')
+    const close = color.indexOf(')')
+
+    if (open === -1 || close === -1) {
+        return false
+    }
+    const args = color.slice(open + 1, close)
+    const alpha_token = alpha_component(args)
+
+    if (alpha_token === undefined) {
+        return false
+    }
+    return parse_alpha(alpha_token) < 1
+}
+
+// The alpha token from a color function's arg list, or undefined when it carries none.
+function alpha_component(args: string): string | undefined {
+    if (args.includes('/')) {
+        return args.split('/')[1]?.trim()
+    }
+    const parts = args.split(',')
+
+    if (parts.length === 4) {
+        return parts[3].trim()
+    }
+    return undefined
+}
+
+// Parse an alpha token to a 0..1 number: a bare number, or a percentage. NaN (unparseable) reads as opaque.
+function parse_alpha(token: string): number {
+    if (token.endsWith('%')) {
+        return parseFloat(token) / 100
+    }
+    return parseFloat(token)
+}

--- a/plot/src/core/interactions/hit.ts
+++ b/plot/src/core/interactions/hit.ts
@@ -1,0 +1,93 @@
+import { series_type } from "../registry"
+import type { ComposedPlot, PointData } from "../types"
+
+// A hit on a specific point of a composed series.
+export type NearestPoint = {
+    series_index: number
+    point_index: number
+}
+
+export type PointerOffset = { offsetX: number; offsetY: number }
+
+/** Whether two hit lists name the same points in the same order. */
+export function same_hits(a: NearestPoint[], b: NearestPoint[]): boolean {
+    if (a.length !== b.length) {
+        return false
+    }
+
+    for (let i = 0; i < a.length; i++) {
+        if (a[i].series_index !== b[i].series_index || a[i].point_index !== b[i].point_index) {
+            return false
+        }
+    }
+    return true
+}
+
+/** Convert overlay-relative pointer offsets into canvas coordinates. */
+export function cursor_position<TooltipContent>(plot: ComposedPlot<TooltipContent>, event: PointerOffset): { x: number; y: number } {
+    return {
+        x: plot.layout.margin_left + event.offsetX,
+        y: plot.layout.margin_top + event.offsetY,
+    }
+}
+
+/** Find one hit per series under the cursor, ordered from topmost-drawn series to bottommost. */
+export function find_hits<TooltipContent>(plot: ComposedPlot<TooltipContent>, cursor: { x: number; y: number }): NearestPoint[] {
+    const hits: NearestPoint[] = []
+
+    for (let series_index = plot.series.length - 1; series_index >= 0; series_index--) {
+        const series = plot.series[series_index]
+
+        if (series.hoverable === false) {
+            continue
+        }
+        const point_index = series_type<TooltipContent>(series.kind).tooltip_hit_test(series, cursor, plot.x_scale, plot.y_scale, plot.inner)
+
+        if (point_index !== null) {
+            hits.push({ series_index, point_index })
+        }
+    }
+    return hits
+}
+
+/** Return the topmost hovered point whose series has an on_select callback. */
+export function selectable_hit<TooltipContent>(plot: ComposedPlot<TooltipContent>, hits: NearestPoint[]): NearestPoint | null {
+    for (const hit of hits) {
+        if (plot.series[hit.series_index]?.on_select !== undefined) {
+            return hit
+        }
+    }
+    return null
+}
+
+/** Resolve the host callback payload for a hit point. */
+export function resolve_point_data<TooltipContent>(plot: ComposedPlot<TooltipContent>, point: NearestPoint): PointData | undefined {
+    const series = plot.series[point.series_index]
+
+    // A plot can change while a host is still rendering hover state from its previous composition.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- runtime bounds guard for stale host state
+    if (series === undefined || point.point_index >= series.x.length) {
+        return undefined
+    }
+    const point_index = point.point_index
+    const data: PointData = {
+        x: point_value(series.x, plot.x_categories, point_index),
+        y: point_value(series.y, plot.y_categories, point_index),
+    }
+    const row = series.rows?.[point_index]
+
+    if (row !== undefined) {
+        data.row = row
+    }
+    const label = series.labels?.[point_index]
+
+    if (label !== undefined) {
+        data.label = label
+    }
+    return data
+}
+
+function point_value(values: Float64Array, categories: string[] | undefined, index: number): number | string {
+    const raw = values[index]
+    return categories === undefined ? raw : (categories[raw] ?? raw)
+}

--- a/plot/src/core/interactions/hover_schedule.ts
+++ b/plot/src/core/interactions/hover_schedule.ts
@@ -1,0 +1,40 @@
+import debounce from 'lodash/debounce'
+import type { PlotController } from '../controller'
+import type { PointerOffset } from './hit'
+import { FRAME_THROTTLE, UPDATE_INTERVAL_MS } from './viewport_schedule'
+
+type HoverInput = PointerOffset & { ctrlKey: boolean }
+
+type HoverHost<T, Input> = {
+    controller(): PlotController<T> | null
+    resolve(input: Input): HoverInput | null
+    on_update(changed: boolean): void
+}
+
+/** Throttle hit testing and discard queued pointer work when hover is invalidated. */
+export function create_hover_schedule<T, Input>(host: HoverHost<T, Input>) {
+    const move = debounce((input: Input) => {
+        const controller = host.controller()
+        if (controller === null || controller.interactions.pan_in_progress) {
+            return
+        }
+        const pointer = host.resolve(input)
+        if (pointer === null) {
+            return
+        }
+        const changed = controller.interactions.handle_hover(pointer, controller.template.zoom_pan)
+        host.on_update(changed)
+    }, UPDATE_INTERVAL_MS, FRAME_THROTTLE)
+
+    return {
+        move,
+        clear(): void {
+            move.cancel()
+            host.controller()?.interactions.on_mouse_leave()
+        },
+        leave(): void {
+            move.cancel()
+            host.controller()?.interactions.leave_pointer()
+        },
+    }
+}

--- a/plot/src/core/interactions/tooltip.ts
+++ b/plot/src/core/interactions/tooltip.ts
@@ -1,0 +1,64 @@
+import type { ComposedPlot, PointData, TooltipData } from "../types"
+import { resolve_point_data, type NearestPoint } from "./hit"
+
+export type ResolvedTooltip<TooltipContent = unknown> =
+    | { kind: 'default'; lines: string[] }
+    | { kind: 'custom'; content: TooltipContent }
+
+/** Resolve opted-in tooltips in hit order, leaving host content opaque. */
+export function resolve_tooltips<TooltipContent>(plot: ComposedPlot<TooltipContent>, hits: NearestPoint[]): ResolvedTooltip<TooltipContent>[] {
+    const resolved: ResolvedTooltip<TooltipContent>[] = []
+
+    for (const hit of hits) {
+        const tooltip = plot.series[hit.series_index]?.tooltip
+
+        if (tooltip === undefined) {
+            continue
+        }
+        const data = resolve_point_data(plot, hit)
+
+        if (data === undefined) {
+            continue
+        }
+        if (tooltip === true) {
+            const lines = default_tooltip_lines(plot, data)
+            if (lines.length > 0) {
+                resolved.push({ kind: 'default', lines })
+            }
+        } else {
+            // Column-backed series retain the existing payload with row omitted.
+            resolved.push({ kind: 'custom', content: tooltip(data as TooltipData<any>) })
+        }
+    }
+    return resolved
+}
+
+function default_tooltip_lines<TooltipContent>(plot: ComposedPlot<TooltipContent>, data: PointData): string[] {
+    // the band side is whichever axis resolved to categories; the other side carries the value
+    const x_is_band = plot.x_categories !== undefined
+    const x_label = side_label(plot.x_axis?.label, 'x', data.label, !x_is_band)
+    const y_label = side_label(plot.y_axis?.label, 'y', data.label, x_is_band)
+    const lines: string[] = []
+
+    if (has_value(data.x)) {
+        lines.push(`${x_label}: ${data.x}`)
+    }
+
+    if (has_value(data.y)) {
+        lines.push(`${y_label}: ${data.y}`)
+    }
+    return lines
+}
+
+// Whether one side of a hit has a value to print
+function has_value(value: number | string): boolean {
+    return typeof value === 'string' || Number.isFinite(value)
+}
+
+// One side's tooltip label: a per-mark label wins on the value side, then the axis label, then the axis letter.
+function side_label(axis_label: string | undefined, fallback: string, mark_label: string | undefined, is_value_side: boolean): string {
+    if (is_value_side && mark_label !== undefined) {
+        return mark_label
+    }
+    return axis_label ?? fallback
+}

--- a/plot/src/core/interactions/viewport.ts
+++ b/plot/src/core/interactions/viewport.ts
@@ -1,0 +1,74 @@
+import type { AxisTemplate, AxisViewport, Domain, Viewport, ViewportChange } from "../types"
+
+export type ViewportAxes = { x: Pick<AxisTemplate, 'kind'>; y: Pick<AxisTemplate, 'kind'> }
+
+/** Retain usable windows after an axis change; incompatible axes return to their full extent. */
+export function compatible_viewport(viewport: Viewport, axes: ViewportAxes): Viewport {
+    const x = compatible_window(viewport.x, axes.x.kind)
+    const y = compatible_window(viewport.y, axes.y.kind)
+    return x === viewport.x && y === viewport.y ? viewport : { x, y }
+}
+
+function compatible_window(window: Domain | null, kind: AxisTemplate['kind']): Domain | null {
+    if (window === null || kind === 'category') {
+        return null
+    }
+    const [low, high] = window
+    if (!Number.isFinite(low) || !Number.isFinite(high) || low >= high) {
+        return null
+    }
+    return kind === 'log' && low <= 0 ? null : window
+}
+
+/**
+ * Whether a zoom moved either axis. Compared by value, not reference: a zoom clamped at an extent hands back a
+ * fresh window holding the same bounds, and that must not read as a move.
+ * @param before - the viewport before the wheel
+ * @param after - the viewport after it
+ * @returns true when the plot moved
+ */
+export function viewport_moved(before: Viewport, after: Viewport): boolean {
+    return !same_window(before.x, after.x) || !same_window(before.y, after.y)
+}
+
+/**
+ * Whether two axis windows cover the same bounds. Null is the full view, so it only matches null.
+ * @param before - one window, or null for the full view
+ * @param after - the other window
+ * @returns true when they're the same window
+ */
+function same_window(before: Domain | null, after: Domain | null): boolean {
+    if (before === null || after === null) {
+        return before === after
+    }
+    return before[0] === after[0] && before[1] === after[1]
+}
+
+/**
+ * The change to report to the caller, per axis. Reads the plot's OWN full domains, never the pinned ones from
+ * `zoomable_views`: a caller hears the real extent of an axis their `zoom_pan` opted out of, and `null` keeps
+ * meaning only "this axis is categorical".
+ * @param viewport - the window to report
+ * @param domains - the plot's full extents, null on a categorical axis
+ * @returns the per-axis change payload
+ */
+export function viewport_change(viewport: Viewport, domains: { x_full_domain: Domain | null; y_full_domain: Domain | null }): ViewportChange {
+    return {
+        x: axis_viewport(viewport.x, domains.x_full_domain),
+        y: axis_viewport(viewport.y, domains.y_full_domain),
+    }
+}
+
+/**
+ * One axis's reported viewport. An unzoomed axis reports its full extent as the window, since the caller can't
+ * derive it: it only exists after padding and d3's nice().
+ * @param override - the axis's window, or null for the full view
+ * @param full - the axis's full extent, or null when it's categorical
+ * @returns the axis payload, or null for a categorical axis
+ */
+function axis_viewport(override: Domain | null, full: Domain | null): AxisViewport | null {
+    if (full === null) {
+        return null
+    }
+    return { window: [...(override ?? full)], full: [...full] }
+}

--- a/plot/src/core/interactions/viewport_schedule.ts
+++ b/plot/src/core/interactions/viewport_schedule.ts
@@ -1,0 +1,125 @@
+import debounce from 'lodash/debounce'
+import type { PointerOffset } from './hit'
+import type { PanInput, PanUpdate, PlotInteractionController } from '../interaction_controller'
+import type { Viewport, ViewportChange, ViewportRequest, ZoomPan } from '../types'
+import { compatible_viewport, viewport_moved, type ViewportAxes } from './viewport'
+
+export const UPDATE_INTERVAL_MS = 40
+const REPORT_SETTLE_MS = 150
+export const FRAME_THROTTLE = { leading: true, trailing: true, maxWait: UPDATE_INTERVAL_MS }
+
+type ViewportHost<T> = {
+    interactions(): PlotInteractionController<T> | null
+    commit_mode: 'immediate' | 'throttled'
+    on_commit(viewport: Viewport): void
+    on_report(change: ViewportChange): void
+}
+
+/** Own viewport timing and cancellation; hosts supply rendering and callback delivery. */
+export function create_viewport_schedule<T>(host: ViewportHost<T>) {
+    const publish = () => {
+        const interactions = host.interactions()
+        if (interactions !== null) {
+            host.on_commit(interactions.commit_viewport())
+        }
+    }
+    const pending_commit = debounce(publish, UPDATE_INTERVAL_MS, FRAME_THROTTLE)
+    const pending_report = debounce(() => {
+        const change = host.interactions()?.viewport_change()
+        if (change !== undefined && change !== null) {
+            host.on_report(change)
+        }
+    }, REPORT_SETTLE_MS)
+
+    const cancel = () => {
+        pending_commit.cancel()
+        pending_report.cancel()
+    }
+
+    // Adopted requests replace pending gesture work without producing a change notification.
+    const adopt = (request: ViewportRequest | undefined): boolean => {
+        if (!host.interactions()?.adopt_viewport_request(request)) {
+            return false
+        }
+        cancel()
+        return true
+    }
+
+    // Stage immediately so successive gestures accumulate even before the next render.
+    const commit = (next: Viewport): void => {
+        host.interactions()?.stage_viewport(next)
+        if (host.commit_mode === 'immediate') {
+            publish()
+        } else {
+            pending_commit()
+        }
+    }
+
+    return {
+        // Only accepted movement schedules work; release flushes the final commit before its report.
+        handle_pan(input: PanInput, zoom_pan: ZoomPan): PanUpdate {
+            const interactions = host.interactions()
+            if (interactions === null) {
+                return { started: false, changed: false, ended: false }
+            }
+            const update = interactions.handle_pan(input, zoom_pan)
+            if (update.changed) {
+                commit(interactions.staged_viewport)
+                pending_report()
+            }
+            if (update.ended) {
+                pending_commit.flush()
+                pending_report.flush()
+            }
+            return update
+        },
+        // Report successful zooms after settling, and tell the host when wheel ownership changes.
+        handle_wheel(
+            input: PointerOffset & { deltaY: number; ctrlKey: boolean },
+            zoom_pan: ZoomPan,
+        ): { changed: boolean; visit_changed: boolean } {
+            const interactions = host.interactions()
+            if (interactions === null) {
+                return { changed: false, visit_changed: false }
+            }
+            const previous_visit = interactions.zoomed_this_visit
+            if (!interactions.handle_wheel(input, zoom_pan)) {
+                return { changed: false, visit_changed: false }
+            }
+            commit(interactions.staged_viewport)
+            pending_report()
+            return { changed: true, visit_changed: previous_visit !== interactions.zoomed_this_visit }
+        },
+        cancel,
+        adopt,
+        // Reconcile a host's render snapshot after composition, then apply any new request.
+        reconcile_rendered_viewport(
+            rendered: Viewport,
+            axes: ViewportAxes,
+            request: ViewportRequest | undefined,
+        ): Viewport {
+            const compatible = compatible_viewport(rendered, axes)
+            if (compatible !== rendered) {
+                pending_report.cancel()
+            }
+            const interactions = host.interactions()
+            if (interactions === null) {
+                return compatible
+            }
+            adopt(request)
+            interactions.normalize_viewport()
+            const committed = interactions.committed_viewport
+            return viewport_moved(rendered, committed) ? committed : rendered
+        },
+        // A successful reset renders and reports immediately; a no-op leaves pending work alone.
+        reset(axes: { x: boolean; y: boolean }): void {
+            if (!host.interactions()?.reset_viewport(axes)) {
+                return
+            }
+            cancel()
+            publish()
+            pending_report()
+            pending_report.flush()
+        },
+    }
+}

--- a/plot/src/core/interactions/zoom_pan.ts
+++ b/plot/src/core/interactions/zoom_pan.ts
@@ -1,0 +1,428 @@
+import type { AxisTemplate, Domain, Scale, Viewport, ZoomPan } from "../types"
+import { clamp_domain, LINEAR_SPACE, LOG_SPACE, type AxisSpace } from "../template/domain"
+
+// Zoom + pan math for the plot's viewport override.
+// Continuous axes carry a numeric full_domain and zoom/pan; a categorical axis passes it as null and holds.
+
+const ZOOM_SPEED = 0.0015 // zoom-factor sensitivity
+const MAX_ZOOM = 10000 // tightest zoom: the narrowest window is the full domain over this
+const ZOOM_LIMIT_SLACK = 1e-6 // relative tolerance for floating point round-off tolerance, so the tightest zoom doesn't read as room left
+
+export type WheelClaim = 'both' | 'up' | 'down' | 'none'
+
+export type CaptureConfiguration = {
+    wheel_capture: WheelClaim | null
+    wheel_modifier: 'ctrl' | 'none'
+    wheel_activation: 'hover' | 'settled'
+    wheel_delay: number
+    wheel_tolerance: number
+    wheel_reset_on_move: boolean
+    pointer_capture: 'mouse' | null
+    pointer_buttons: number[]
+    pointer_threshold: number
+    pointer_modifier: 'ctrl' | 'any'
+}
+
+/** Resolve interaction policy once; hosts translate it into Capture props or attributes. */
+export function resolve_capture_configuration(
+    enabled: boolean,
+    modifier: boolean,
+    wheel_claim: WheelClaim,
+): CaptureConfiguration {
+    return {
+        wheel_capture: enabled ? (modifier ? 'both' : wheel_claim) : null,
+        wheel_modifier: modifier ? 'ctrl' : 'none',
+        wheel_activation: modifier ? 'hover' : 'settled',
+        wheel_delay: 150,
+        wheel_tolerance: 5,
+        wheel_reset_on_move: false,
+        pointer_capture: enabled ? 'mouse' : null,
+        pointer_buttons: [0],
+        pointer_threshold: 3,
+        pointer_modifier: modifier ? 'ctrl' : 'any',
+    }
+}
+
+// a pan drag frame captured at pointer-down
+type PanAxisFrame = { domain: Domain; space_delta_per_pixel: number; space: AxisSpace }
+
+type AxisViews = {
+    x_scale: Scale
+    y_scale: Scale
+    x_full_domain: Domain | null
+    y_full_domain: Domain | null
+}
+
+export type PanSnapshot = {
+    x_axis_frame: PanAxisFrame | null
+    y_axis_frame: PanAxisFrame | null
+    pointer_origin: { x: number; y: number }
+}
+
+/** Enable gestures only when at least one selected axis is continuous. */
+export function zoom_pan_enabled(template: {
+    x: Pick<AxisTemplate, 'kind'>
+    y: Pick<AxisTemplate, 'kind'>
+    zoom_pan: ZoomPan
+}): boolean {
+    if (!template.zoom_pan.enabled) {
+        return false
+    }
+    const x_zoomable = template.zoom_pan.x && template.x.kind !== 'category'
+    const y_zoomable = template.zoom_pan.y && template.y.kind !== 'category'
+    return x_zoomable || y_zoomable
+}
+
+/**
+ * The views a gesture may actually move: an axis opted out of `zoom_pan` reads as having no full domain, which
+ * is exactly how a categorical axis already arrives here.
+ * @param views - the plot's scales and full domains
+ * @param axes - which axes zoom_pan may move
+ * @returns the views with an opted-out axis pinned
+ */
+export function zoomable_views(views: AxisViews, axes: { x: boolean; y: boolean }): AxisViews {
+    return {
+        x_scale: views.x_scale,
+        y_scale: views.y_scale,
+        x_full_domain: axes.x ? views.x_full_domain : null,
+        y_full_domain: axes.y ? views.y_full_domain : null,
+    }
+}
+
+/**
+ * A viewport held inside the plot's full extents, each axis in its own working space. Gesture windows are
+ * already inside; a caller's window may not be, and compose clamps only what it renders — so without this the
+ * hook's state would describe a window the plot isn't on, and `is_zoomed`, the wheel claim and the zoom
+ * anchor would all read from it.
+ * @param views - the plot's scales and full domains
+ * @param viewport - the window to hold, per axis
+ * @returns the clamped viewport
+ */
+export function clamp_viewport(views: AxisViews, viewport: Viewport): Viewport {
+    return {
+        x: clamp_axis_window(views.x_scale, views.x_full_domain, viewport.x),
+        y: clamp_axis_window(views.y_scale, views.y_full_domain, viewport.y),
+    }
+}
+
+/**
+ * One axis's window, held inside its full domain. An axis with no numeric domain holds nothing.
+ * @param scale - the axis's composed scale
+ * @param full_domain - the full unzoomed domain, or null for a categorical axis
+ * @param window - the window to hold, or null for the full view
+ * @returns the clamped window, or null for the full view
+ */
+function clamp_axis_window(scale: Scale, full_domain: Domain | null, window: Domain | null): Domain | null {
+    if (window === null || full_domain === null) {
+        return null
+    }
+    const space = axis_space(scale)
+    const full_lo = space.to(full_domain[0])
+    const full_hi = space.to(full_domain[1])
+    const clamped = clamp_domain([space.to(window[0]), space.to(window[1])], [full_lo, full_hi])
+
+    // a caller-supplied window that merely covers the full domain is the full view, so null it here too
+    if (clamped === null || is_full_view(clamped[1] - clamped[0], full_hi - full_lo)) {
+        return null
+    }
+    return from_space(clamped, space)
+}
+
+/**
+ * The viewport after a wheel zoom anchored at the cursor
+ * @param views - the plot's scales and full domains
+ * @param override - the current viewport (null on an axis = full view)
+ * @param cursor - the cursor position in plot pixels
+ * @param delta_y - the wheel event's deltaY
+ * @returns the new viewport
+ */
+export function zoom_viewport(views: AxisViews, override: Viewport, cursor: { x: number; y: number }, delta_y: number): Viewport {
+    const factor = zoom_factor(delta_y)
+    return {
+        x: zoom_axis(views.x_scale, views.x_full_domain, override.x, cursor.x, factor),
+        y: zoom_axis(views.y_scale, views.y_full_domain, override.y, cursor.y, factor),
+    }
+}
+
+/**
+ * Which wheel directions still zoom, so a host can hand the wheel back once the plot has run out - the same
+ * way a scroll container at its edge lets the page scroll on.
+ * @param views - the plot's scales and full domains
+ * @param override - the current viewport (null on an axis = full view)
+ * @returns the directions still available
+ */
+export function wheel_claim(views: AxisViews, override: Viewport): WheelClaim {
+    const zooms_in = axis_zooms_in(views.x_scale, views.x_full_domain, override.x)
+        || axis_zooms_in(views.y_scale, views.y_full_domain, override.y)
+    const zooms_out = axis_zooms_out(views.x_scale, views.x_full_domain, override.x)
+        || axis_zooms_out(views.y_scale, views.y_full_domain, override.y)
+
+    if (zooms_in && zooms_out) {
+        return 'both'
+    }
+
+    if (zooms_in) {
+        return 'up'
+    }
+
+    return zooms_out ? 'down' : 'none'
+}
+
+/**
+ * The claim to hand the UI thread: the directions still zoomable, or every direction once this visit has
+ * zoomed. A plot the user is actively zooming keeps the wheel at its extents too, rather than letting the page
+ * scroll out from under a gesture - only leaving the data area releases it. A plot that can't zoom at all
+ * (both axes categorical) never claims.
+ * @param zoomable - the directions the plot could still zoom
+ * @param zoomed_this_visit - whether a wheel has already moved the plot since the pointer arrived
+ * @returns the claim to publish
+ */
+export function published_claim(zoomable: WheelClaim, zoomed_this_visit: boolean): WheelClaim {
+    if (zoomable === 'none') {
+        return 'none'
+    }
+    return zoomed_this_visit ? 'both' : zoomable
+}
+
+/**
+ * The pan drag frame captured at pointer-down. Each axis's start window plus the pointer origin.
+ * @param views - the plot's scales and full domains
+ * @param override - the current viewport (null on an axis = full view)
+ * @param pointer_origin - the pointer position at pan start
+ * @returns the pan snapshot
+ */
+export function pan_frame(views: AxisViews, override: Viewport, pointer_origin: { x: number; y: number }): PanSnapshot {
+    return {
+        x_axis_frame: pan_axis_snapshot(views.x_scale, views.x_full_domain, override.x),
+        y_axis_frame: pan_axis_snapshot(views.y_scale, views.y_full_domain, override.y),
+        pointer_origin,
+    }
+}
+
+/**
+ * The viewport after a pan move. Shift each axis's snapshot window by the pointer delta since pan start.
+ * @param snapshot - the pan frame from pan_frame
+ * @param views - the plot's scales and full domains
+ * @param override - the current window per axis, which an axis that can't pan keeps
+ * @param pointer - the current pointer position
+ * @returns the new viewport
+ */
+export function pan_viewport(snapshot: PanSnapshot, views: AxisViews, override: Viewport, pointer: { x: number; y: number }): Viewport {
+    return {
+        x: pan_axis(snapshot.x_axis_frame, views.x_full_domain, override.x, pointer.x - snapshot.pointer_origin.x),
+        y: pan_axis(snapshot.y_axis_frame, views.y_full_domain, override.y, pointer.y - snapshot.pointer_origin.y),
+    }
+}
+
+/**
+ * Zoom factor from a wheel deltaY. `Math.exp` keeps the factor positive for any deltaY and makes zoom-in then zoom-out symmetric.
+ * @param delta_y - the wheel event's deltaY
+ * @returns the multiplicative zoom factor
+ */
+function zoom_factor(delta_y: number): number {
+    return Math.exp(delta_y * ZOOM_SPEED)
+}
+
+/**
+ * Per-axis zoom: a categorical axis keeps its override; a continuous one zooms around the cursor pixel position.
+ * @param scale - the axis's composed scale
+ * @param full_domain - the full unzoomed domain, or null for a categorical axis
+ * @param override - the current window, or null for the full view
+ * @param cursor_position - the cursor position in plot pixels
+ * @param zoom_factor - the multiplicative zoom factor
+ * @returns the new window, or null for the full view / an axis that doesn't zoom
+ */
+function zoom_axis(scale: Scale, full_domain: Domain | null, override: Domain | null, cursor_position: number, zoom_factor: number): Domain | null {
+    if (full_domain === null) {
+        return override
+    }
+    const range = scale_range(scale)
+
+    if (range === undefined) {
+        return override
+    }
+    const space = axis_space(scale)
+    const full_space: Domain = [space.to(full_domain[0]), space.to(full_domain[1])]
+    const override_space = to_space(override, space)
+    const anchor = anchor_in_space(override_space ?? full_space, range, cursor_position)
+    const window = zoom_domain(override_space, full_space, anchor, zoom_factor)
+    return from_space(window, space)
+}
+
+/**
+ * Whether this axis's window is still wider than the tightest zoom. Measured in the axis's working space, so a
+ * log axis is compared against the same span `zoom_domain` would cap it at.
+ * @param scale - the axis's composed scale
+ * @param full_domain - the full unzoomed domain, or null for a categorical axis
+ * @param override - the current window, or null for the full view
+ * @returns whether a zoom-in would still move this axis
+ */
+function axis_zooms_in(scale: Scale, full_domain: Domain | null, override: Domain | null): boolean {
+    if (full_domain === null) {
+        return false
+    }
+    const space = axis_space(scale)
+    const window: Domain = override ?? full_domain
+    const window_span = space.to(window[1]) - space.to(window[0])
+    const min_span = (space.to(full_domain[1]) - space.to(full_domain[0])) / MAX_ZOOM
+
+    return window_span > min_span * (1 + ZOOM_LIMIT_SLACK)
+}
+
+// Whether this axis's window is still narrower than the full domain.
+function is_full_view(window_span: number, full_span: number): boolean {
+    return window_span >= full_span * (1 - ZOOM_LIMIT_SLACK)
+}
+
+function axis_zooms_out(scale: Scale, full_domain: Domain | null, override: Domain | null): boolean {
+    // no full domain means the axis is pinned
+    if (full_domain === null || override === null) {
+        return false
+    }
+    const space = axis_space(scale)
+    const window_span = space.to(override[1]) - space.to(override[0])
+    const full_span = space.to(full_domain[1]) - space.to(full_domain[0])
+
+    return !is_full_view(window_span, full_span)
+}
+
+/**
+ * Snapshot a continuous axis's start window + data-per-pixel at pan start. Null for a categorical axis.
+ * @param scale - the axis's composed scale
+ * @param full_domain - the full unzoomed domain, or null for a categorical axis
+ * @param override - the current window, or null for the full view
+ * @returns the snapshot, or null for an axis that doesn't pan
+ */
+function pan_axis_snapshot(scale: Scale, full_domain: Domain | null, override: Domain | null): PanAxisFrame | null {
+    if (full_domain === null) {
+        return null
+    }
+    const space = axis_space(scale)
+    const dpp = space_delta_per_pixel(scale, space)
+
+    if (dpp === undefined) {
+        return null
+    }
+    const window: Domain = override ?? full_domain
+    return { domain: [space.to(window[0]), space.to(window[1])], space_delta_per_pixel: dpp, space }
+}
+
+/**
+ * Per-axis pan: shift the snapshot window by the pixel delta (converted to data units). An axis that can't pan
+ * keeps the window it is on, the same way `zoom_axis` does: a pinned axis holds its position, it doesn't lose it.
+ * @param snapshot - the axis's pan-start snapshot, or null
+ * @param full_domain - the full unzoomed domain, or null for a categorical or pinned axis
+ * @param override - this axis's current window, or null for the full view
+ * @param pixel_delta - the drag distance in pixels since pan start
+ * @returns the shifted window, the untouched one for an axis that doesn't pan, or null for the full extent
+ */
+function pan_axis(snapshot: PanAxisFrame | null, full_domain: Domain | null, override: Domain | null, pixel_delta: number): Domain | null {
+    if (snapshot === null || full_domain === null) {
+        return override
+    }
+    const { space } = snapshot
+    const full_space: Domain = [space.to(full_domain[0]), space.to(full_domain[1])]
+    const shifted = pan_domain(snapshot.domain, full_space, -snapshot.space_delta_per_pixel * pixel_delta)
+    return from_space(shifted, space)
+}
+
+// --- pure domain math (numeric windows) ---
+
+/**
+ * Scale the current window around `anchor` (the cursor position, in working-space coordinates) by factor, then
+ * clamp to full_domain. The zoom-in factor is capped so the window lands exactly on the tightest zoom and never below.
+ * A zoom-out that reaches the full extent returns null, not a window covering it
+ */
+function zoom_domain(override: Domain | null, full_domain: Domain, anchor: number, factor: number): Domain | null {
+    const current_domain = override ?? full_domain
+    const current_span = current_domain[1] - current_domain[0]
+    const full_span = full_domain[1] - full_domain[0]
+
+    const min_span = full_span / MAX_ZOOM // the narrowest span possible
+    const capped = Math.max(factor, min_span / current_span) // cap zoom-in at min_span
+
+    const lo = anchor + (current_domain[0] - anchor) * capped
+    const hi = anchor + (current_domain[1] - anchor) * capped
+    const next_window = clamp_domain([lo, hi], full_domain)
+
+    // clamp_domain already nulls a window at or wider than full; is_full_view additionally catches one that lands a hair short
+    if (next_window === null || is_full_view(next_window[1] - next_window[0], full_span)) {
+        return null
+    }
+    return next_window
+}
+
+/**
+ * Shift `start_domain` by `data_delta`, held inside `full`. At the full extent there's nothing to pan and it
+ * returns null.
+ */
+function pan_domain(start_domain: Domain, full: Domain, data_delta: number): Domain | null {
+    const span = start_domain[1] - start_domain[0]
+
+    if (span >= full[1] - full[0]) {
+        return null
+    }
+    const highest_low = full[1] - span
+    const low = Math.min(Math.max(start_domain[0] + data_delta, full[0]), highest_low)
+
+    return [low, low + span]
+}
+
+// --- scale ↔ pixel plumbing ---
+
+// data value at a pixel on a continuous scale; undefined for a categorical scale
+function pixel_to_data(scale: Scale, px: number): number | undefined {
+    if ('invert' in scale) {
+        return Number(scale.invert(px))
+    }
+    return undefined
+}
+
+// the scale's pixel range [start, end], stable across zoom.
+function scale_range(scale: { range(): number[] }): [number, number] | undefined {
+    const range = scale.range()
+    const start = range[0]
+    const end = range[range.length - 1]
+
+    if (typeof start !== 'number' || typeof end !== 'number' || start === end) {
+        return undefined
+    }
+    return [start, end]
+}
+
+// invert a cursor pixel to a working-space value within window_space
+function anchor_in_space(window_space: Domain, range: [number, number], cursor_position: number): number {
+    const [pixel_start, pixel_end] = range
+    const [window_lo, window_hi] = window_space
+
+    // how far the cursor sits along the pixel range: 0 at the start edge, 1 at the end edge
+    const cursor_fraction = (cursor_position - pixel_start) / (pixel_end - pixel_start)
+
+    // the value the same fraction of the way across the window is the one under the cursor
+    const window_span = window_hi - window_lo
+    return window_lo + cursor_fraction * window_span
+}
+
+// signed working-space units per pixel — constant per pixel in that space, so it stays exact when panning a log
+// axis (y is negative: pixels grow downward while data grows upward)
+function space_delta_per_pixel(scale: Scale, space: AxisSpace): number | undefined {
+    const at0 = pixel_to_data(scale, 0)
+    const at1 = pixel_to_data(scale, 1)
+
+    if (at0 === undefined || at1 === undefined) {
+        return undefined
+    }
+    return space.to(at1) - space.to(at0)
+}
+
+function axis_space(scale: Scale): AxisSpace {
+    return 'base' in scale ? LOG_SPACE : LINEAR_SPACE
+}
+
+function to_space(domain: Domain | null, space: AxisSpace): Domain | null {
+    return domain === null ? null : [space.to(domain[0]), space.to(domain[1])]
+}
+
+function from_space(domain: Domain | null, space: AxisSpace): Domain | null {
+    return domain === null ? null : [space.from(domain[0]), space.from(domain[1])]
+}

--- a/plot/src/core/presentation/plot.ts
+++ b/plot/src/core/presentation/plot.ts
@@ -1,0 +1,21 @@
+import type { Dimensions } from '../compose/layout'
+import type { ColorTheme, PlotTemplate } from '../types'
+import { should_invert_color } from '../template/color'
+
+const DARK_THEME_FILTER = 'invert(1) hue-rotate(180deg)'
+
+/** An unpinned wrapper side fills its container; a pinned side follows the resolved canvas size. */
+export function plot_wrapper_size(template: Partial<Dimensions>, canvas: Dimensions | null) {
+    return {
+        width: template.width === undefined ? '100%' : `${canvas?.width ?? template.width}px`,
+        height: template.height === undefined ? '100%' : `${canvas?.height ?? template.height}px`,
+    }
+}
+
+/** Invert dark-mode output only when the plot's color configuration calls for it. */
+export function plot_color_filter<T>(
+    template: Pick<PlotTemplate<T>, 'series' | 'background' | 'theme_invert'>,
+    theme: ColorTheme,
+): string | undefined {
+    return theme === 'dark' && should_invert_color(template) ? DARK_THEME_FILTER : undefined
+}

--- a/plot/src/core/presentation/reset_zoom.ts
+++ b/plot/src/core/presentation/reset_zoom.ts
@@ -1,0 +1,37 @@
+import type { PlotController } from '../controller'
+import type { ColorTheme, Rect, ThemeColor } from '../types'
+import { resolve_theme_color } from '../template/color'
+import { zoom_pan_enabled } from '../interactions/zoom_pan'
+
+const EDGE_INSET = 8
+const BACKGROUND: ThemeColor = {
+    light: 'rgba(242, 241, 242, 0.7)',
+    dark: 'rgba(18, 16, 19, 0.7)',
+}
+
+export const RESET_ZOOM_BUTTON = {
+    priority: 'secondary',
+    size: 'small',
+    label: 'Reset zoom',
+    iconTrailing: 'rotate-ccw',
+} as const
+
+/** Shared Anta button presentation; hosts mount it in their own overlay and stacking context. */
+export function reset_zoom_presentation<T>(controller: PlotController<T>, inner: Rect, theme: ColorTheme) {
+    return {
+        visible: zoom_pan_enabled(controller.template)
+            && controller.interactions.is_zoomed(controller.template.zoom_pan),
+        position: {
+            position: 'absolute' as const,
+            left: `${inner.left + EDGE_INSET}px`,
+            top: `${inner.top + EDGE_INSET}px`,
+        },
+        button: {
+            ...RESET_ZOOM_BUTTON,
+            style: {
+                backgroundColor: resolve_theme_color(BACKGROUND, theme),
+                padding: '5px',
+            },
+        },
+    }
+}

--- a/plot/src/core/presentation/tooltip.ts
+++ b/plot/src/core/presentation/tooltip.ts
@@ -1,0 +1,75 @@
+import type { Rect } from '../types'
+import type { ResolvedTooltip } from '../interactions/tooltip'
+
+export const TOOLTIP_OPTIONS = { follow: true, delay: 10 }
+export const TOOLTIP_DIVIDER_STYLE = {
+    border: '0',
+    borderTop: '1px solid rgba(160, 160, 160, 0.4)',
+    margin: '5px 0 4px',
+}
+
+type TooltipRenderer<Content, Body, Text> = {
+    custom(content: Content): Body | undefined
+    text(value: string): Text
+    line_break(): Body
+    divider(): Body
+    group(children: (Body | Text)[]): Body
+}
+
+/** Format default lines and separate valid bodies; hosts create nodes and validate custom content. */
+export function render_tooltip_bodies<Content, Body, Text>(
+    tooltips: ResolvedTooltip<Content>[],
+    renderer: TooltipRenderer<Content, Body, Text>,
+) {
+    const bodies: Body[] = []
+    for (const tooltip of tooltips) {
+        let body: Body | undefined
+        if (tooltip.kind === 'custom') {
+            body = renderer.custom(tooltip.content)
+        } else {
+            const lines: (Body | Text)[] = []
+            for (const line of tooltip.lines) {
+                if (lines.length > 0) {
+                    lines.push(renderer.line_break())
+                }
+                lines.push(renderer.text(line))
+            }
+            body = renderer.group(lines)
+        }
+        if (body === undefined) {
+            continue
+        }
+        if (bodies.length > 0) {
+            bodies.push(renderer.divider())
+        }
+        bodies.push(body)
+    }
+    const hidden = bodies.length === 0
+    return { bodies, hidden, style: hidden ? { display: 'none' } : undefined }
+}
+
+/** Mount as one body, wrapping only multiple entries so a single custom body keeps its identity. */
+export function render_tooltip_body<Content, Body, Text>(
+    tooltips: ResolvedTooltip<Content>[],
+    renderer: TooltipRenderer<Content, Body, Text>,
+) {
+    const { bodies, style } = render_tooltip_bodies(tooltips, renderer)
+    let body: Body | undefined
+    if (bodies.length === 1) {
+        body = bodies[0]
+    } else if (bodies.length > 1) {
+        body = renderer.group(bodies)
+    }
+    return { style, body }
+}
+
+/** Place the tooltip's input overlay at the inner-plot origin. */
+export function tooltip_wrapper_style(inner: Rect) {
+    return {
+        position: 'absolute' as const,
+        left: `${inner.left}px`,
+        top: `${inner.top}px`,
+        width: `${inner.right - inner.left}px`,
+        height: `${inner.bottom - inner.top}px`,
+    }
+}

--- a/plot/src/core/registry.ts
+++ b/plot/src/core/registry.ts
@@ -1,0 +1,25 @@
+import type { Series, SeriesType } from "./types"
+import { area_runtime } from "./series/area"
+import { bar_runtime } from "./series/bar"
+import { custom_runtime } from "./series/custom"
+import { line_runtime } from "./series/line"
+import { rect_runtime } from "./series/rect"
+import { rule_runtime } from "./series/rule"
+import { scatter_runtime } from "./series/scatter"
+
+const SERIES_TYPES: Record<Series['kind'], SeriesType> = {
+    scatter: scatter_runtime,
+    bar: bar_runtime,
+    rect: rect_runtime,
+    line: line_runtime,
+    rule: rule_runtime,
+    area: area_runtime,
+    custom: custom_runtime,
+}
+
+/** Look up core behavior for a registered series kind. */
+export function series_type<TooltipContent = unknown>(kind: Series['kind']): SeriesType<TooltipContent> {
+    // Runtime behavior does not inspect host tooltip content. The registry stores one implementation
+    // per kind and restores the caller's host-specific content type at this lookup boundary.
+    return SERIES_TYPES[kind] as unknown as SeriesType<TooltipContent>
+}

--- a/plot/src/core/render/axes.ts
+++ b/plot/src/core/render/axes.ts
@@ -1,0 +1,706 @@
+import type { Axis, BandScale, CanvasContext, ColorTheme, ContinuousScale, GridSpec, Layout, Rect, Scale } from "../types"
+import { resolve_text_color } from "../template/color"
+
+type ContinuousTickScale = {
+    (value: number | Date): number
+    ticks(count: number): (number | Date)[]
+    tickFormat(count: number, specifier?: string): (value: number | Date) => string
+    domain(): (number | Date)[]
+}
+
+const AXIS_STROKE = '#777'
+const TICK_LENGTH = 4
+const TICK_LABEL_SIZE = 10 // default tick-label font size (px)
+const TICK_LABEL_COLOR = '#777'
+const TICK_LABEL_PADDING = 3
+const AXIS_LABEL_SIZE = 12 // default axis-name font size (px)
+const AXIS_LABEL_COLOR = TICK_LABEL_COLOR // axis names share the tick-label gray
+const AXIS_LABEL_END_GAP = 10
+const AXIS_LABEL_CANVAS_PAD = 2
+const AXIS_LABEL_EDGE_PAD = 9
+export const X_TICK_PX_TARGET = 60
+export const Y_TICK_PX_TARGET = 50
+const GRID_COLOR = { light: '#e0e0e0', dark: '#777' }
+// min gap between adjacent tick labels before they're decimated
+const LABEL_GAP = 8
+
+function sans(size: number): string {
+    return `${size}px sans-serif`
+}
+
+function tick_label_size_of(axis: Axis | undefined): number {
+    return axis?.tick_label_size ?? TICK_LABEL_SIZE
+}
+
+function tick_label_font_of(axis: Axis | undefined): string {
+    return sans(tick_label_size_of(axis))
+}
+
+function x_tick_label_top(inner: Rect): number {
+    return inner.bottom + TICK_LENGTH + TICK_LABEL_PADDING
+}
+
+function x_tick_label_bottom(inner: Rect, axis: Axis | undefined): number {
+    return x_tick_label_top(inner) + tick_label_size_of(axis)
+}
+
+const DAY_MS = 86_400_000
+const DAY_TICKS_MAX_MS = 20 * DAY_MS
+const MONTH_TICKS_MAX_MS = 180 * DAY_MS
+const SI_THRESHOLD = 100_000
+
+/**
+ * Linear tick count for a pixel span, floored at 2 so narrow axes still show both endpoints.
+ * @param span_px - the axis's inner pixel length
+ * @param target - the target pixels per tick for the side
+ * @returns the number of ticks to request
+ */
+export function linear_tick_count(span_px: number, target: number): number {
+    return Math.max(2, Math.round(span_px / target))
+}
+
+function axis_tick_count(side: 'x' | 'y', inner: Rect): number {
+    const is_x = side === 'x'
+    const span = is_x ? inner.right - inner.left : inner.bottom - inner.top
+    return linear_tick_count(span, is_x ? X_TICK_PX_TARGET : Y_TICK_PX_TARGET)
+}
+
+/**
+ * Tick count for a time axis capped so a multi-day span keeps day-or-coarser ticks
+ * rather than sub-day ticks, whose bare times ("00:00" / "12:00") repeat across days.
+ * @param domain - the scale's [start, end]
+ * @param side - axis side
+ * @param inner - inner plot rect
+ * @returns the number of ticks to request
+ */
+function time_tick_count(domain: (number | Date)[], side: 'x' | 'y', inner: Rect): number {
+    const target = axis_tick_count(side, inner)
+    const span_ms = Math.abs(Number(domain[domain.length - 1]) - Number(domain[0]))
+
+    if (span_ms < 2 * DAY_MS) {
+        return target
+    }
+    const max_day_ticks = Math.floor(span_ms / DAY_MS)
+    return Math.max(2, Math.min(target, max_day_ticks))
+}
+
+/**
+ * Keep every Nth label so they don't collide, returning N. The tighter the pixel spacing between items,
+ * the larger N. x measures the widest label against the tick-label font; y uses a fixed line height.
+ * @param ctx - canvas context, for measuring x label widths
+ * @param side - axis side
+ * @param spacing - pixels between adjacent items
+ * @param labels - candidate labels (measured for x; ignored for y)
+ * @returns the step between kept labels
+ */
+function label_skip(ctx: CanvasContext, side: 'x' | 'y', spacing: number, labels: string[], tick_size: number, tick_font: string): number {
+    if (spacing <= 0) {
+        return 1
+    }
+
+    if (side === 'y') {
+        return Math.max(1, Math.ceil((tick_size + LABEL_GAP) / spacing))
+    }
+    // measure x label widths against the tick-label font, restoring whatever the caller had set
+    const prev_font = ctx.font
+    ctx.font = tick_font
+    let max_width = 0
+
+    for (const label of labels) {
+        const width = ctx.measureText(label).width
+
+        if (width > max_width) {
+            max_width = width
+        }
+    }
+    ctx.font = prev_font
+    return Math.max(1, Math.ceil((max_width + LABEL_GAP) / spacing))
+}
+
+/**
+ * Skip bands if category axis is too crowded and labels would overlap
+ * @param ctx - canvas context, used to measure x label widths against the tick-label font
+ * @param side - axis side
+ * @param scale - the band scale
+ * @param labels - the category labels in axis order
+ * @returns the number of bands to step between drawn labels
+ */
+function categorical_skip(ctx: CanvasContext, side: 'x' | 'y', scale: BandScale, labels: string[], tick_size: number, tick_font: string): number {
+    return label_skip(ctx, side, scale.step(), labels, tick_size, tick_font)
+}
+
+/**
+ * A single d3 time-format specifier for the whole axis, chosen from the tick interval so every tick reads
+ * the same way. d3's default mixes formats like "Fri 19" / "Jun 21" / "Jul".
+ * @param ticks - the tick values (Dates for a time scale)
+ * @returns a d3 time-format specifier
+ */
+function time_specifier(ticks: (number | Date)[]): string {
+    const first_ms = Number(ticks[0])
+    const second_ms = Number(ticks[1])
+    const interval = ticks.length > 1 ? Math.abs(second_ms - first_ms) : 0
+
+    if (interval > 0 && interval < DAY_MS) {
+        return '%H:%M'
+    }
+
+    if (interval < DAY_TICKS_MAX_MS) {
+        return '%b %d'
+    }
+
+    if (interval < MONTH_TICKS_MAX_MS) {
+        return '%b %Y'
+    }
+    return '%Y'
+}
+
+/**
+ * A d3 numeric-format specifier for the axis: SI-suffix ("~s" → "1k", "1.5M") once ticks reach the SI_THRESHOLD
+ * @param ticks - the tick values (numbers for a numeric scale)
+ * @returns a d3 format specifier, or undefined for d3's default
+ */
+function numeric_specifier(ticks: (number | Date)[]): string | undefined {
+    let max_abs = 0
+
+    for (const tick of ticks) {
+        const value = Number(tick)
+        max_abs = Math.max(max_abs, Math.abs(value))
+    }
+    return max_abs >= SI_THRESHOLD ? '~s' : undefined
+}
+
+/**
+ * Even skip between kept continuous labels so they don't collide and gaps stay regular.
+ * @param ctx - canvas context, for measuring x label widths
+ * @param side - axis side
+ * @param entries - all candidate ticks (pixel position + label), evenly spaced
+ * @returns the number of ticks to step between kept labels
+ */
+function continuous_skip(ctx: CanvasContext, side: 'x' | 'y', entries: { pos: number; label: string }[], tick_size: number, tick_font: string): number {
+    if (entries.length < 2) {
+        return 1
+    }
+    const spacing = Math.abs(entries[1].pos - entries[0].pos)
+    return label_skip(ctx, side, spacing, entries.map(entry => entry.label), tick_size, tick_font)
+}
+
+type ContinuousTicks = { pos: number; label: string }[]
+
+export type AxisChrome = {
+    layout: Layout
+    inner: Rect
+    x_axis: Axis | undefined
+    y_axis: Axis | undefined
+    x_scale: Scale
+    y_scale: Scale
+    theme: ColorTheme
+    chrome_color: string | undefined
+    x_ticks: ContinuousTicks | undefined
+    y_ticks: ContinuousTicks | undefined
+}
+
+/**
+ * Evenly-decimated continuous ticks with uniform labels, shared by grid and axis so both decimate together.
+ * Time scales get one format and numeric scales keep d3's format.
+ * @param ctx - canvas context, for measuring label widths
+ * @param side - axis side
+ * @param scale - the continuous scale
+ * @param inner - inner plot rect
+ * @returns the kept ticks as pixel position + label
+ */
+function continuous_tick_layout(ctx: CanvasContext, side: 'x' | 'y', scale: ContinuousScale, inner: Rect, axis: Axis | undefined): { pos: number; label: string }[] {
+    const tick_scale = scale as ContinuousTickScale
+    const domain = tick_scale.domain()
+    const is_time = domain[0] instanceof Date
+    const count = is_time ? time_tick_count(domain, side, inner) : axis_tick_count(side, inner)
+    const ticks = tick_scale.ticks(count)
+
+    if (ticks.length === 0) {
+        return []
+    }
+    const specifier = is_time ? time_specifier(ticks) : numeric_specifier(ticks)
+    const format = tick_scale.tickFormat(count, specifier)
+    const custom_format = axis?.tick_label_format
+    const entries = ticks.map((tick, i) => {
+        const label = custom_format !== undefined ? custom_format(Number(tick), i) : format(tick)
+
+        return { pos: tick_scale(tick), label }
+    })
+    const auto_stride = continuous_skip(ctx, side, entries, tick_label_size_of(axis), tick_label_font_of(axis))
+    const indices = decimated_indices(entries.length, auto_stride)
+    return indices.map(i => entries[i])
+}
+
+/**
+ * The continuous tick layout for a side, or undefined for a (categorical) band scale. Computed once
+ * per frame in draw() and passed to both the grid and the axis ticks
+ * @param ctx - canvas context, for measuring label widths
+ * @param side - axis side
+ * @param scale - the side's scale
+ * @param inner - inner plot rect
+ * @param axis - the side's axis spec, carrying an optional tick_label_format override
+ * @returns the tick layout, or undefined for a band scale
+ */
+export function continuous_axis_layout(ctx: CanvasContext, side: 'x' | 'y', scale: Scale, inner: Rect, axis: Axis | undefined): ContinuousTicks | undefined {
+    if ('bandwidth' in scale) {
+        return undefined
+    }
+    return continuous_tick_layout(ctx, side, scale, inner, axis)
+}
+
+/**
+ * Category labels for an axis, or empty when the axis is absent or not categorical.
+ * @param axis - the axis spec, or undefined
+ * @returns the category labels in axis order
+ */
+function category_labels(axis: Axis | undefined): string[] {
+    if (axis?.scale === 'category') {
+        return axis.categories ?? []
+    }
+    return []
+}
+
+function category_display_labels(axis: Axis | undefined): string[] {
+    const categories = category_labels(axis)
+    const format = axis?.tick_label_format
+
+    if (format === undefined) {
+        return categories
+    }
+    return categories.map((label, i) => format(label, i))
+}
+
+/**
+ * Pixel positions for ticks on a categorical axis, shared by tick and grid
+ * drawing so they align. Continuous positions come precomputed via continuous_axis_layout instead.
+ * @param ctx - canvas context, for measuring categorical label widths
+ * @param side - axis side
+ * @param scale - the band scale
+ * @param labels - the category labels in axis order
+ * @param edge_aligned - place lines at the delimiters between bands rather than centers
+ * @returns tick pixel positions along the side
+ */
+function categorical_tick_positions(ctx: CanvasContext, side: 'x' | 'y', scale: BandScale, axis: Axis | undefined, labels: string[], edge_aligned: boolean): number[] {
+    const positions: number[] = []
+    const half = scale.bandwidth() / 2
+    const domain = scale.domain()
+    const centers: number[] = []
+
+    for (let i = 0; i < domain.length; i++) {
+        const band_start = scale(domain[i])
+
+        if (band_start === undefined) {
+            continue
+        }
+        centers.push(band_start + half)
+    }
+
+    if (edge_aligned) {
+        for (let i = 0; i < centers.length - 1; i++) {
+            positions.push((centers[i] + centers[i + 1]) / 2)
+        }
+        return positions
+    }
+    const indices = categorical_tick_indices(ctx, side, scale, axis, labels)
+
+    for (const i of indices) {
+        if (i < centers.length) {
+            positions.push(centers[i])
+        }
+    }
+    return positions
+}
+
+function categorical_tick_indices(ctx: CanvasContext, side: 'x' | 'y', scale: BandScale, axis: Axis | undefined, labels: string[]): number[] {
+    const stride = categorical_skip(ctx, side, scale, labels, tick_label_size_of(axis), tick_label_font_of(axis))
+    return decimated_indices(labels.length, stride)
+}
+
+function decimated_indices(count: number, stride: number): number[] {
+    const indices: number[] = []
+
+    for (let i = 0; i < count; i += stride) {
+        indices.push(i)
+    }
+    return indices
+}
+
+/**
+ * Draw both axes, each picking linear or categorical ticks independently so a plot can mix them.
+ * An undefined axis paints no chrome on that side.
+ * @param ctx - canvas context
+ * @param chrome - the resolved per-frame chrome inputs
+ */
+export function draw_axes(ctx: CanvasContext, chrome: AxisChrome): void {
+    const { layout, inner, x_axis, y_axis, x_scale, y_scale, theme, chrome_color, x_ticks, y_ticks } = chrome
+
+    if (x_axis === undefined && y_axis === undefined) {
+        return
+    }
+
+    ctx.save()
+    ctx.strokeStyle = chrome_color ?? AXIS_STROKE
+    ctx.lineWidth = 1
+
+    const draw_x_line = x_axis !== undefined && x_axis.line !== false
+    const draw_y_line = y_axis !== undefined && y_axis.line !== false
+    draw_axis_lines(ctx, inner, draw_x_line, draw_y_line)
+
+    if (x_axis !== undefined) {
+        ctx.strokeStyle = tick_mark_color(x_axis, theme, chrome_color)
+        ctx.fillStyle = resolve_text_color(x_axis.tick_label_color, theme, TICK_LABEL_COLOR)
+        ctx.font = tick_label_font_of(x_axis)
+        const draw_x_mark = x_axis.tick_mark !== false
+
+        if (x_axis.scale === 'category') {
+            draw_ticks_categorical(ctx, 'x', x_axis, x_scale as BandScale, inner, draw_x_mark)
+        } else {
+            draw_ticks_continuous(ctx, 'x', inner, x_ticks ?? [], draw_x_mark)
+        }
+    }
+
+    if (y_axis !== undefined) {
+        ctx.strokeStyle = tick_mark_color(y_axis, theme, chrome_color)
+        ctx.fillStyle = resolve_text_color(y_axis.tick_label_color, theme, TICK_LABEL_COLOR)
+        ctx.font = tick_label_font_of(y_axis)
+        const draw_y_mark = y_axis.tick_mark !== false
+
+        if (y_axis.scale === 'category') {
+            draw_ticks_categorical(ctx, 'y', y_axis, y_scale as BandScale, inner, draw_y_mark)
+        } else {
+            draw_ticks_continuous(ctx, 'y', inner, y_ticks ?? [], draw_y_mark)
+        }
+    }
+
+    draw_axis_labels(ctx, layout, inner, x_axis, y_axis, theme)
+
+    ctx.restore()
+}
+
+/**
+ * Tick-mark stroke color: the chrome_color override when set, else match the axis line when it's drawn,
+ * else blend with the (theme-aware) grid.
+ * @param axis - the axis spec
+ * @param theme - the chrome theme
+ * @param chrome_color - the resolved chrome_color override, or undefined
+ * @returns the tick-mark stroke color
+ */
+function tick_mark_color(axis: Axis, theme: ColorTheme, chrome_color: string | undefined): string {
+    if (chrome_color !== undefined) {
+        return chrome_color
+    }
+    return axis.line === false ? GRID_COLOR[theme] : AXIS_STROKE
+}
+
+/**
+ * Draw gridlines at the tick positions across the inner plot area, driven by the scales.
+ * @param ctx - canvas context
+ * @param chrome - the resolved per-frame chrome inputs
+ */
+export function draw_grid(ctx: CanvasContext, chrome: AxisChrome, sides: { x: boolean; y: boolean }): void {
+    const { inner, x_scale, y_scale, x_axis, y_axis, theme, chrome_color, x_ticks, y_ticks } = chrome
+    ctx.save()
+    ctx.strokeStyle = chrome_color ?? GRID_COLOR[theme]
+    ctx.lineWidth = 1
+
+    // vertical lines at x ticks
+    if (sides.x) {
+        const x_edge_aligned = x_axis?.grid_align === 'edge'
+        const x_positions = grid_positions(ctx, 'x', x_scale, x_axis, x_ticks, x_edge_aligned)
+
+        for (const pos of x_positions) {
+            const x = grid_line_pos(pos, x_edge_aligned)
+            ctx.beginPath()
+            ctx.moveTo(x, inner.top)
+            ctx.lineTo(x, inner.bottom)
+            ctx.stroke()
+        }
+    }
+
+    // horizontal lines at y ticks
+    if (sides.y) {
+        const y_edge_aligned = y_axis?.grid_align === 'edge'
+        const y_positions = grid_positions(ctx, 'y', y_scale, y_axis, y_ticks, y_edge_aligned)
+
+        for (const pos of y_positions) {
+            const y = grid_line_pos(pos, y_edge_aligned)
+            ctx.beginPath()
+            ctx.moveTo(inner.left, y)
+            ctx.lineTo(inner.right, y)
+            ctx.stroke()
+        }
+    }
+    ctx.restore()
+}
+
+export function resolve_grid(grid: GridSpec | undefined): { x: boolean; y: boolean } {
+    if (typeof grid === 'boolean' || grid === undefined) {
+        return { x: grid === true, y: grid === true }
+    }
+    return { x: grid.x === true, y: grid.y === true }
+}
+
+/**
+ * Grid-line positions for a side. Precomputed continuous tick positions when present, else the band-scale positions for a categorical axis.
+ * @param ctx - canvas context, for measuring categorical label widths
+ * @param side - axis side
+ * @param scale - the side's scale
+ * @param axis - the axis spec, or undefined
+ * @param ticks - the precomputed continuous layout, or undefined for a band scale
+ * @param edge_aligned - band scale only: lines at band delimiters rather than centers
+ * @returns grid-line pixel positions along the side
+ */
+function grid_positions(ctx: CanvasContext, side: 'x' | 'y', scale: Scale, axis: Axis | undefined, ticks: ContinuousTicks | undefined, edge_aligned: boolean): number[] {
+    if (ticks !== undefined) {
+        return ticks.map(entry => entry.pos)
+    }
+    return categorical_tick_positions(ctx, side, scale as BandScale, axis, category_display_labels(axis), edge_aligned)
+}
+
+/**
+ * Get pixel position of the grid line. Center aligned grid
+ * lines snap to a pixel center so they render crisp under their
+ * label. Edge-aligned band dividers stay at the true band edge.
+ * @param pos - the raw scale position
+ * @param edge_aligned - whether the line sits at a band delimiter rather than a tick
+ * @returns the pixel coordinate to stroke at
+ */
+function grid_line_pos(pos: number, edge_aligned: boolean): number {
+    if (edge_aligned) {
+        return pos
+    }
+    return Math.round(pos) + 0.5
+}
+
+/**
+ * Draw the x and/or y axis lines on the inner rect edges. Rounded then +0.5 so a 1px stroke lands crisp on a
+ * device pixel (matching the grid) even when the inner edges or the device-pixel ratio are fractional.
+ * @param ctx - canvas context
+ * @param inner - inner plot rect
+ * @param draw_x - whether to draw the x axis line
+ * @param draw_y - whether to draw the y axis line
+ */
+function draw_axis_lines(ctx: CanvasContext, inner: Rect, draw_x: boolean, draw_y: boolean): void {
+    const left = Math.round(inner.left) + 0.5
+    const right = Math.round(inner.right) + 0.5
+    const top = Math.round(inner.top) + 0.5
+    const bottom = Math.round(inner.bottom) + 0.5
+    ctx.beginPath()
+
+    if (draw_x) {
+        ctx.moveTo(left, bottom)
+        ctx.lineTo(right, bottom)
+    }
+
+    if (draw_y) {
+        ctx.moveTo(left, top)
+        ctx.lineTo(left, bottom)
+    }
+    ctx.stroke()
+}
+
+/**
+ * Draw continuous ticks and their labels along a side, perpendicular to the axis.
+ * Covers linear, log, and time scales. Labels are uniformly formatted and evenly decimated,
+ * and the grid reads the same layout so tick marks, labels, and gridlines decimate together.
+ * @param ctx - canvas context
+ * @param side - axis side, selects span, spacing, alignment, and tick geometry
+ * @param scale - the continuous scale
+ * @param inner - inner plot rect
+ */
+function draw_ticks_continuous(ctx: CanvasContext, side: 'x' | 'y', inner: Rect, ticks: ContinuousTicks, draw_mark: boolean): void {
+    const is_x = side === 'x'
+    ctx.textAlign = is_x ? 'center' : 'right'
+    ctx.textBaseline = is_x ? 'top' : 'middle'
+
+    for (const entry of ticks) {
+        const pos = Math.round(entry.pos) + 0.5
+
+        if (is_x) {
+            if (draw_mark) {
+                ctx.beginPath()
+                ctx.moveTo(pos, inner.bottom + 0.5)
+                ctx.lineTo(pos, inner.bottom + 0.5 + TICK_LENGTH)
+                ctx.stroke()
+            }
+            ctx.fillText(entry.label, pos, x_tick_label_top(inner))
+        } else {
+            if (draw_mark) {
+                ctx.beginPath()
+                ctx.moveTo(inner.left + 0.5 - TICK_LENGTH, pos)
+                ctx.lineTo(inner.left + 0.5, pos)
+                ctx.stroke()
+            }
+            ctx.fillText(entry.label, inner.left - TICK_LENGTH - TICK_LABEL_PADDING, pos)
+        }
+    }
+}
+
+/**
+ * Draw one tick and label per category, centered in the band.
+ * @param ctx - canvas context
+ * @param side - axis side
+ * @param axis - the category axis spec
+ * @param scale - the band scale
+ * @param inner - inner plot rect
+ */
+function draw_ticks_categorical(
+    ctx: CanvasContext,
+    side: 'x' | 'y',
+    axis: Axis,
+    scale: BandScale,
+    inner: Rect,
+    draw_mark: boolean,
+): void {
+    const is_x = side === 'x'
+    const labels = category_display_labels(axis)
+    const half = scale.bandwidth() / 2
+    const indices = categorical_tick_indices(ctx, side, scale, axis, labels)
+    ctx.textAlign = is_x ? 'center' : 'right'
+    ctx.textBaseline = is_x ? 'top' : 'middle'
+
+    for (const i of indices) {
+        const band_start = scale(i)
+
+        if (band_start === undefined) {
+            continue
+        }
+        const pos = Math.round(band_start + half) + 0.5
+
+        if (is_x) {
+            if (draw_mark) {
+                ctx.beginPath()
+                ctx.moveTo(pos, inner.bottom + 0.5)
+                ctx.lineTo(pos, inner.bottom + 0.5 + TICK_LENGTH)
+                ctx.stroke()
+            }
+            ctx.fillText(labels[i], pos, x_tick_label_top(inner))
+        } else {
+            if (draw_mark) {
+                ctx.beginPath()
+                ctx.moveTo(inner.left + 0.5 - TICK_LENGTH, pos)
+                ctx.lineTo(inner.left + 0.5, pos)
+                ctx.stroke()
+            }
+            ctx.fillText(labels[i], inner.left - TICK_LENGTH - TICK_LABEL_PADDING, pos)
+        }
+    }
+}
+
+/**
+ * Draw each axis name centered in its margin band, across from the plot.
+ * @param ctx - canvas context
+ * @param layout - resolved layout
+ * @param inner - inner plot rect
+ * @param x_axis - x axis spec, or undefined
+ * @param y_axis - y axis spec, or undefined
+ */
+function draw_axis_labels(ctx: CanvasContext, layout: Layout, inner: Rect, x_axis: Axis | undefined, y_axis: Axis | undefined, theme: ColorTheme): void {
+    if (!x_axis?.label && !y_axis?.label) {
+        return
+    }
+
+    if (x_axis?.label) {
+        draw_x_axis_label(ctx, layout, inner, x_axis, theme)
+    }
+
+    if (y_axis?.label) {
+        draw_y_axis_label(ctx, layout, inner, y_axis, theme)
+    }
+}
+
+function set_axis_label_style(ctx: CanvasContext, axis: Axis, theme: ColorTheme): void {
+    ctx.fillStyle = resolve_text_color(axis.label_color, theme, AXIS_LABEL_COLOR)
+    ctx.font = sans(axis.label_size ?? AXIS_LABEL_SIZE)
+}
+
+/**
+ * Vertical center for the x-axis name: midway between the bottom of the x tick labels and the canvas edge.
+ * Falls back to centering in the whole bottom margin when that leaves the name no room.
+ * @param layout - resolved layout
+ * @param inner - inner plot rect
+ * @param axis - x axis spec
+ * @returns the y to draw the name at, with textBaseline 'middle'
+ */
+function x_axis_label_center_y(layout: Layout, inner: Rect, axis: Axis): number {
+    const ticks_bottom = x_tick_label_bottom(inner, axis)
+    const label_size = axis.label_size ?? AXIS_LABEL_SIZE
+
+    if (ticks_bottom + label_size > layout.height) {
+        return layout.height - layout.margin_bottom / 2
+    }
+    return (ticks_bottom + layout.height) / 2
+}
+
+/**
+ * Draw the x-axis name in the bottom margin, all positions horizontal: 'center' (default) centered,
+ * 'left' aligned to the axis start, 'right' aligned to the axis end.
+ * @param ctx - canvas context
+ * @param layout - resolved layout
+ * @param inner - inner plot rect
+ * @param axis - x axis spec (label already confirmed present by the caller)
+ */
+function draw_x_axis_label(ctx: CanvasContext, layout: Layout, inner: Rect, axis: Axis, theme: ColorTheme): void {
+    const label = axis.label
+
+    if (label === undefined) {
+        return
+    }
+    set_axis_label_style(ctx, axis, theme)
+    const position = axis.label_position ?? 'center'
+    const center_y = x_axis_label_center_y(layout, inner, axis)
+    ctx.textBaseline = 'middle'
+
+    if (position === 'left') {
+        ctx.textAlign = 'left'
+        ctx.fillText(label, inner.left, center_y)
+        return
+    }
+
+    if (position === 'right') {
+        ctx.textAlign = 'right'
+        ctx.fillText(label, inner.right, center_y)
+        return
+    }
+    ctx.textAlign = 'center'
+    ctx.fillText(label, (inner.left + inner.right) / 2, center_y)
+}
+
+/**
+ * Draw the y-axis label. center is the default (rotated -90), top/bottom read horizontally/
+ * @param ctx - canvas context
+ * @param layout - resolved layout
+ * @param inner - inner plot rect
+ * @param axis - y axis spec (label already confirmed present by the caller)
+ */
+function draw_y_axis_label(ctx: CanvasContext, layout: Layout, inner: Rect, axis: Axis, theme: ColorTheme): void {
+    const label = axis.label
+
+    if (label === undefined) {
+        return
+    }
+    set_axis_label_style(ctx, axis, theme)
+    const position = axis.label_position ?? 'center'
+
+    if (position === 'center') {
+        ctx.save()
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.translate(layout.margin_left / 2, (inner.top + inner.bottom) / 2)
+        ctx.rotate(-Math.PI / 2)
+        ctx.fillText(label, 0, 0)
+        ctx.restore()
+        return
+    }
+    const text_width = ctx.measureText(label).width
+    const right_edge = Math.max(inner.left - AXIS_LABEL_END_GAP, AXIS_LABEL_CANVAS_PAD + text_width)
+    ctx.textAlign = 'right'
+
+    if (position === 'top') {
+        ctx.textBaseline = 'bottom'
+        ctx.fillText(label, right_edge, inner.top - AXIS_LABEL_EDGE_PAD)
+        return
+    }
+    ctx.textBaseline = 'top'
+    ctx.fillText(label, right_edge, inner.bottom + AXIS_LABEL_EDGE_PAD)
+}

--- a/plot/src/core/render/band.ts
+++ b/plot/src/core/render/band.ts
@@ -1,0 +1,15 @@
+export const DEFAULT_BAND_INSET_FRACTION = 1 / 6
+
+/**
+ * The band interval [start, start + extent] after applying a per-series inset.
+ * @param start - the band's scale-start pixel
+ * @param bandwidth - the full band width in pixels (positive)
+ * @param inset - pixels trimmed from each side, or undefined for the default fraction
+ * @returns the inset start and extent
+ */
+export function inset_band(start: number, bandwidth: number, inset: number | undefined): { start: number; extent: number } {
+    const raw = inset ?? bandwidth * DEFAULT_BAND_INSET_FRACTION
+    const clamped = Math.min(Math.max(0, raw), bandwidth / 2)
+
+    return { start: start + clamped, extent: bandwidth - 2 * clamped }
+}

--- a/plot/src/core/render/canvas.ts
+++ b/plot/src/core/render/canvas.ts
@@ -1,0 +1,155 @@
+import type { CanvasContext, ComposedPlot, Layout, Rect, RenderContext } from "../types"
+import { draw_axes, draw_grid, resolve_grid, continuous_axis_layout, type AxisChrome } from "./axes"
+import { series_type } from "../registry"
+import { DEFAULT_SERIES_COLOR, resolve_text_color } from "../template/color"
+
+// Paint function: (context, plot) to pixels, on a CanvasRenderingContext2D or
+// OffscreenCanvasRenderingContext2D so the same code runs in a Worker. No preact, no DOM
+// globals. Per-series drawing is dispatched through the registry. `draw` is idempotent via
+// save/restore.
+
+const TITLE_SIZE = 14
+const TITLE_COLOR = '#000'
+const BORDER_COLOR = '#777'
+
+/** Convert CSS dimensions to backing-store pixels using the same rounding for every canvas. */
+export function canvas_pixel_size(width: number, height: number, dpr: number): { width: number; height: number } {
+    return { width: Math.round(width * dpr), height: Math.round(height * dpr) }
+}
+
+/** Resize only when backing dimensions change, avoiding unnecessary canvas-state resets. */
+export function resize_canvas(canvas: CanvasContext['canvas'], width: number, height: number, dpr: number): void {
+    const pixels = canvas_pixel_size(width, height, dpr)
+    if (canvas.width !== pixels.width || canvas.height !== pixels.height) {
+        canvas.width = pixels.width
+        canvas.height = pixels.height
+    }
+}
+
+/** Prepare either canvas context to draw in CSS-pixel coordinates. */
+export function prepare_canvas_context(ctx: CanvasContext, width: number, height: number, dpr: number): void {
+    resize_canvas(ctx.canvas, width, height, dpr)
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+}
+
+/**
+ * Paint a ComposedPlot to the canvas: background, grid, title, axes, each series, then border. Idempotent via save/restore.
+ * @param ctx - canvas context
+ * @param plot - the ComposedPlot to render
+ */
+export function draw<TooltipContent = unknown>(ctx: CanvasContext, plot: ComposedPlot<TooltipContent>): void {
+    ctx.save()
+    try {
+        const { layout, inner, x_scale, y_scale } = plot
+
+        ctx.clearRect(0, 0, layout.width, layout.height)
+
+        if (typeof plot.background === 'string') {
+            draw_background(ctx, inner, plot.background)
+        }
+
+        // continuous tick layout is shared by the grid and the axis ticks, so compute it once here
+        const chrome: AxisChrome = {
+            layout,
+            inner,
+            x_axis: plot.x_axis,
+            y_axis: plot.y_axis,
+            x_scale,
+            y_scale,
+            theme: plot.chrome_theme,
+            chrome_color: plot.chrome_color,
+            x_ticks: continuous_axis_layout(ctx, 'x', x_scale, inner, plot.x_axis),
+            y_ticks: continuous_axis_layout(ctx, 'y', y_scale, inner, plot.y_axis),
+        }
+
+        // grid sits above the background, below axes and series
+        const grid = resolve_grid(plot.grid)
+
+        if (grid.x || grid.y) {
+            draw_grid(ctx, chrome, grid)
+        }
+
+        if (plot.title) {
+            const title_color = resolve_text_color(plot.title_color, plot.chrome_theme, TITLE_COLOR)
+            draw_title(ctx, layout, inner, plot.title, plot.title_size ?? TITLE_SIZE, title_color)
+        }
+        draw_axes(ctx, chrome)
+
+        for (let series of plot.series) {
+            const render: RenderContext = {
+                ctx,
+                inner,
+                x_scale,
+                y_scale,
+                color: series.color ?? DEFAULT_SERIES_COLOR,
+                x_categories: plot.x_categories,
+                y_categories: plot.y_categories,
+            }
+            ctx.save()
+            ctx.beginPath()
+            ctx.rect(inner.left, inner.top, inner.right - inner.left, inner.bottom - inner.top)
+            ctx.clip()
+
+            try {
+                series_type<TooltipContent>(series.kind).paint(series, render)
+            } finally {
+                ctx.restore()
+            }
+        }
+
+        if (plot.border !== false) {
+            draw_border(ctx, inner, layout, plot.chrome_color ?? BORDER_COLOR)
+        }
+    } finally {
+        ctx.restore()
+    }
+}
+
+/**
+ * Fill the inner rect only, leaving the margin transparent.
+ * @param ctx - canvas context
+ * @param inner - inner plot rect
+ * @param color - the resolved fill color
+ */
+function draw_background(ctx: CanvasContext, inner: Rect, color: string): void {
+    ctx.save()
+    ctx.fillStyle = color
+    ctx.fillRect(inner.left, inner.top, inner.right - inner.left, inner.bottom - inner.top)
+    ctx.restore()
+}
+
+/**
+ * Draw a full frame around the plot area. Axis lines sit on its bottom and left edges.
+ * @param ctx - canvas context
+ * @param inner - inner plot rect
+ * @param layout - resolved layout
+ */
+function draw_border(ctx: CanvasContext, inner: Rect, layout: Layout, color: string): void {
+    ctx.save()
+    ctx.strokeStyle = color
+    ctx.lineWidth = 1
+    // round then +0.5 so the frame lands crisp on a device pixel
+    const left = Math.max(Math.round(inner.left) + 0.5, 0.5)
+    const top = Math.max(Math.round(inner.top) + 0.5, 0.5)
+    const right = Math.min(Math.round(inner.right) + 0.5, layout.width - 0.5)
+    const bottom = Math.min(Math.round(inner.bottom) + 0.5, layout.height - 0.5)
+    ctx.strokeRect(left, top, right - left, bottom - top)
+    ctx.restore()
+}
+
+/**
+ * Draw the title centered over the plot area, in the top margin band.
+ * @param ctx - canvas context
+ * @param layout - resolved layout
+ * @param inner - inner plot rect
+ * @param title - title text
+ */
+function draw_title(ctx: CanvasContext, layout: Layout, inner: Rect, title: string, size: number, color: string): void {
+    ctx.save()
+    ctx.fillStyle = color
+    ctx.font = `${size}px sans-serif`
+    ctx.textAlign = 'center'
+    ctx.textBaseline = 'middle'
+    ctx.fillText(title, (inner.left + inner.right) / 2, layout.margin_top / 2)
+    ctx.restore()
+}

--- a/plot/src/core/render/highlight.ts
+++ b/plot/src/core/render/highlight.ts
@@ -1,0 +1,73 @@
+import type { CanvasContext, ColorTheme, ComposedPlot, HighlightSpec, Rect } from '../types'
+import {
+    resolve_highlight_color, resolve_rect_highlight_box, resolve_highlight_corner_radii,
+} from '../interactions/highlight'
+import { draw_mark } from './mark'
+import { prepare_canvas_context } from './canvas'
+
+/** Refresh a highlight surface, resolving geometry after clearing so failed resolution leaves no stale image. */
+export function update_highlight_canvas(
+    ctx: CanvasContext,
+    plot: Pick<ComposedPlot, 'layout' | 'inner' | 'chrome_theme'> | null,
+    dpr: number,
+    resolve_specs: () => HighlightSpec[],
+): void {
+    if (plot === null) {
+        clear_highlights(ctx)
+        return
+    }
+    prepare_canvas_context(ctx, plot.layout.width, plot.layout.height, dpr)
+    clear_highlights(ctx)
+    draw_highlights(ctx, resolve_specs(), plot.inner, plot.chrome_theme)
+}
+
+/** Clear the entire backing store independently of the current DPR transform. */
+export function clear_highlights(ctx: CanvasContext): void {
+    ctx.save()
+    try {
+        ctx.setTransform(1, 0, 0, 1, 0, 0)
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height)
+    } finally {
+        ctx.restore()
+    }
+}
+
+/** Paint highlight specs within the plot bounds, preserving the caller's canvas state. */
+export function draw_highlights(
+    ctx: CanvasContext,
+    specs: HighlightSpec[],
+    inner: Rect,
+    theme: ColorTheme,
+): void {
+    ctx.save()
+    try {
+        ctx.beginPath()
+        ctx.rect(inner.left, inner.top, inner.right - inner.left, inner.bottom - inner.top)
+        ctx.clip()
+
+        for (const spec of specs) {
+            ctx.fillStyle = resolve_highlight_color(spec.color, theme)
+            if (spec.shape === 'mark') {
+                draw_mark(ctx, spec.mark, spec.cx, spec.cy, spec.r, undefined)
+            } else {
+                draw_rect_highlight(ctx, spec, inner)
+            }
+        }
+    } finally {
+        ctx.restore()
+    }
+}
+
+// Match the old DOM overlay: snap relative to its origin and keep thin shapes at least one CSS pixel.
+function draw_rect_highlight(
+    ctx: CanvasContext,
+    spec: Extract<HighlightSpec, { shape: 'rect' }>,
+    inner: Rect,
+): void {
+    const { left, top, width, height } = resolve_rect_highlight_box(spec, inner)
+    const radii = resolve_highlight_corner_radii(spec.border_radius, width, height)
+
+    ctx.beginPath()
+    ctx.roundRect(inner.left + left, inner.top + top, width, height, radii)
+    ctx.fill()
+}

--- a/plot/src/core/render/hit.ts
+++ b/plot/src/core/render/hit.ts
@@ -1,0 +1,50 @@
+import type { Scale } from "../types"
+import { pixel_resolver } from "./pixel_resolver"
+
+// floor on the hover radius, so a small mark keeps a forgiving hitbox even when drawn smaller than this
+const MIN_HIT_RADIUS = 8
+
+/**
+ * The point under the cursor, or null: the nearest point whose distance is within its hit radius. Shared
+ * by the scatter and line hover tests. radius_for(i) gives point i's drawn radius; each is floored to
+ * MIN_HIT_RADIUS so small marks stay hittable, and where hit regions overlap the nearest point wins.
+ * @param series - the x / y pixel-space columns
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param radius_for - point i's drawn radius in pixels
+ * @returns the point index under the cursor, or null
+ */
+export function nearest_point_hit(series: { x: Float64Array; y: Float64Array }, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale, radius_for: (i: number) => number): number | null {
+    const resolve_x = pixel_resolver(x_scale, series.x)
+    const resolve_y = pixel_resolver(y_scale, series.y)
+
+    let hit: number | null = null
+    let best_distance_squared = Infinity
+
+    for (let i = 0; i < series.x.length; i++) {
+        const center_x = resolve_x(i)
+
+        if (center_x === undefined) {
+            continue
+        }
+        const center_y = resolve_y(i)
+
+        if (center_y === undefined) {
+            continue
+        }
+        const dx = center_x - cursor.x
+        const dy = center_y - cursor.y
+        const distance_squared = dx * dx + dy * dy
+        const hit_radius = Math.max(radius_for(i), MIN_HIT_RADIUS)
+        const within_hit = distance_squared <= hit_radius * hit_radius
+        const is_nearest = distance_squared < best_distance_squared
+
+        if (within_hit && is_nearest) {
+            best_distance_squared = distance_squared
+            hit = i
+        }
+    }
+
+    return hit
+}

--- a/plot/src/core/render/mark.ts
+++ b/plot/src/core/render/mark.ts
@@ -1,0 +1,91 @@
+import type { CanvasContext, MarkShape } from "../types"
+
+const STROKE_AUTO_FRACTION = 0.1 // border width as a fraction of the mark diameter
+const STROKE_MIN_WIDTH = 0.5
+const STROKE_MAX_WIDTH = 1.5
+
+/**
+ * Draw a filled mark, with an optional border. Shared by scatter dots and line vertex markers. The caller
+ * sets the fill color (`ctx.fillStyle`, which may vary per row); the border color / width come from `stroke`.
+ * An unpinned stroke width auto-scales to the mark diameter so it stays proportionate across sizes.
+ * @param ctx - canvas context
+ * @param shape - the mark shape
+ * @param cx - center x in pixels
+ * @param cy - center y in pixels
+ * @param radius - the mark radius in pixels
+ * @param stroke - the resolved border { color, width? }, or undefined for no border
+ */
+export function draw_mark(ctx: CanvasContext, shape: MarkShape, cx: number, cy: number, radius: number, stroke: { color: string; width?: number } | undefined): void {
+    trace_mark(ctx, shape, cx, cy, radius)
+    ctx.fill()
+
+    if (stroke === undefined) {
+        return
+    }
+    ctx.strokeStyle = stroke.color
+    ctx.lineWidth = stroke.width ?? mark_stroke_width(radius)
+    ctx.stroke()
+}
+
+/**
+ * Derive a mark's border width from its radius, scaling with the diameter and clamped, so an unpinned
+ * stroke stays proportionate across mark sizes.
+ * @param radius - the mark radius in pixels
+ * @returns the clamped stroke width in pixels
+ */
+function mark_stroke_width(radius: number): number {
+    const derived = radius * 2 * STROKE_AUTO_FRACTION
+    return Math.max(STROKE_MIN_WIDTH, Math.min(derived, STROKE_MAX_WIDTH))
+}
+
+// diamond is a square rotated 45°: side matches the square, so its half-diagonal is radius · √2
+export const DIAMOND_HALF_DIAGONAL = Math.SQRT2
+
+// upward equilateral triangle with side 2·radius
+const TRIANGLE_HALF_BASE = 1
+export const TRIANGLE_APEX_RISE = 2 / Math.sqrt(3)
+export const TRIANGLE_BASE_DROP = 1 / Math.sqrt(3)
+export const TRIANGLE_SIZE_SCALE = 1.2
+
+/**
+ * Trace a mark's outline as the current path (draw_mark fills / strokes it).
+ * @param ctx - canvas context
+ * @param shape - the mark shape
+ * @param cx - center x in pixels
+ * @param cy - center y in pixels
+ * @param radius - the mark radius in pixels
+ */
+function trace_mark(ctx: CanvasContext, shape: MarkShape, cx: number, cy: number, radius: number): void {
+    ctx.beginPath()
+
+    switch (shape) {
+        case 'square':
+            ctx.rect(cx - radius, cy - radius, radius * 2, radius * 2)
+            break
+
+        case 'diamond': {
+            const half_diagonal = radius * DIAMOND_HALF_DIAGONAL
+            ctx.moveTo(cx, cy - half_diagonal)
+            ctx.lineTo(cx + half_diagonal, cy)
+            ctx.lineTo(cx, cy + half_diagonal)
+            ctx.lineTo(cx - half_diagonal, cy)
+            ctx.closePath()
+            break
+        }
+
+        case 'triangle': {
+            const r = radius * TRIANGLE_SIZE_SCALE
+            const half_base = r * TRIANGLE_HALF_BASE
+            const base_y = cy + r * TRIANGLE_BASE_DROP
+            ctx.moveTo(cx, cy - r * TRIANGLE_APEX_RISE)
+            ctx.lineTo(cx + half_base, base_y)
+            ctx.lineTo(cx - half_base, base_y)
+            ctx.closePath()
+            break
+        }
+
+        // circle is the default
+        default:
+            ctx.arc(cx, cy, radius, 0, 2 * Math.PI)
+    }
+}

--- a/plot/src/core/render/pixel_resolver.ts
+++ b/plot/src/core/render/pixel_resolver.ts
@@ -1,0 +1,19 @@
+import type { Scale } from "../types"
+
+/**
+ * Build a value-to-pixel resolver, hoisting the band-vs-linear branch out of the caller's loop.
+ * Band returns undefined for unknown categories so the caller can skip.
+ * @param scale - the axis scale
+ * @param values - the series values for that axis
+ * @returns a resolver mapping row index to a pixel position, or undefined to skip
+ */
+export function pixel_resolver(scale: Scale, values: Float64Array): (i: number) => number | undefined {
+    if ('bandwidth' in scale) {
+        const half = scale.bandwidth() / 2
+        return (i) => {
+            const value = scale(values[i])
+            return value === undefined ? undefined : value + half
+        }
+    }
+    return (i) => scale(values[i])
+}

--- a/plot/src/core/series/area/factory.ts
+++ b/plot/src/core/series/area/factory.ts
@@ -1,0 +1,245 @@
+import { resolve_xy_columns, attach_resolved_columns, resolve_column, validate_field_present } from "../../template/column"
+import { array_extent } from "../../template/extent"
+import { validate_finite, validate_non_negative, validate_hoverable } from "../../template/validate"
+import { resolve_stroke } from "../../template/color"
+import type { AreaSeries, AxisContext, FieldArg, SelectFn, StrokeArg, ThemeColor, TooltipArg } from "../../types"
+
+export type AreaBoundArg = FieldArg | number
+
+export type AreaArgs<TooltipContent = unknown> = {
+    data: Record<string, unknown>[]
+    x?: FieldArg
+    x2?: AreaBoundArg
+    y?: FieldArg
+    y2?: AreaBoundArg
+    color?: ThemeColor
+    stroke?: StrokeArg
+    dash?: number[]
+    tooltip?: TooltipArg<Record<string, unknown>, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown>>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+type AreaBound = { side: 'x' | 'y'; values: Float64Array; pinned: boolean }
+
+/**
+ * Area series factory. Resolves x / y and the second boundary (x2 or y2) into aligned Float64Arrays and
+ * validates the boundary dash pattern.
+ * @param args - area series args (data, x, x2, y, y2, color, stroke, dash)
+ * @returns the resolved AreaSeries
+ */
+export function new_area<TooltipContent = unknown>(args: AreaArgs<TooltipContent>): AreaSeries<TooltipContent> {
+    const x_arg = args.x ?? 'x'
+    const y_arg = args.y ?? 'y'
+    const resolved = resolve_xy_columns(args.data, x_arg, y_arg, 'plot.area', args.x === undefined, args.y === undefined)
+    const bound = resolve_bound(args)
+    const stroke = resolve_stroke(args.stroke, 'plot.area')
+    const series: AreaSeries<TooltipContent> = {
+        kind: 'area',
+        x: resolved.x,
+        y: resolved.y,
+    }
+
+    if (bound?.side === 'x') {
+        series.x2 = bound.values
+    }
+
+    if (bound?.side === 'y') {
+        series.y2 = bound.values
+    }
+
+    if (bound?.pinned === true) {
+        series.bound_pinned = true
+    }
+
+    if (args.color !== undefined) {
+        series.color = args.color
+    }
+
+    if (stroke !== undefined) {
+        series.stroke = stroke
+    }
+
+    if (args.dash !== undefined) {
+        series.dash = args.dash.map((segment, i) => validate_non_negative(segment, `plot.area: dash[${i}]`))
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+
+    const hoverable = validate_hoverable(args, 'plot.area')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+
+    series.rows = args.data // caller's original for the tooltip
+    attach_resolved_columns(series, resolved, x_arg, y_arg)
+    return series
+}
+
+/**
+ * Resolve the band's second boundary: which axis it pairs on, and its column. A number pins the boundary at
+ * that constant for every row.
+ * @param args - the area series args
+ * @returns the resolved bound, or undefined when the band fills to the zero baseline
+ */
+function resolve_bound(args: AreaArgs): AreaBound | undefined {
+    const field = bound_field(args)
+
+    if (field === undefined) {
+        return undefined
+    }
+    const slot = `${field.side}2`
+
+    if (typeof field.arg === 'number') {
+        const value = validate_finite(field.arg, `plot.area: ${slot}`)
+        return { side: field.side, values: new Float64Array(args.data.length).fill(value), pinned: true }
+    }
+
+    if (args.data.length > 0) {
+        validate_field_present(args.data[0], field.arg, field.defaulted, 'plot.area', slot)
+    }
+    const resolved = resolve_column(args.data, field.arg, 'plot.area', slot)
+
+    if (resolved.mode === 'categorical') {
+        throw new Error(`plot.area: ${slot} must be numeric to pair with ${field.side}.`)
+    }
+    return { side: field.side, values: resolved.values, pinned: false }
+}
+
+/**
+ * Which boundary pair the caller declared, and so which way the band runs: `y2` gives a horizontal band
+ * riding x, `x2` a vertical band riding y. Neither arg defaults to horizontal, and the band fills to the zero baseline.
+ * @param args - the area series args
+ * @returns the second boundary's axis, its field name / accessor / pinned constant, and whether that name
+ * was adopted off the rows rather than passed, or undefined for a baseline fill
+ */
+function bound_field(args: AreaArgs): { side: 'x' | 'y'; arg: AreaBoundArg; defaulted: boolean } | undefined {
+    if (args.x2 !== undefined && args.y2 !== undefined) {
+        throw new Error('plot.area: pass y2 (a horizontal band riding the x axis) or x2 (a vertical band riding the y axis), not both. Two bounds on each axis is a box per row, which is plot.rect.')
+    }
+
+    if (args.x2 !== undefined) {
+        return { side: 'x', arg: args.x2, defaulted: false }
+    }
+
+    if (args.y2 !== undefined) {
+        return { side: 'y', arg: args.y2, defaulted: false }
+    }
+
+    if (args.data.some(row => 'y2' in row)) {
+        return { side: 'y', arg: 'y2', defaulted: true }
+    }
+
+    if (args.data.some(row => 'x2' in row)) {
+        return { side: 'x', arg: 'x2', defaulted: true }
+    }
+    return undefined
+}
+
+/**
+ * Reject axes the band can't be drawn against: the paired axis carries two numeric boundaries, a baseline
+ * band needs room for zero on it, and a pinned boundary has to be placeable on it.
+ * @param x - the resolved x axis context
+ * @param y - the resolved y axis context
+ * @param series - the area series
+ * @param index - the series' position in the plot, for messages
+ */
+export function validate_area_axes(x: AxisContext, y: AxisContext, series: AreaSeries, index: number): void {
+    // an empty series exposes no column types and draws nothing
+    if (series.x.length === 0) {
+        return
+    }
+
+    if (series.x2 !== undefined) {
+        if (x.is_category) {
+            throw new Error(`plot: area series at index ${index} has x2, so it runs between two numeric x values and can't use a categorical x axis. Put the categories on y.`)
+        }
+        validate_pinned_bound(series, series.x2, x, 'x', index)
+        return
+    }
+
+    if (y.is_category) {
+        throw new Error(`plot: area series at index ${index} can't use a categorical y axis. The band runs between two numeric y values; put the categories on x.`)
+    }
+
+    if (series.y2 === undefined) {
+        if (y.scale === 'log') {
+            throw new Error(`plot: area series at index ${index} has no y2, so it fills to the zero baseline, which a log y axis has no room for. Pass y2 to bound the band, or use a linear y axis.`)
+        }
+        return
+    }
+    validate_pinned_bound(series, series.y2, y, 'y', index)
+}
+
+/**
+ * Reject a pinned boundary the axis can't place. A constant is a caller instruction rather than data, so a
+ * non-positive pin on a log scale is an error the way a non-positive `axis.{min,max}` is; a data column that
+ * can't be placed only breaks the band.
+ * @param series - the area series
+ * @param bound - the second boundary's column
+ * @param axis - the axis context the boundaries live on
+ * @param side - which axis that is, for the message
+ * @param index - the series' position in the plot, for messages
+ */
+function validate_pinned_bound(series: AreaSeries, bound: Float64Array, axis: AxisContext, side: 'x' | 'y', index: number): void {
+    if (series.bound_pinned !== true || axis.scale !== 'log') {
+        return
+    }
+    const pinned = bound[0]
+
+    if (pinned > 0) {
+        return
+    }
+    throw new Error(`plot: area series at index ${index} pins ${side}2 at ${pinned}, which a log ${side} axis can't place. Pin ${side}2 to a positive value, or use a linear ${side} axis.`)
+}
+
+/**
+ * The area's data extent: the free axis spans its points, the paired axis spans both boundaries. With no
+ * second boundary the band fills to zero, so that extent includes it.
+ * @param series - the area series
+ * @returns the [min, max] per axis
+ */
+export function area_domain_extent(series: AreaSeries): { x: [number, number]; y: [number, number] } {
+    if (series.x2 !== undefined) {
+        return {
+            x: merged_extent(series.x, series.x2),
+            y: array_extent(series.y),
+        }
+    }
+
+    if (series.y2 !== undefined) {
+        return {
+            x: array_extent(series.x),
+            y: merged_extent(series.y, series.y2),
+        }
+    }
+    const [y_min, y_max] = array_extent(series.y)
+    return {
+        x: array_extent(series.x),
+        y: [Math.min(y_min, 0), Math.max(y_max, 0)],
+    }
+}
+
+/**
+ * The extent covering both of a band's boundary columns.
+ * @param first - one boundary's values
+ * @param second - the other boundary's values
+ * @returns the [min, max] spanning both
+ */
+function merged_extent(first: Float64Array, second: Float64Array): [number, number] {
+    const [first_min, first_max] = array_extent(first)
+    const [second_min, second_max] = array_extent(second)
+    return [Math.min(first_min, second_min), Math.max(first_max, second_max)]
+}

--- a/plot/src/core/series/area/hit.ts
+++ b/plot/src/core/series/area/hit.ts
@@ -1,0 +1,95 @@
+import type { AreaPixelRuns, ComposedArea, Scale } from "../../types"
+import { is_vertical_area, run_count, series_pixel_runs } from "./layout"
+
+/**
+ * The area point under the cursor, or null. The band itself is the hit region: the cursor hits when it sits
+ * between the two boundaries, and the nearer of the two points bracketing it wins (so the tooltip reads the
+ * column you're closest to).
+ * @param series - the composed area series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the point index under the cursor, or null
+ */
+export function area_hit_test(series: ComposedArea, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale): number | null {
+    const vertical = is_vertical_area(series)
+    const along = vertical ? cursor.y : cursor.x
+    const across = vertical ? cursor.x : cursor.y
+    const runs = series_pixel_runs(series, x_scale, y_scale)
+    const runs_tested = run_count(runs)
+
+    for (let run = 0; run < runs_tested; run++) {
+        const hit = run_hit(runs, runs.run_starts[run], runs.run_starts[run + 1], along, across)
+
+        if (hit !== null) {
+            return hit
+        }
+    }
+    return null
+}
+
+/**
+ * The point under the cursor within one run, or null.
+ * @param runs - the band's pixel runs
+ * @param start - the run's first point
+ * @param end - one past the run's last point
+ * @param along - the cursor's pixel on the free axis
+ * @param across - the cursor's pixel on the paired axis
+ * @returns the source row index, or null
+ */
+function run_hit(runs: AreaPixelRuns, start: number, end: number, along: number, across: number): number | null {
+    for (let i = start; i + 1 < end; i++) {
+        const hit = segment_hit(runs, i, along, across)
+
+        if (hit !== null) {
+            return hit
+        }
+    }
+    return null
+}
+
+/**
+ * The point under the cursor within one band segment, or null. Both boundaries are interpolated at the
+ * cursor's position along the free axis, so a sloped band is hit only where it's actually drawn.
+ * @param runs - the band's pixel runs
+ * @param first - the segment's first point
+ * @param along - the cursor's pixel on the free axis
+ * @param across - the cursor's pixel on the paired axis
+ * @returns the nearer end's source row index, or null when the cursor is outside the segment
+ */
+function segment_hit(runs: AreaPixelRuns, first: number, along: number, across: number): number | null {
+    const second = first + 1
+    const min_along = Math.min(runs.along[first], runs.along[second])
+    const max_along = Math.max(runs.along[first], runs.along[second])
+    const within_segment = along >= min_along && along <= max_along
+
+    if (!within_segment) {
+        return null
+    }
+    const fraction = interpolation_fraction(runs.along[first], runs.along[second], along)
+    const edge = runs.edge[first] + (runs.edge[second] - runs.edge[first]) * fraction
+    const base = runs.base[first] + (runs.base[second] - runs.base[first]) * fraction
+    const within_band = across >= Math.min(edge, base) && across <= Math.max(edge, base)
+
+    if (!within_band) {
+        return null
+    }
+    return fraction < 0.5 ? runs.row[first] : runs.row[second]
+}
+
+/**
+ * How far the cursor sits along a segment, 0 at the first point and 1 at the second. A zero-length segment
+ * (repeated position) reads as 0.
+ * @param first_along - the segment's first point on the free axis, in pixels
+ * @param second_along - the segment's second point on the free axis, in pixels
+ * @param cursor_along - the cursor's pixel on the free axis
+ * @returns the fraction along the segment
+ */
+function interpolation_fraction(first_along: number, second_along: number, cursor_along: number): number {
+    const span = second_along - first_along
+
+    if (span === 0) {
+        return 0
+    }
+    return (cursor_along - first_along) / span
+}

--- a/plot/src/core/series/area/index.ts
+++ b/plot/src/core/series/area/index.ts
@@ -1,0 +1,26 @@
+import type { AreaSeries, SeriesType } from "../../types"
+import { area_domain_extent, new_area, validate_area_axes } from "./factory"
+import { area_hit_test } from "./hit"
+import { compose_area_layout } from "./layout"
+import { draw_area } from "./paint"
+
+export {
+    area_domain_extent,
+    new_area,
+    validate_area_axes,
+    type AreaArgs,
+    type AreaBoundArg,
+} from "./factory"
+export { area_hit_test } from "./hit"
+export { compose_area_layout, is_vertical_area, run_count, series_pixel_runs } from "./layout"
+export { draw_area } from "./paint"
+
+export const area_runtime = {
+    kind: 'area',
+    factory: new_area,
+    paint: draw_area,
+    tooltip_hit_test: area_hit_test,
+    compose_layout: compose_area_layout,
+    validate_axes: validate_area_axes,
+    domain_extent: area_domain_extent,
+} satisfies SeriesType<unknown, AreaSeries>

--- a/plot/src/core/series/area/layout.ts
+++ b/plot/src/core/series/area/layout.ts
@@ -1,0 +1,153 @@
+import type { AreaPixelRuns, ComposedArea, ComposedSeries, Scale } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+
+// The band's pixel geometry, built once per compose and read by both the paint and the hit test. Kept off
+// the render path because the hit test runs per pointer frame, where rebuilding it is the dominant cost.
+
+/**
+ * Whether the band rides the y axis: an x2 pairs the boundaries on x, leaving y as the free axis.
+ * @param series - the composed area series
+ * @returns true for a vertical band
+ */
+export function is_vertical_area(series: ComposedArea): boolean {
+    return series.x2 !== undefined
+}
+
+/**
+ * Precompute the band's pixel geometry for the current scales. Runs once per compose (the `compose_layout`
+ * hook), so the per-frame hit test and each redraw only index into it.
+ * @param series - the composed area series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the series carrying its pixel runs
+ */
+export function compose_area_layout<TooltipContent>(series: ComposedArea<TooltipContent>, x_scale: Scale, y_scale: Scale): ComposedSeries<TooltipContent> {
+    return { ...series, pixel_runs: area_pixel_runs(series, x_scale, y_scale) }
+}
+
+/**
+ * The band's pixel runs: the ones compose built, or a fresh pass for a series that reached the renderer
+ * without going through compose.
+ * @param series - the composed area series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the pixel runs
+ */
+export function series_pixel_runs(series: ComposedArea, x_scale: Scale, y_scale: Scale): AreaPixelRuns {
+    return series.pixel_runs ?? area_pixel_runs(series, x_scale, y_scale)
+}
+
+/**
+ * How many runs the geometry holds. `run_starts` carries a trailing sentinel so run i spans
+ * [run_starts[i], run_starts[i + 1]).
+ * @param runs - the band's pixel runs
+ * @returns the run count
+ */
+export function run_count(runs: AreaPixelRuns): number {
+    return Math.max(runs.run_starts.length - 1, 0)
+}
+
+/**
+ * Resolve every row to pixels, splitting into runs of consecutive placeable points. Columns are parallel and
+ * hold only the survivors, so a run indexes them directly; `row` maps back to the source row for the tooltip.
+ * @param series - the composed area series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the band's pixel runs
+ */
+function area_pixel_runs(series: ComposedArea, x_scale: Scale, y_scale: Scale): AreaPixelRuns {
+    const vertical = is_vertical_area(series)
+    const along_scale = vertical ? y_scale : x_scale
+    const paired_scale = vertical ? x_scale : y_scale
+    const resolve_along = pixel_resolver(along_scale, vertical ? series.y : series.x)
+    const resolve_edge = pixel_resolver(paired_scale, vertical ? series.x : series.y)
+    const resolve_base = base_resolver(series, paired_scale)
+    const length = series.x.length
+    const along = new Float64Array(length)
+    const edge = new Float64Array(length)
+    const base = new Float64Array(length)
+    const row = new Int32Array(length)
+    const run_starts: number[] = []
+    let count = 0
+    let in_run = false
+
+    for (let i = 0; i < length; i++) {
+        const point_along = resolve_along(i)
+        const point_edge = resolve_edge(i)
+        const point_base = resolve_base(i)
+
+        if (!is_placeable(point_along) || !is_placeable(point_edge) || !is_placeable(point_base)) {
+            in_run = false
+            continue
+        }
+
+        if (!in_run) {
+            run_starts.push(count)
+            in_run = true
+        }
+        along[count] = point_along
+        edge[count] = point_edge
+        base[count] = point_base
+        row[count] = i
+        count++
+    }
+    // sentinel: closes the last run, and is the only entry when nothing was placeable
+    run_starts.push(count)
+    // trim only when rows were dropped, otherwise pass the full buffer through
+    const full = count === length
+    return {
+        along: full ? along : along.slice(0, count),
+        edge: full ? edge : edge.slice(0, count),
+        base: full ? base : base.slice(0, count),
+        row: full ? row : row.slice(0, count),
+        run_starts: Int32Array.from(run_starts),
+    }
+}
+
+/**
+ * Whether a resolved pixel can be drawn. A band scale gives undefined for an unknown category, and a log
+ * scale maps a non-positive value to a non-finite pixel — canvas discards a path holding one, so the whole
+ * run would vanish rather than the band breaking at that point.
+ * @param pixel - the resolved pixel, or undefined
+ * @returns true when the point can be placed
+ */
+function is_placeable(pixel: number | undefined): pixel is number {
+    return pixel !== undefined && Number.isFinite(pixel)
+}
+
+/**
+ * The resolver for the band's second boundary: the paired data column, or the zero baseline when the band
+ * has none.
+ * @param series - the composed area series
+ * @param paired_scale - the scale of the axis the boundaries live on
+ * @returns a resolver giving the boundary pixel, or undefined to break the band
+ */
+function base_resolver(series: ComposedArea, paired_scale: Scale): (i: number) => number | undefined {
+    if (series.x2 !== undefined) {
+        return pixel_resolver(paired_scale, series.x2)
+    }
+
+    if (series.y2 !== undefined) {
+        return pixel_resolver(paired_scale, series.y2)
+    }
+    return baseline_resolver(paired_scale)
+}
+
+/**
+ * The zero-baseline resolver for a band with no second boundary. A band scale has no zero and a log scale
+ * can't place it, so neither resolves and the series draws nothing (the factory rejects both up front).
+ * @param paired_scale - the scale of the axis the boundaries live on
+ * @returns a resolver giving the baseline pixel, or undefined when the scale has no zero
+ */
+function baseline_resolver(paired_scale: Scale): () => number | undefined {
+    if ('bandwidth' in paired_scale) {
+        return () => undefined
+    }
+    const baseline = paired_scale(0)
+
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TODO: fix when next touching this code
+    if (baseline === undefined || !Number.isFinite(baseline)) {
+        return () => undefined
+    }
+    return () => baseline
+}

--- a/plot/src/core/series/area/paint.ts
+++ b/plot/src/core/series/area/paint.ts
@@ -1,0 +1,136 @@
+import type { AreaPixelRuns, ComposedArea, RenderContext } from "../../types"
+import { is_vertical_area, run_count, series_pixel_runs } from "./layout"
+
+const DEFAULT_STROKE_WIDTH = 1
+
+/**
+ * Draw an area series: the band between the two boundaries, filled in the series color and clipped to the
+ * plot area. With `stroke` set, each boundary that comes from data is outlined (a zero baseline isn't).
+ * @param series - the area series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_area(series: ComposedArea, render: RenderContext): void {
+    const { ctx, x_scale, y_scale, color } = render
+    const runs = series_pixel_runs(series, x_scale, y_scale)
+    const runs_drawn = run_count(runs)
+
+    if (runs_drawn === 0) {
+        return
+    }
+    const vertical = is_vertical_area(series)
+    const has_data_base = series.x2 !== undefined || series.y2 !== undefined
+    ctx.fillStyle = color
+
+    for (let run = 0; run < runs_drawn; run++) {
+        fill_run(ctx, runs, runs.run_starts[run], runs.run_starts[run + 1], vertical)
+    }
+
+    if (series.stroke !== undefined) {
+        stroke_runs(ctx, runs, series.stroke, series.dash, has_data_base, vertical)
+    }
+}
+
+/**
+ * Fill one run: forward along the first boundary, back along the second, closed.
+ * @param ctx - canvas context
+ * @param runs - the band's pixel runs
+ * @param start - the run's first point
+ * @param end - one past the run's last point
+ * @param vertical - whether the band rides the y axis
+ */
+function fill_run(ctx: RenderContext['ctx'], runs: AreaPixelRuns, start: number, end: number, vertical: boolean): void {
+    // a lone point spans no width, so it fills nothing
+    if (end - start < 2) {
+        return
+    }
+    ctx.beginPath()
+    move_to(ctx, runs.along[start], runs.edge[start], vertical)
+
+    for (let i = start + 1; i < end; i++) {
+        line_to(ctx, runs.along[i], runs.edge[i], vertical)
+    }
+
+    for (let i = end - 1; i >= start; i--) {
+        line_to(ctx, runs.along[i], runs.base[i], vertical)
+    }
+    ctx.closePath()
+    ctx.fill()
+}
+
+/**
+ * Outline each run's boundaries in the stroke color.
+ * @param ctx - canvas context
+ * @param runs - the band's pixel runs
+ * @param stroke - the resolved stroke
+ * @param dash - the boundary dash pattern, or undefined for solid
+ * @param has_data_base - whether the second boundary is a data column (a synthetic baseline isn't drawn)
+ * @param vertical - whether the band rides the y axis
+ */
+function stroke_runs(ctx: RenderContext['ctx'], runs: AreaPixelRuns, stroke: { color: string; width?: number }, dash: number[] | undefined, has_data_base: boolean, vertical: boolean): void {
+    ctx.strokeStyle = stroke.color
+    ctx.lineWidth = stroke.width ?? DEFAULT_STROKE_WIDTH
+    ctx.setLineDash(dash ?? [])
+    const runs_drawn = run_count(runs)
+
+    for (let run = 0; run < runs_drawn; run++) {
+        const start = runs.run_starts[run]
+        const end = runs.run_starts[run + 1]
+        stroke_boundary(ctx, runs.along, runs.edge, start, end, vertical)
+
+        if (has_data_base) {
+            stroke_boundary(ctx, runs.along, runs.base, start, end, vertical)
+        }
+    }
+}
+
+/**
+ * Stroke one boundary of a run as a polyline.
+ * @param ctx - canvas context
+ * @param along - the free-axis pixels
+ * @param across - the boundary's paired-axis pixels
+ * @param start - the run's first point
+ * @param end - one past the run's last point
+ * @param vertical - whether the band rides the y axis
+ */
+function stroke_boundary(ctx: RenderContext['ctx'], along: Float64Array, across: Float64Array, start: number, end: number, vertical: boolean): void {
+    if (end - start < 2) {
+        return
+    }
+    ctx.beginPath()
+    move_to(ctx, along[start], across[start], vertical)
+
+    for (let i = start + 1; i < end; i++) {
+        line_to(ctx, along[i], across[i], vertical)
+    }
+    ctx.stroke()
+}
+
+/**
+ * Move to a point in the band's own axes, mapped to canvas x/y by orientation.
+ * @param ctx - canvas context
+ * @param along - the pixel on the free axis
+ * @param across - the pixel on the paired axis
+ * @param vertical - whether the band rides the y axis
+ */
+function move_to(ctx: RenderContext['ctx'], along: number, across: number, vertical: boolean): void {
+    if (vertical) {
+        ctx.moveTo(across, along)
+        return
+    }
+    ctx.moveTo(along, across)
+}
+
+/**
+ * Line to a point in the band's own axes, mapped to canvas x/y by orientation.
+ * @param ctx - canvas context
+ * @param along - the pixel on the free axis
+ * @param across - the pixel on the paired axis
+ * @param vertical - whether the band rides the y axis
+ */
+function line_to(ctx: RenderContext['ctx'], along: number, across: number, vertical: boolean): void {
+    if (vertical) {
+        ctx.lineTo(across, along)
+        return
+    }
+    ctx.lineTo(along, across)
+}

--- a/plot/src/core/series/bar/duplicates.ts
+++ b/plot/src/core/series/bar/duplicates.ts
@@ -1,0 +1,83 @@
+export type BandDuplicates = {
+    keep: Int32Array
+    repeated: string[]
+}
+
+/**
+ * The rows to keep when a band value repeats, last row winning, or null when every band appears once.
+ * Category indices are untouched, so a band keeps the axis position it earned on first sight.
+ * @param band_values - the resolved band column, one entry per row
+ * @param row_count - how many rows the series carries
+ * @param categories - the band's category labels, indexed by the values in band_values
+ * @returns the surviving rows and the repeated category names, or null when there's nothing to drop
+ */
+export function dedupe_bands(
+    band_values: Float64Array,
+    row_count: number,
+    categories: string[],
+): BandDuplicates | null {
+    const last_row = new Map<number, number>()
+    const rows_per_band = new Map<number, number>()
+
+    for (let row = 0; row < row_count; row++) {
+        const band = band_values[row]
+
+        last_row.set(band, row)
+        rows_per_band.set(band, (rows_per_band.get(band) ?? 0) + 1)
+    }
+
+    if (last_row.size === row_count) {
+        return null
+    }
+    const keep = new Int32Array(last_row.size)
+    const repeated: string[] = []
+    let next = 0
+
+    for (let row = 0; row < row_count; row++) {
+        const band = band_values[row]
+
+        if (last_row.get(band) !== row) {
+            continue
+        }
+        keep[next] = row
+        next++
+    }
+
+    // report in category order so the message is stable regardless of row order
+    for (let band = 0; band < categories.length; band++) {
+        const rows = rows_per_band.get(band) ?? 0
+
+        if (rows > 1) {
+            repeated.push(categories[band])
+        }
+    }
+    return { keep, repeated }
+}
+
+/**
+ * Warn that repeated bands collapsed to their last row. Dropping is deliberate rather than an error: the
+ * earlier rows were already painted over, so this makes the data agree with the picture.
+ * @param repeated - the repeated category names
+ * @param error_prefix - label prefixed to the message
+ */
+export function warn_dropped_bands(repeated: string[], error_prefix: string): void {
+    const noun = repeated.length === 1 ? 'category' : 'categories'
+    const list = repeated.map(category => `'${category}'`).join(', ')
+
+    console.warn(`${error_prefix}: band ${noun} on more than one row: ${list} — only the last row for each is drawn, since later rows paint over earlier ones. Pre-aggregate the data if you meant to combine them.`)
+}
+
+/**
+ * Pick the kept rows out of a resolved column.
+ * @param values - the full column, one entry per row
+ * @param keep - the surviving row indices
+ * @returns a column holding just the kept rows
+ */
+export function compact_column(values: Float64Array, keep: Int32Array): Float64Array {
+    const compacted = new Float64Array(keep.length)
+
+    for (let i = 0; i < keep.length; i++) {
+        compacted[i] = values[keep[i]]
+    }
+    return compacted
+}

--- a/plot/src/core/series/bar/factory.ts
+++ b/plot/src/core/series/bar/factory.ts
@@ -1,0 +1,298 @@
+import { resolve_xy_columns, attach_resolved_columns, type ResolvedColumnMeta } from "../../template/column"
+import { compact_column, dedupe_bands, warn_dropped_bands } from "./duplicates"
+import { array_extent, xy_extent } from "../../template/extent"
+import { resolve_color } from "../../template/color"
+import { validate_hoverable, validate_hover_span, validate_non_negative } from "../../template/validate"
+import type { AxisContext, BarSeries, ColorArg, FieldArg, SelectFn, SideMode, ThemeColor, TooltipArg } from "../../types"
+import { expand_stack, resolve_stack_colors } from "./stack"
+
+export type BarSideArg = FieldArg | string[]
+export type BarColorArg = ColorArg | ThemeColor[]
+
+export type BarArgs<TooltipContent = unknown> = {
+    data: Record<string, unknown>[]
+    x?: BarSideArg
+    y?: BarSideArg
+    color?: BarColorArg
+    border_radius?: number
+    inset?: number
+    min_size?: number
+    hover_span_x?: boolean
+    hover_span_y?: boolean
+    tooltip?: TooltipArg<Record<string, unknown>, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown>>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+/**
+ * Bar series factory. Whichever of x / y is an array of field names is the stacked value side, and the
+ * other side is the band: array y stacks vertically, array x stacks horizontally. Neither gives one bar per row.
+ * @param args - bar series args (data, x, y, color)
+ * @returns the resolved BarSeries
+ */
+export function new_bar<TooltipContent = unknown>(args: BarArgs<TooltipContent>): BarSeries<TooltipContent> {
+    const x_arg = args.x ?? 'x'
+    const y_arg = args.y ?? 'y'
+
+    if (Array.isArray(y_arg)) {
+
+        if (Array.isArray(x_arg)) {
+            throw new Error(`plot.bar: both x and y are arrays of value fields. Stacked bars need exactly one value side (the array of field names) and one categorical band side.`)
+        }
+        return new_stacked_bar(args, x_arg, 'x', y_arg)
+    }
+
+    if (Array.isArray(x_arg)) {
+        return new_stacked_bar(args, y_arg, 'y', x_arg)
+    }
+    return new_plain_bar(args, x_arg, y_arg)
+}
+
+/**
+ * One bar per row. Detects column types and requires exactly one categorical axis.
+ * @param args - bar series args
+ * @param x_arg - the x field name or accessor
+ * @param y_arg - the y field name or accessor
+ * @returns the resolved BarSeries
+ */
+function new_plain_bar<TooltipContent>(args: BarArgs<TooltipContent>, x_arg: FieldArg, y_arg: FieldArg): BarSeries<TooltipContent> {
+    const color = args.color
+
+    if (Array.isArray(color)) {
+        throw new Error(`plot.bar: color is an array, which pairs one color to each stacked segment, but this series isn't stacked. Pass a single color or an accessor, or stack it with y: ['first', 'second'].`)
+    }
+    // labels mirror resolve_xy_columns for consistent error messages
+    const x_label = typeof x_arg === 'string' ? x_arg : 'x'
+    const y_label = typeof y_arg === 'string' ? y_arg : 'y'
+
+    const resolved = resolve_xy_columns(args.data, x_arg, y_arg, 'plot.bar', args.x === undefined, args.y === undefined)
+
+    // empty data exposes no column types to detect. Empty series will render bare chrome
+    if (args.data.length > 0) {
+
+        if (resolved.x_mode === 'categorical' && resolved.y_mode === 'categorical') {
+            throw new Error(`plot.bar: both x ('${x_label}') and y ('${y_label}') resolved to categorical columns. Bar series requires exactly one categorical (band) axis and one numeric (height) axis.`)
+        }
+
+        if (resolved.x_mode !== 'categorical' && resolved.y_mode !== 'categorical') {
+            throw new Error(`plot.bar: neither x ('${x_label}') nor y ('${y_label}') is a categorical column. Pass string values on one column or use plot.scatter for two numeric columns.`)
+        }
+    }
+    // a band on more than one row collapses to its last row
+    const drawn = drop_shadowed_rows(args.data, resolved)
+    const series: BarSeries<TooltipContent> = {
+        kind: 'bar',
+        x: drawn.x,
+        y: drawn.y,
+        ...resolve_color(drawn.data, color),
+    }
+
+    apply_bar_options(series, args)
+    series.rows = drawn.data // caller's original for the tooltip
+    attach_resolved_columns(series, resolved, x_arg, y_arg)
+    return series
+}
+
+/**
+ * Collapse repeated band values to their last row, leaving the columns untouched when every band is unique.
+ * Category indices come from the full data, so a band keeps the axis position it earned on first sight.
+ * @param data - the caller's rows
+ * @param resolved - the resolved x / y columns and their modes
+ * @returns the rows and columns to draw
+ */
+function drop_shadowed_rows(
+    data: Record<string, unknown>[],
+    resolved: ResolvedColumnMeta & { x: Float64Array; y: Float64Array },
+): { data: Record<string, unknown>[]; x: Float64Array; y: Float64Array } {
+    const x_is_band = resolved.x_mode === 'categorical'
+    const band_values = x_is_band ? resolved.x : resolved.y
+    const categories = (x_is_band ? resolved.x_categories : resolved.y_categories) ?? []
+
+    // an empty or non-categorical series has no bands to collapse
+    if (data.length === 0 || categories.length === 0) {
+        return { data, x: resolved.x, y: resolved.y }
+    }
+    const duplicates = dedupe_bands(band_values, data.length, categories)
+
+    if (duplicates === null) {
+        return { data, x: resolved.x, y: resolved.y }
+    }
+    warn_dropped_bands(duplicates.repeated, 'plot.bar')
+    const keep = duplicates.keep
+    const kept_data: Record<string, unknown>[] = new Array(keep.length)
+
+    for (let i = 0; i < keep.length; i++) {
+        kept_data[i] = data[keep[i]]
+    }
+    return { data: kept_data, x: compact_column(resolved.x, keep), y: compact_column(resolved.y, keep) }
+}
+
+/**
+ * Wide-form stacked bars: each row becomes one segment per value field, flattened to per-mark columns.
+ * Band on x stacks vertically, band on y horizontally.
+ * @param args - bar series args
+ * @param band_arg - the band axis field name or accessor
+ * @param band_side - which axis is the band; the other side carries the stacked values
+ * @param value_fields - the per-segment value field names, in stacking order
+ * @returns the resolved BarSeries
+ */
+function new_stacked_bar<TooltipContent>(args: BarArgs<TooltipContent>, band_arg: FieldArg, band_side: 'x' | 'y', value_fields: string[]): BarSeries<TooltipContent> {
+    const expanded = expand_stack(args.data, band_arg, band_side, value_fields, 'plot.bar')
+    const is_vertical = band_side === 'x'
+    const value_side = is_vertical ? 'y' : 'x'
+    const series: BarSeries<TooltipContent> = {
+        kind: 'bar',
+        x: is_vertical ? expanded.band : expanded.value,
+        y: is_vertical ? expanded.value : expanded.band,
+        stack_base: expanded.stack_base,
+        is_tip: expanded.is_tip,
+        labels: expanded.labels,
+        ...resolve_stack_colors(expanded.rows, value_fields.length, args.color, value_side, 'plot.bar'),
+    }
+
+    apply_bar_options(series, args)
+    series.rows = expanded.rows
+    series.x_axis_kind = is_vertical ? 'categorical' : 'numeric'
+    series.y_axis_kind = is_vertical ? 'numeric' : 'categorical'
+
+    // categories and the source field name land on the band side only.
+    // The value side has many source fields, so it carries no auto axis label
+    const category_key = is_vertical ? 'x_categories' : 'y_categories'
+    const field_key = is_vertical ? 'x_field' : 'y_field'
+
+    if (expanded.categories.length > 0) {
+        series[category_key] = expanded.categories
+    }
+
+    if (typeof band_arg === 'string') {
+        series[field_key] = band_arg
+    }
+    return series
+}
+
+/**
+ * Apply the options shared by plain and stacked bars, mutating the series in place.
+ * @param series - the series under construction
+ * @param args - the caller's bar args
+ */
+function apply_bar_options<TooltipContent>(series: BarSeries<TooltipContent>, args: BarArgs<TooltipContent>): void {
+    if (args.border_radius !== undefined) {
+        series.border_radius = validate_non_negative(args.border_radius, 'plot.bar: border_radius')
+    }
+
+    if (args.inset !== undefined) {
+        series.inset = validate_non_negative(args.inset, 'plot.bar: inset')
+    }
+
+    if (args.min_size !== undefined) {
+        series.min_size = validate_non_negative(args.min_size, 'plot.bar: min_size')
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+
+    const hoverable = validate_hoverable(args, 'plot.bar')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.hover_span_x !== undefined) {
+        series.hover_span_x = validate_hover_span(args.hover_span_x, hoverable, 'hover_span_x', 'plot.bar')
+    }
+
+    if (args.hover_span_y !== undefined) {
+        series.hover_span_y = validate_hover_span(args.hover_span_y, hoverable, 'hover_span_y', 'plot.bar')
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+}
+
+/**
+ * The [min, max] a bar series spans per axis. Stacked segments sit on running offsets, so the value side
+ * spans each segment's start..start+value rather than the raw column extent.
+ * @param series - the bar series
+ * @returns the [min, max] per axis
+ */
+export function bar_domain_extent(series: BarSeries): { x: [number, number]; y: [number, number] } {
+    const stack_base = series.stack_base
+
+    if (stack_base === undefined) {
+        return xy_extent(series)
+    }
+    const is_vertical = series.x_axis_kind === 'categorical'
+    const values = is_vertical ? series.y : series.x
+    let min = Infinity
+    let max = -Infinity
+
+    for (let i = 0; i < values.length; i++) {
+        const start = stack_base[i]
+        const end = start + values[i]
+
+        min = Math.min(min, start, end)
+        max = Math.max(max, start, end)
+    }
+    const value_extent: [number, number] = [min, max]
+
+    if (is_vertical) {
+        return { x: array_extent(series.x), y: value_extent }
+    }
+    return { x: value_extent, y: array_extent(series.y) }
+}
+
+/**
+ * Require exactly one categorical axis (band) and one linear axis (height), and reject a log value axis
+ * for a stacked series. Throws otherwise.
+ * @param x - resolved x axis
+ * @param y - resolved y axis
+ * @param series - the bar series, to skip the check when it has no rows
+ * @param index - series index, for the error message
+ */
+export function validate_bar_axes(x: AxisContext, y: AxisContext, series: BarSeries, index: number): void {
+
+    // empty series has no detectable band axis; nothing to draw, so don't enforce the requirement
+    if (series.x.length === 0) {
+        return
+    }
+
+    if (x.scale === 'time' || x.scale === 'utc' || y.scale === 'time' || y.scale === 'utc') {
+        throw new Error(`plot: bar series at index ${index} can't use a time axis. Bars need a categorical band axis and a numeric height axis`)
+    }
+
+    if (x.is_category === y.is_category) {
+        throw new Error(`plot: bar series at index ${index} requires exactly one categorical axis (band) and one linear axis (height); got x_is_category=${x.is_category}, y_is_category=${y.is_category}.`)
+    }
+
+    // exactly one side is categorical by here, so the other side carries the values
+    const value_axis = x.is_category ? y : x
+    const value_side = x.is_category ? 'y' : 'x'
+
+    if (series.stack_base !== undefined && value_axis.scale === 'log') {
+        throw new Error(`plot: stacked bar series at index ${index} can't use a log ${value_side} axis. Segments stack by summing from a zero baseline, which a log scale has no room for. Use a linear ${value_side} axis, or drop the stack and pass a single ${value_side} field.`)
+    }
+}
+
+/**
+ * Anchor the value axis at zero. A hidden axis pads symmetrically so bars sit off the edges without a visible baseline.
+ * @param x - resolved x axis
+ * @param y - resolved y axis
+ * @returns the value-side padding override
+ */
+export function bar_padding_mode(x: AxisContext, y: AxisContext): { x?: SideMode, y?: SideMode } {
+    if (x.is_category && !y.is_category) {
+        return { y: y.rendered ? 'anchor_zero' : 'spark_symmetric' }
+    }
+
+    if (!x.is_category && y.is_category) {
+        return { x: x.rendered ? 'anchor_zero' : 'spark_symmetric' }
+    }
+    return {}
+}

--- a/plot/src/core/series/bar/highlight.ts
+++ b/plot/src/core/series/bar/highlight.ts
@@ -1,0 +1,80 @@
+import type { ComposedBar, HighlightSpec, Scale, BarPixelSpan } from "../../types"
+import { DEFAULT_SERIES_COLOR } from "../../template/color"
+import { resolve_bar_rect, bar_corner_radius_css, segment_border_radius, type BarRect } from "./paint"
+import { series_value_span, bar_axes, type BarAxes } from "./layout"
+
+/**
+ * The hover-select halo for a bar: the bar's rectangle bounds in canvas pixels, in the bar's color. Reuses
+ * bar_rect so the bounds match the drawn bar exactly (orientation, log / linear baseline, negative bars).
+ * Hovering a stacked segment halos the whole stack, rebuilt segment by segment in each segment's own color, so
+ * the halo is the same bar rather than one block over it. The tooltip still names the segment under the cursor.
+ * @param series - the composed bar series
+ * @param point_index - the hovered bar's row index
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the rect spec (one per stacked segment), or null where the bar has no band position (unknown category) or paints nothing
+ */
+export function bar_highlight_spec(series: ComposedBar, point_index: number, x_scale: Scale, y_scale: Scale): HighlightSpec | HighlightSpec[] | null {
+    const axes = bar_axes(series, x_scale, y_scale)
+    const value_span = series_value_span(series, axes)
+    const rect = resolve_bar_rect(series, point_index, axes, value_span)
+
+    if (rect === null) {
+        return null
+    }
+
+    if (series.stack_base === undefined) {
+        if (rect.width === 0 || rect.height === 0) {
+            return null
+        }
+        return mark_spec(series, point_index, rect)
+    }
+    return stack_specs(series, point_index, axes, value_span)
+}
+
+/**
+ * One mark's halo: its drawn rectangle, its own color, and the rounding it actually painted.
+ * @param series - the composed bar series
+ * @param i - the mark index
+ * @param rect - the mark's resolved rectangle
+ * @returns the halo spec for that mark
+ */
+function mark_spec(series: ComposedBar, i: number, rect: BarRect): HighlightSpec {
+    const color = series.colors?.[i] ?? series.color ?? DEFAULT_SERIES_COLOR
+    const border_radius = bar_corner_radius_css(segment_border_radius(series, i), rect)
+    return { shape: 'rect', x: rect.left, y: rect.top, width: rect.width, height: rect.height, color, border_radius }
+}
+
+/**
+ * A halo per segment of the hovered mark's stack. Each segment carries its own color and its own tip rounding,
+ * so the halo tiles into the same shape the stack painted.
+ * @param series - the composed bar series
+ * @param point_index - the hovered segment's index
+ * @param axes - the series' resolved band / value axes
+ * @param value_span - the series' value axis layout, shared with the paint
+ * @returns one spec per drawn segment of the stack
+ */
+function stack_specs(series: ComposedBar, point_index: number, axes: BarAxes, value_span: BarPixelSpan): HighlightSpec[] {
+    const band = axes.bands
+    const hovered_band = band[point_index]
+    const specs: HighlightSpec[] = []
+
+    // one pass over the band column, so the stack needs no assumption about its segments being adjacent
+    for (let i = 0; i < band.length; i++) {
+        if (band[i] !== hovered_band) {
+            continue
+        }
+        const rect = resolve_bar_rect(series, i, axes, value_span)
+
+        if (rect === null) {
+            continue
+        }
+
+        // a zero-valued segment paints nothing
+        if (rect.width === 0 || rect.height === 0) {
+            continue
+        }
+        specs.push(mark_spec(series, i, rect))
+    }
+    return specs
+}

--- a/plot/src/core/series/bar/hit.ts
+++ b/plot/src/core/series/bar/hit.ts
@@ -1,0 +1,126 @@
+import type { ComposedBar, Rect, Scale } from "../../types"
+import { resolve_bar_rect, type BarRect } from "./paint"
+import { series_value_span, bar_axes, type BarAxes } from "./layout"
+
+type HitSpan = { start: number; extent: number }
+
+type HoverSpans = { band: boolean; value: boolean; value_bounds: HitSpan }
+
+/**
+ * The bar whose hit region contains the cursor, or null.
+ * A value-axis hover span then makes the rest of the band answer too
+ * @param series - the composed bar series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area, which a value-axis hover span fills
+ * @returns the point index under the cursor, or null
+ */
+export function bar_hit_test(series: ComposedBar, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale, inner: Rect): number | null {
+    const axes = bar_axes(series, x_scale, y_scale)
+    const value_span = series_value_span(series, axes)
+    const hover = hover_spans(series, axes, inner)
+    let band_hit: number | null = null
+
+    for (let i = 0; i < series.x.length; i++) {
+        const drawn = resolve_bar_rect(series, i, axes, value_span)
+
+        if (drawn === null) {
+            continue
+        }
+        const band = band_hit_span(i, axes, drawn, hover.band)
+
+        // a mark that paints nothing is never hit where it's drawn, but its band can still answer below
+        if (is_drawn(drawn) && contains(cursor, band, drawn_value_span(axes, drawn), axes.is_vertical)) {
+            return i
+        }
+
+        if (hover.value && band_hit === null && contains(cursor, band, hover.value_bounds, axes.is_vertical)) {
+            band_hit = i
+        }
+    }
+
+    return band_hit
+}
+
+/**
+ * Map the caller's x / y hover spans onto the series' band and value axes, and measure the value axis' full
+ * extent. A vertical bar bands on x and takes its value on y; a horizontal one is the other way around.
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @param inner - the plot area
+ * @returns which axes fill their span, and the value axis' extent
+ */
+function hover_spans(series: ComposedBar, axes: BarAxes, inner: Rect): HoverSpans {
+    const span_x = series.hover_span_x === true
+    const span_y = series.hover_span_y === true
+
+    if (axes.is_vertical) {
+        return { band: span_x, value: span_y, value_bounds: { start: inner.top, extent: inner.bottom - inner.top } }
+    }
+    return { band: span_y, value: span_x, value_bounds: { start: inner.left, extent: inner.right - inner.left } }
+}
+
+/**
+ * The hit region's band axis span: the whole band when it fills its hover span, so the inset gaps between
+ * bars hover the bar they belong to, else the bar's own thickness.
+ * @param i - the mark index
+ * @param axes - the series' resolved band / value axes
+ * @param drawn - the mark's drawn rect
+ * @param widen - whether the band axis fills its hover span
+ * @returns the span on the band axis
+ */
+function band_hit_span(i: number, axes: BarAxes, drawn: BarRect, widen: boolean): HitSpan {
+    const thickness = drawn_band_span(axes, drawn)
+
+    if (!widen) {
+        return thickness
+    }
+    const band_start = axes.band_scale(axes.bands[i])
+
+    if (band_start === undefined) {
+        return thickness
+    }
+    return { start: band_start, extent: axes.band_scale.bandwidth() }
+}
+
+// The mark's drawn extent across the band axis.
+function drawn_band_span(axes: BarAxes, drawn: BarRect): HitSpan {
+    if (axes.is_vertical) {
+        return { start: drawn.left, extent: drawn.width }
+    }
+    return { start: drawn.top, extent: drawn.height }
+}
+
+// The mark's drawn extent along the value axis, which is zero for a zero-valued mark.
+function drawn_value_span(axes: BarAxes, drawn: BarRect): HitSpan {
+    if (axes.is_vertical) {
+        return { start: drawn.top, extent: drawn.height }
+    }
+    return { start: drawn.left, extent: drawn.width }
+}
+
+// Whether a mark paints anything at all. A zero value, or an inset that eats the whole band, draws nothing.
+function is_drawn(drawn: BarRect): boolean {
+    return drawn.width > 0 && drawn.height > 0
+}
+
+/**
+ * Whether the cursor is inside a hit region, given as its two axis spans.
+ * @param cursor - cursor position in canvas pixels
+ * @param band - the region's span across the band axis
+ * @param value - the region's span along the value axis
+ * @param is_vertical - whether the series bands on x
+ * @returns true when the cursor is within both spans
+ */
+function contains(cursor: { x: number; y: number }, band: HitSpan, value: HitSpan, is_vertical: boolean): boolean {
+    const across = is_vertical ? cursor.x : cursor.y
+    const along = is_vertical ? cursor.y : cursor.x
+
+    return within(across, band) && within(along, value)
+}
+
+// Whether a pixel position falls inside one axis' span, both ends inclusive.
+function within(position: number, span: HitSpan): boolean {
+    return position >= span.start && position <= span.start + span.extent
+}

--- a/plot/src/core/series/bar/index.ts
+++ b/plot/src/core/series/bar/index.ts
@@ -1,0 +1,34 @@
+import type { BarSeries, SeriesType } from "../../types"
+import { bar_domain_extent, bar_padding_mode, new_bar, validate_bar_axes } from "./factory"
+import { bar_highlight_spec } from "./highlight"
+import { bar_hit_test } from "./hit"
+import { compose_bar_layout } from "./layout"
+import { draw_bar } from "./paint"
+
+export { compact_column, dedupe_bands, warn_dropped_bands, type BandDuplicates } from "./duplicates"
+export {
+    bar_domain_extent,
+    bar_padding_mode,
+    new_bar,
+    validate_bar_axes,
+    type BarArgs,
+    type BarColorArg,
+    type BarSideArg,
+} from "./factory"
+export { bar_highlight_spec } from "./highlight"
+export { bar_hit_test } from "./hit"
+export { bar_axes, compose_bar_layout, series_value_span, type BarAxes } from "./layout"
+export { bar_corner_radius_css, draw_bar, resolve_bar_rect, segment_border_radius, type BarRect } from "./paint"
+export { expand_stack, resolve_stack_colors, type ExpandedStack, type StackColorArg } from "./stack"
+
+export const bar_runtime = {
+    kind: 'bar',
+    factory: new_bar,
+    paint: draw_bar,
+    tooltip_hit_test: bar_hit_test,
+    highlight_spec: bar_highlight_spec,
+    compose_layout: compose_bar_layout,
+    validate_axes: validate_bar_axes,
+    padding_mode: bar_padding_mode,
+    domain_extent: bar_domain_extent,
+} satisfies SeriesType<unknown, BarSeries>

--- a/plot/src/core/series/bar/layout.ts
+++ b/plot/src/core/series/bar/layout.ts
@@ -1,0 +1,155 @@
+import type { BandScale, ComposedBar, ComposedSeries, NumericalScale, Scale, BarPixelSpan } from "../../types"
+
+// Smallest a non-zero bar draws, so a value that maps to a sub-pixel extent stays visible. Per-series `min_size` overrides it.
+const DEFAULT_MIN_BAR_SIZE = 2
+
+export type BarAxes = {
+    is_vertical: boolean
+    band_scale: BandScale
+    value_scale: NumericalScale
+    bands: Float64Array
+    values: Float64Array
+}
+
+/**
+ * Resolve which side of a bar series is the band. The band axis is the one with a band scale, which plot.ts
+ * guarantees is exactly one of the two.
+ * @param series - the composed bar series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the band / value scales and columns
+ */
+export function bar_axes(series: ComposedBar, x_scale: Scale, y_scale: Scale): BarAxes {
+    if ('bandwidth' in x_scale) {
+        return {
+            is_vertical: true,
+            band_scale: x_scale,
+            // a non-band axis is still linear | log | time in the union, and only a bar's value axis reaches here
+            value_scale: y_scale as NumericalScale,
+            bands: series.x,
+            values: series.y,
+        }
+    }
+
+    return {
+        is_vertical: false,
+        band_scale: y_scale as BandScale,
+        value_scale: x_scale as NumericalScale,
+        bands: series.y,
+        values: series.x,
+    }
+}
+
+/**
+ * Attach a bar series' value-axis layout, so the paint, hit-test and hover halo all read the same pixels.
+ * Runs once per compose, where the scales are built.
+ * @param series - the color-resolved bar series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the series with its value_span filled in
+ */
+export function compose_bar_layout<TooltipContent>(series: ComposedBar<TooltipContent>, x_scale: Scale, y_scale: Scale): ComposedSeries<TooltipContent> {
+    return { ...series, value_span: bar_value_span(series, bar_axes(series, x_scale, y_scale)) }
+}
+
+/**
+ * The value-axis layout to draw a bar series with: the one compose already built, or a fresh pass for a series
+ * that reached the renderer without going through compose.
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @returns the series' value span
+ */
+export function series_value_span(series: ComposedBar, axes: BarAxes): BarPixelSpan {
+    return series.value_span ?? bar_value_span(series, axes)
+}
+
+/**
+ * Lay a bar series out along the value axis, in pixels. Each mark is sized first — its own size, floored at
+ * `min_size`, with zero left at zero — and a stack then places its segments by adding those drawn sizes up from
+ * the value baseline, on one running total per side of zero. Sizing before placing is what keeps a floored
+ * segment from being painted over by the one above it, and keeps the two directions independent.
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @returns the baseline and tip pixel of every mark, index-parallel with the series columns
+ */
+function bar_value_span(series: ComposedBar, axes: BarAxes): BarPixelSpan {
+    const { value_scale: linear_scale, values, bands } = axes
+    const baseline = new Float64Array(values.length)
+    const tip = new Float64Array(values.length)
+    const min_size = Math.max(series.min_size ?? DEFAULT_MIN_BAR_SIZE, 0)
+    const origin = value_origin(series, linear_scale)
+    const is_stacked = series.stack_base !== undefined
+    let positive_total = 0
+    let negative_total = 0
+
+    for (let i = 0; i < values.length; i++) {
+        // a stack is contiguous marks sharing one band (bands are deduped, so no two stacks share one), so a
+        // new band value starts both running totals over
+        if (i === 0 || bands[i] !== bands[i - 1]) {
+            positive_total = 0
+            negative_total = 0
+        }
+        const value = values[i]
+        const raw = raw_span(series, i, linear_scale, value, origin)
+        // pixels grow downward, so the raw tip's own sign is which way this mark grows
+        const direction = raw.tip <= raw.baseline ? -1 : 1
+        const size = value === 0 ? 0 : Math.max(Math.abs(raw.tip - raw.baseline), min_size)
+        const stacked_below = stacked_offset(is_stacked, value, positive_total, negative_total)
+
+        baseline[i] = origin + direction * stacked_below
+        tip[i] = baseline[i] + direction * size
+
+        if (value < 0) {
+            negative_total += size
+            continue
+        }
+        positive_total += size
+    }
+
+    return { baseline, tip }
+}
+
+/**
+ * How far a mark starts from the value baseline: the drawn sizes of the segments below it on its own side of
+ * zero. Only a stack piles up — a plain bar always starts at the baseline.
+ * @param is_stacked - whether the series carries stack offsets
+ * @param value - the mark's value, for which side of zero it stacks on
+ * @param positive_total - the drawn size of the positive segments so far in this stack
+ * @param negative_total - the drawn size of the negative segments so far in this stack
+ * @returns the offset from the baseline, in pixels
+ */
+function stacked_offset(is_stacked: boolean, value: number, positive_total: number, negative_total: number): number {
+    if (!is_stacked) {
+        return 0
+    }
+    return value < 0 ? negative_total : positive_total
+}
+
+// The pixel a stack grows from: the value axis' zero, or the low end of the domain on a log axis, which has no zero.
+function value_origin(series: ComposedBar, linear_scale: NumericalScale): number {
+    const is_log = 'base' in linear_scale
+
+    if (is_log && series.stack_base === undefined) {
+        return linear_scale(linear_scale.domain()[0])
+    }
+    return linear_scale(0)
+}
+
+// What a mark would span with no minimum applied. A stacked segment is measured at its own place in the stack,
+// so a non-linear scale sizes it where it actually sits; a plain bar is measured from the axis baseline.
+function raw_span(
+    series: ComposedBar,
+    i: number,
+    linear_scale: NumericalScale,
+    value: number,
+    origin: number,
+): { baseline: number; tip: number } {
+    const stack_base = series.stack_base
+
+    if (stack_base === undefined) {
+        return { baseline: origin, tip: linear_scale(value) }
+    }
+    const start = stack_base[i]
+
+    return { baseline: linear_scale(start), tip: linear_scale(start + value) }
+}

--- a/plot/src/core/series/bar/paint.ts
+++ b/plot/src/core/series/bar/paint.ts
@@ -1,0 +1,257 @@
+import type { CanvasContext, ComposedBar, PixelRect, RenderContext, BarPixelSpan } from "../../types"
+import { inset_band } from "../../render/band"
+import { series_value_span, bar_axes, type BarAxes } from "./layout"
+
+// The bar edge away from the value baseline — the end whose corners `radius` rounds.
+type BarTipSide = 'top' | 'bottom' | 'left' | 'right'
+export type BarRect = PixelRect & { tip_side: BarTipSide }
+
+type BarSegment = { rect: BarRect; color: string }
+
+/**
+ * Draw a bar series. Each bar's rectangle comes from resolve_bar_rect.
+ * @param series - the bar series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_bar(series: ComposedBar, render: RenderContext): void {
+    const { ctx, x_scale, y_scale, color } = render
+
+    if (series.x.length === 0) {
+        return
+    }
+    ctx.fillStyle = color
+    const axes = bar_axes(series, x_scale, y_scale)
+    const value_span = series_value_span(series, axes)
+    const is_stacked = series.is_tip !== undefined
+    const has_radius = series.border_radius !== undefined && series.border_radius > 0
+
+    if (is_stacked && has_radius) {
+        draw_stacks(ctx, series, axes, value_span, color)
+    } else {
+        draw_marks(ctx, series, axes, value_span, color)
+    }
+}
+
+/**
+ * Draw each mark on its own, rounding its own tip. Stacks reach here only without a radius, where a segment
+ * and a stack paint the same square rectangles.
+ * @param ctx - canvas context
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @param value_span - the series' value axis layout
+ * @param fallback - the series color, used where a mark has none
+ */
+function draw_marks(ctx: CanvasContext, series: ComposedBar, axes: BarAxes, value_span: BarPixelSpan, fallback: string): void {
+    const colors = series.colors
+
+    for (let i = 0; i < series.x.length; i++) {
+        const rect = resolve_bar_rect(series, i, axes, value_span)
+
+        if (rect === null) {
+            continue
+        }
+
+        if (colors !== undefined) {
+            ctx.fillStyle = colors[i] ?? fallback
+        }
+        fill_bar(ctx, rect, segment_border_radius(series, i))
+    }
+}
+
+/**
+ * Draw rounded stacks one at a time: clip to the whole stack's rounded silhouette, then fill its segments
+ * square. Rounding the tip segment alone would clamp the radius to that segment's height, so a stack with a
+ * short tip drew a flatter corner than its neighbours and the segment below it stayed square.
+ * @param ctx - canvas context
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @param value_span - the series' value axis layout
+ * @param fallback - the series color, used where a segment has none
+ */
+function draw_stacks(ctx: CanvasContext, series: ComposedBar, axes: BarAxes, value_span: BarPixelSpan, fallback: string): void {
+    const border_radius = series.border_radius ?? 0
+
+    for (const segments of group_stacks(series, axes, value_span, fallback).values()) {
+        ctx.save()
+        trace_rounded_bar(ctx, stack_silhouette(segments), border_radius)
+        ctx.clip()
+
+        for (const segment of segments) {
+            const rect = segment.rect
+            ctx.fillStyle = segment.color
+            ctx.fillRect(rect.left, rect.top, rect.width, rect.height)
+        }
+        ctx.restore()
+    }
+}
+
+/**
+ * Group the drawn segments into stacks, keyed by band and tip side so a band's positive and negative stacks round independently
+ * @param series - the composed bar series
+ * @param axes - the series' resolved band / value axes
+ * @param value_span - the series' value axis layout
+ * @param fallback - the series color, used where a segment has none
+ * @returns the segments of each stack, in mark order
+ */
+function group_stacks(series: ComposedBar, axes: BarAxes, value_span: BarPixelSpan, fallback: string): Map<string, BarSegment[]> {
+    const groups = new Map<string, BarSegment[]>()
+
+    for (let i = 0; i < series.x.length; i++) {
+        const rect = resolve_bar_rect(series, i, axes, value_span)
+
+        if (rect === null) {
+            continue
+        }
+
+        if (rect.width === 0 || rect.height === 0) {
+            continue
+        }
+
+        const key = `${axes.bands[i]}|${rect.tip_side}`
+        const segment = { rect, color: series.colors?.[i] ?? fallback }
+        const existing = groups.get(key)
+
+        if (existing === undefined) {
+            groups.set(key, [segment])
+            continue
+        }
+        existing.push(segment)
+    }
+    return groups
+}
+
+/**
+ * The rectangle a whole stack occupies: the union of its segments, carrying their shared tip side.
+ * @param segments - one stack's drawn segments, at least one
+ * @returns the stack's bounding rectangle
+ */
+function stack_silhouette(segments: BarSegment[]): BarRect {
+    const first = segments[0].rect
+    let left = first.left
+    let top = first.top
+    let right = first.left + first.width
+    let bottom = first.top + first.height
+
+    for (const segment of segments) {
+        const rect = segment.rect
+        left = Math.min(left, rect.left)
+        top = Math.min(top, rect.top)
+        right = Math.max(right, rect.left + rect.width)
+        bottom = Math.max(bottom, rect.top + rect.height)
+    }
+    return { left, top, width: right - left, height: bottom - top, tip_side: first.tip_side }
+}
+
+/**
+ * The radius to round one mark with. A plain bar always rounds its own tip; a stacked segment rounds only
+ * when it sits at the visible end of its stack, so inner and zero-valued segments stay square.
+ * @param series - the composed bar series
+ * @param i - the mark index
+ * @returns the border radius to draw, or undefined for square corners
+ */
+export function segment_border_radius(series: ComposedBar, i: number): number | undefined {
+    const is_tip = series.is_tip
+
+    if (is_tip === undefined) {
+        return series.border_radius
+    }
+
+    if (is_tip[i] === 1) {
+        return series.border_radius
+    }
+    return undefined
+}
+
+// Fill one bar: a plain rect, or a path with the two tip-side corners rounded when border_radius is set.
+function fill_bar(ctx: CanvasContext, rect: BarRect, border_radius: number | undefined): void {
+    if (border_radius === undefined || border_radius <= 0) {
+        ctx.fillRect(rect.left, rect.top, rect.width, rect.height)
+        return
+    }
+    trace_rounded_bar(ctx, rect, border_radius)
+    ctx.fill()
+}
+
+// Trace a bar path clockwise, rounding only the tip-side corners (border_radius clamped to half the bar).
+function trace_rounded_bar(ctx: CanvasContext, rect: BarRect, border_radius: number): void {
+    const right = rect.left + rect.width
+    const bottom = rect.top + rect.height
+    const r = Math.min(border_radius, rect.width / 2, rect.height / 2)
+    const corner = tip_corner_radii(rect.tip_side, r)
+
+    ctx.beginPath()
+    ctx.moveTo(rect.left + corner.tl, rect.top)
+    ctx.lineTo(right - corner.tr, rect.top)
+    ctx.arcTo(right, rect.top, right, rect.top + corner.tr, corner.tr)
+    ctx.lineTo(right, bottom - corner.br)
+    ctx.arcTo(right, bottom, right - corner.br, bottom, corner.br)
+    ctx.lineTo(rect.left + corner.bl, bottom)
+    ctx.arcTo(rect.left, bottom, rect.left, bottom - corner.bl, corner.bl)
+    ctx.lineTo(rect.left, rect.top + corner.tl)
+    ctx.arcTo(rect.left, rect.top, rect.left + corner.tl, rect.top, corner.tl)
+    ctx.closePath()
+}
+
+// Per-corner radii {top-left, top-right, bottom-right, bottom-left}: r on the two tip-side corners, 0 elsewhere.
+function tip_corner_radii(tip_side: BarTipSide, r: number): { tl: number; tr: number; br: number; bl: number } {
+    if (tip_side === 'top') {
+        return { tl: r, tr: r, br: 0, bl: 0 }
+    }
+
+    if (tip_side === 'bottom') {
+        return { tl: 0, tr: 0, br: r, bl: r }
+    }
+
+    if (tip_side === 'left') {
+        return { tl: r, tr: 0, br: 0, bl: r }
+    }
+    return { tl: 0, tr: r, br: r, bl: 0 } // right
+}
+
+// The CSS border-radius (top-left top-right bottom-right bottom-left) matching a rounded bar's tip corners,
+// or undefined when the bar has no radius.
+export function bar_corner_radius_css(border_radius: number | undefined, rect: BarRect): string | undefined {
+    if (border_radius === undefined || border_radius <= 0) {
+        return undefined
+    }
+    const r = Math.min(border_radius, rect.width / 2, rect.height / 2)
+    const corner = tip_corner_radii(rect.tip_side, r)
+    return `${corner.tl}px ${corner.tr}px ${corner.br}px ${corner.bl}px`
+}
+
+/**
+ * The pixel rectangle of one bar, or null if its band position is unknown (normally unreachable). Shared by the bar paint,
+ * hit-test, and hover highlight. Places the bar across its band; the value axis comes ready-made in value_span.
+ * @param series - the composed bar series
+ * @param i - the bar's row index
+ * @param axes - the series' resolved band / value axes
+ * @param value_span - the series' value axis layout, from series_value_span
+ * @returns the bar's { left, top, width, height } in canvas pixels, or null
+ */
+export function resolve_bar_rect(series: ComposedBar, i: number, axes: BarAxes, value_span: BarPixelSpan): BarRect | null {
+    const { is_vertical, band_scale, bands } = axes
+    const band_pos = band_scale(bands[i])
+
+    if (band_pos === undefined) {
+        return null
+    }
+    const baseline = value_span.baseline[i]
+    const tip = value_span.tip[i]
+    const linear_start = Math.min(tip, baseline)
+    const linear_extent = Math.abs(tip - baseline)
+    // shrink the bar within its band by the per-series inset (undefined keeps the default gap), centered
+    const { start: band_start, extent: thickness } = inset_band(band_pos, band_scale.bandwidth(), series.inset)
+    const tip_side = bar_tip_side(is_vertical, tip, baseline)
+
+    if (is_vertical) {
+        return { left: band_start, top: linear_start, width: thickness, height: linear_extent, tip_side }
+    }
+    return { left: linear_start, top: band_start, width: linear_extent, height: thickness, tip_side }
+}
+
+function bar_tip_side(is_vertical: boolean, tip: number, baseline: number): BarTipSide {
+    if (is_vertical) {
+        return tip <= baseline ? 'top' : 'bottom'
+    }
+    return tip >= baseline ? 'right' : 'left'
+}

--- a/plot/src/core/series/bar/stack.ts
+++ b/plot/src/core/series/bar/stack.ts
@@ -1,0 +1,207 @@
+import { resolve_column } from "../../template/column"
+import { is_theme_color, resolve_color_arg } from "../../template/color"
+import { dedupe_bands, warn_dropped_bands } from "./duplicates"
+import type { ColorArg, FieldArg, ThemeColor } from "../../types"
+
+export type StackColorArg = ColorArg | ThemeColor[]
+
+// side-agnostic: the caller assigns band / value to x / y depending on which side carried the array
+export type ExpandedStack = {
+    band: Float64Array // the band axis column: category indices, repeated once per segment
+    value: Float64Array // the value axis column: each segment's own value
+    stack_base: Float64Array // per-mark running offset on the value axis: where this segment starts
+    is_tip: Uint8Array // 1 when the mark is the outermost non-zero segment of its band, per direction
+    labels: string[] // per-mark source field name, for the tooltip
+    rows: Record<string, unknown>[] // the band's original row, repeated once per segment
+    categories: string[]
+}
+
+/**
+ * Expand wide-form stacked input into flat per-segment columns. Positive segments stack up from zero and
+ * negative segments stack down, each on its own running offset, so a row can carry both directions.
+ * @param data - the data rows, one per band
+ * @param band_arg - the band axis field name or accessor
+ * @param band_side - which axis is the band; the other side carries the values
+ * @param value_fields - the per-segment value field names, in stacking order
+ * @param error_prefix - label prefixed to thrown errors
+ * @returns the flattened per-mark columns plus the band categories
+ */
+export function expand_stack(
+    data: Record<string, unknown>[],
+    band_arg: FieldArg,
+    band_side: 'x' | 'y',
+    value_fields: string[],
+    error_prefix: string,
+): ExpandedStack {
+    const value_side = band_side === 'x' ? 'y' : 'x'
+
+    if (value_fields.length === 0) {
+        throw new Error(`${error_prefix}: ${value_side} is an empty array. Stacked bars need at least one value field name, e.g. ${value_side}: ['pass', 'fail'].`)
+    }
+
+    const band = resolve_column(data, band_arg, error_prefix, band_side)
+    const band_label = typeof band_arg === 'string' ? band_arg : band_side
+
+    // empty data exposes no column type to detect; an empty series renders bare chrome
+    if (data.length > 0 && band.mode !== 'categorical') {
+        throw new Error(`${error_prefix}: ${value_side} is an array of value fields (stacked bars), so ${band_side} ('${band_label}') must be a categorical band axis, but it resolved to numbers. Pass string values on ${band_side}.`)
+    }
+
+    const categories = band.categories ?? []
+
+    const duplicates = dedupe_bands(band.values, data.length, categories)
+
+    if (duplicates !== null) {
+        warn_dropped_bands(duplicates.repeated, error_prefix)
+    }
+    const kept_rows = duplicates === null ? null : duplicates.keep
+    const stack_count = kept_rows === null ? data.length : kept_rows.length
+    const segment_count = value_fields.length
+    // one entry per drawn rectangle, not per row: every stack contributes segment_count of them
+    const mark_count = stack_count * segment_count
+    const band_column = new Float64Array(mark_count)
+    const value_column = new Float64Array(mark_count)
+    const stack_base = new Float64Array(mark_count)
+    const is_tip = new Uint8Array(mark_count)
+    const labels: string[] = new Array(mark_count)
+    const rows: Record<string, unknown>[] = new Array(mark_count)
+
+    for (let stack = 0; stack < stack_count; stack++) {
+        const row_index = kept_rows === null ? stack : kept_rows[stack]
+        const row = data[row_index]
+        let positive_offset = 0
+        let negative_offset = 0
+        let positive_tip = -1 // mark the index of the tip in case we need to apply border radius
+        let negative_tip = -1
+
+        for (let segment = 0; segment < segment_count; segment++) {
+            const field = value_fields[segment]
+            const value = read_segment_value(row, field, row_index, error_prefix)
+            const mark = stack * segment_count + segment // flatten the (stack, segment) grid into the per-mark columns
+
+            band_column[mark] = band.values[row_index]
+            value_column[mark] = value
+            labels[mark] = field
+            rows[mark] = row
+
+            if (value < 0) {
+                stack_base[mark] = negative_offset
+                negative_offset += value
+                negative_tip = mark
+                continue
+            }
+            stack_base[mark] = positive_offset
+            positive_offset += value
+
+            if (value > 0) {
+                positive_tip = mark
+            }
+        }
+
+        if (positive_tip >= 0) {
+            is_tip[positive_tip] = 1
+        }
+
+        if (negative_tip >= 0) {
+            is_tip[negative_tip] = 1
+        }
+    }
+
+    return { band: band_column, value: value_column, stack_base, is_tip, labels, rows, categories }
+}
+
+/**
+ * Resolve a color per stacked mark. A per-row `color` field wins and paints that band's whole stack; then
+ * a positional array pairs one color to each value field; then an accessor, which receives the row and the
+ * segment index. A single ThemeColor stays uniform and needs no per-mark array.
+ * @param rows - the expanded per-mark rows (the band's row, repeated once per segment)
+ * @param segment_count - how many segments each band carries
+ * @param arg - the caller's color arg
+ * @param value_side - the axis carrying the value fields, for the error message
+ * @param error_prefix - label prefixed to thrown errors
+ * @returns the uniform color and / or the per-mark colors to attach to the series
+ */
+export function resolve_stack_colors(
+    rows: Record<string, unknown>[],
+    segment_count: number,
+    arg: StackColorArg | undefined,
+    value_side: 'x' | 'y',
+    error_prefix: string,
+): { color?: ThemeColor; colors?: (ThemeColor | null)[] } {
+
+    if (Array.isArray(arg) && arg.length !== segment_count) {
+        throw new Error(`${error_prefix}: color has ${arg.length} ${arg.length === 1 ? 'entry' : 'entries'} but ${value_side} names ${segment_count} stacked value fields. A color array needs one entry per segment, in the same order.`)
+    }
+
+    const has_per_row = rows.some(row => is_theme_color(row.color))
+    const varies_per_mark = has_per_row || Array.isArray(arg) || typeof arg === 'function'
+    const uniform = is_theme_color(arg) ? arg : undefined
+    const result: { color?: ThemeColor; colors?: (ThemeColor | null)[] } = {}
+
+    if (varies_per_mark) {
+        const colors = new Array<ThemeColor | null>(rows.length)
+
+        for (let mark = 0; mark < rows.length; mark++) {
+            const row = rows[mark]
+
+            // the mark's position within its band's block is the segment it came from
+            const segment = mark % segment_count
+            const per_row = is_theme_color(row.color) ? row.color : undefined
+
+            colors[mark] = per_row ?? segment_color(arg, row, segment) ?? null
+        }
+        result.colors = colors
+    }
+
+    if (uniform !== undefined) {
+        result.color = uniform
+    }
+    return result
+}
+
+// One segment's color from the series-level arg: positional for an array, otherwise the shared accessor /
+// uniform path with the segment index standing in for the row index.
+function segment_color(
+    arg: StackColorArg | undefined,
+    row: Record<string, unknown>,
+    segment: number,
+): ThemeColor | undefined {
+    if (Array.isArray(arg)) {
+        const value = arg[segment]
+        return is_theme_color(value) ? value : undefined
+    }
+    return resolve_color_arg(arg, row, segment)
+}
+
+// One segment's value. An absent field stacks as 0 (sparse rows are the norm); anything else non-numeric
+// is a data error, so null / NaN / strings throw rather than silently vanishing.
+function read_segment_value(
+    row: Record<string, unknown>,
+    field: string,
+    row_index: number,
+    error_prefix: string,
+): number {
+    const raw = row[field]
+
+    if (raw === undefined) {
+        // default to 0 value for missing fields
+        return 0
+    }
+
+    if (typeof raw === 'number' && Number.isFinite(raw)) {
+        return raw
+    }
+    throw new Error(`${error_prefix}: row ${row_index} field '${field}' must be a finite number for a stacked segment; got ${describe_value(raw)}. Omit the field to stack it as 0.`)
+}
+
+// Short description of a rejected cell value, for the error message.
+function describe_value(raw: unknown): string {
+    if (raw === null) {
+        return 'null'
+    }
+
+    if (typeof raw === 'number') {
+        return String(raw)
+    }
+    return `a ${typeof raw}`
+}

--- a/plot/src/core/series/custom/factory.ts
+++ b/plot/src/core/series/custom/factory.ts
@@ -1,0 +1,221 @@
+import { attach_resolved_columns, resolve_column, validate_field_present, type ResolvedColumn } from "../../template/column"
+import { array_extent } from "../../template/extent"
+import { resolve_color } from "../../template/color"
+import { validate_finite, validate_hoverable } from "../../template/validate"
+import type { ColorArg, CustomHitTestFn, CustomRendererFn, CustomSeries, Domain, FieldArg, SelectFn, TooltipArg } from "../../types"
+
+export type CustomAxisRangeArg = { x?: number[]; y?: number[] }
+
+export type CustomArgs<TooltipContent = unknown> = {
+    data?: Record<string, unknown>[]
+    x?: FieldArg
+    y?: FieldArg
+    renderer: CustomRendererFn<TooltipContent>
+    hit_test?: CustomHitTestFn<TooltipContent>
+    color?: ColorArg
+    axis_range?: CustomAxisRangeArg
+    tooltip?: TooltipArg<Record<string, unknown> | undefined, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown> | undefined>
+    hoverable?: boolean
+}
+
+/**
+ * Custom series factory. Resolves whichever of x / y the caller claimed, leaves the other unclaimed, and
+ * carries the caller's renderer through to render time.
+ * @param args - custom series args (renderer, plus optional data, x, y, color, axis_range)
+ * @returns the resolved CustomSeries
+ */
+export function new_custom<TooltipContent = unknown>(args: CustomArgs<TooltipContent>): CustomSeries<TooltipContent> {
+    const resolved_x = resolve_custom_column(args.data, args.x, 'x')
+    const resolved_y = resolve_custom_column(args.data, args.y, 'y')
+    const series: CustomSeries<TooltipContent> = {
+        kind: 'custom',
+        x: resolved_x.values,
+        y: resolved_y.values,
+        renderer: args.renderer,
+    }
+    apply_custom_options(series, args)
+    attach_resolved_columns(
+        series,
+        {
+            x_mode: resolved_x.mode,
+            y_mode: resolved_y.mode,
+            x_categories: resolved_x.categories,
+            y_categories: resolved_y.categories,
+        },
+        args.x,
+        args.y,
+    )
+    return series
+}
+
+/**
+ * Resolve one axis' column. An axis the caller didn't name is left unclaimed: NaN at every row, so indices
+ * still line up with `rows` while the axis' domain stays untouched (array_extent returns the inverted
+ * [Infinity, -Infinity] that compute_domains merges away). With no data at all the column is empty, which is
+ * what makes a static overlay possible. Throws if a field is named but no data was passed.
+ * @param data - the data rows, when the value is a field
+ * @param field - the field name or accessor for this axis, or undefined
+ * @param side - the axis, for error messages
+ * @returns the resolved column plus its mode and categories
+ */
+function resolve_custom_column(
+    data: Record<string, unknown>[] | undefined,
+    field: FieldArg | undefined,
+    side: 'x' | 'y',
+): ResolvedColumn {
+    if (field === undefined) {
+        const length = data?.length ?? 0
+        return { values: new Float64Array(length).fill(NaN), mode: 'undecided', categories: null }
+    }
+
+    if (data === undefined) {
+        throw new Error(`plot.custom: ${side} names a field but no data was passed. Pass data to read ${side} per row, or drop ${side} and position what you draw from the scales.`)
+    }
+
+    if (data.length > 0) {
+        validate_field_present(data[0], field, false, 'plot.custom', side)
+    }
+    return resolve_column(data, field, 'plot.custom', side)
+}
+
+/**
+ * Apply the optional custom args onto the series, validating each.
+ * @param series - the series under construction
+ * @param args - the custom series args
+ */
+function apply_custom_options<TooltipContent>(series: CustomSeries<TooltipContent>, args: CustomArgs<TooltipContent>): void {
+    apply_custom_color(series, args)
+
+    if (args.axis_range !== undefined) {
+        series.axis_range = validate_axis_range(args.axis_range)
+    }
+    apply_custom_hover(series, args)
+
+    if (args.data !== undefined) {
+        series.rows = args.data // caller's original, so a renderer can read whatever the accessors didn't
+    }
+}
+
+/**
+ * Apply the hover args, rejecting the combinations that would silently never fire. Hover on a custom series
+ * runs entirely through the caller's `hit_test`, and its result indexes the series' own points — so a
+ * tooltip without a hit test, or either without rows to index, is a bug rather than a no-op.
+ * @param series - the series under construction
+ * @param args - the custom series args
+ */
+function apply_custom_hover<TooltipContent>(series: CustomSeries<TooltipContent>, args: CustomArgs<TooltipContent>): void {
+    const hoverable = validate_hoverable(args, 'plot.custom')
+    const wants_hover = args.tooltip !== undefined || args.on_select !== undefined
+
+    if (wants_hover && args.hit_test === undefined) {
+        throw new Error('plot.custom: tooltip / on_select are set but hit_test is not. A custom series is only ever hovered through its own hit_test, so nothing would fire. Add hit_test, or drop them.')
+    }
+
+    if (args.hit_test !== undefined && args.data === undefined) {
+        throw new Error('plot.custom: hit_test is set but no data was passed. A hit test returns the index of a point, and the hovered x / y / row are read back from the series at that index, so a series with no rows can never report a hit. Pass data.')
+    }
+
+    if (args.hit_test !== undefined && !wants_hover) {
+        throw new Error('plot.custom: hit_test is set but neither tooltip nor on_select is. A custom series has no hover highlight, so a hit test with nothing to fire runs on every pointer move and shows nothing. Add tooltip or on_select, or drop hit_test.')
+    }
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.hit_test !== undefined) {
+        series.hit_test = args.hit_test
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+}
+
+/**
+ * Resolve the series color(s). With data, per-row colors work as they do for any series; without it there's
+ * no row for an accessor to read, so only a uniform color is accepted. Throws on an accessor without data.
+ * @param series - the series under construction
+ * @param args - the custom series args
+ */
+function apply_custom_color<TooltipContent>(series: CustomSeries<TooltipContent>, args: CustomArgs<TooltipContent>): void {
+    const data = args.data
+
+    if (data !== undefined) {
+        const { color, colors } = resolve_color(data, args.color)
+
+        if (color !== undefined) {
+            series.color = color
+        }
+
+        if (colors !== undefined) {
+            series.colors = colors
+        }
+        return
+    }
+
+    if (args.color === undefined) {
+        return
+    }
+
+    if (typeof args.color === 'function') {
+        throw new Error('plot.custom: color is an accessor but no data was passed. An accessor reads a color per row; pass a color string or {light, dark} for a series with no rows.')
+    }
+    series.color = args.color
+}
+
+/**
+ * Validate a declared axis_range: each side present must be exactly [low, high], finite, and non-inverted.
+ * The schema only checks that the entries are numbers.
+ * @param axis_range - the caller's axis_range
+ * @returns the validated axis_range
+ */
+function validate_axis_range(axis_range: { x?: number[]; y?: number[] }): { x?: Domain; y?: Domain } {
+    const validated: { x?: Domain; y?: Domain } = {}
+
+    if (axis_range.x !== undefined) {
+        validated.x = validate_axis_range_side(axis_range.x, 'x')
+    }
+
+    if (axis_range.y !== undefined) {
+        validated.y = validate_axis_range_side(axis_range.y, 'y')
+    }
+    return validated
+}
+
+/**
+ * Validate one side of a declared axis_range.
+ * @param side_range - the [low, high] pair
+ * @param side - the axis, for error messages
+ * @returns the validated [low, high]
+ */
+function validate_axis_range_side(side_range: number[], side: 'x' | 'y'): Domain {
+    if (side_range.length !== 2) {
+        throw new Error(`plot.custom: axis_range.${side} takes exactly [low, high], got ${side_range.length} value(s).`)
+    }
+    const low = validate_finite(side_range[0], `plot.custom: axis_range.${side} low`)
+    const high = validate_finite(side_range[1], `plot.custom: axis_range.${side} high`)
+
+    if (low > high) {
+        throw new Error(`plot.custom: axis_range.${side} is [${low}, ${high}], which is inverted. Pass [low, high].`)
+    }
+    return [low, high]
+}
+
+/**
+ * The domain this series claims per axis: the declared axis_range where the caller gave one, otherwise the span
+ * of its own points. Per side, so declaring one axis leaves the other reading its points.
+ * @param series - the custom series
+ * @returns the [min, max] per axis
+ */
+export function custom_domain_extent(series: CustomSeries): { x: [number, number]; y: [number, number] } {
+    return {
+        x: series.axis_range?.x ?? array_extent(series.x),
+        y: series.axis_range?.y ?? array_extent(series.y),
+    }
+}

--- a/plot/src/core/series/custom/hit.ts
+++ b/plot/src/core/series/custom/hit.ts
@@ -1,0 +1,60 @@
+import type { ComposedCustom, ComposedSeries, HitContext, Rect, Scale } from "../../types"
+import { custom_resolvers } from "./paint"
+
+/**
+ * Hit-test a custom series by handing the cursor and the plot geometry to the caller's `hit_test`.
+ * Returns null when the series declared none, when the caller reports no hit, or when it reports an index
+ * outside the series — an out-of-range index would otherwise resolve to an undefined row. A hit test that
+ * throws is warned about and treated as a miss, so a broken one costs the tooltip rather than the plot.
+ * @param series - the composed custom series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area
+ * @returns the point index under the cursor, or null
+ */
+export function custom_hit_test<TooltipContent>(
+    series: ComposedSeries<TooltipContent>,
+    cursor: { x: number; y: number },
+    x_scale: Scale,
+    y_scale: Scale,
+    inner: Rect,
+): number | null {
+    const custom = series as ComposedCustom<TooltipContent>
+    const hit_test = custom.hit_test
+
+    if (hit_test === undefined) {
+        return null
+    }
+    const hit: HitContext = {
+        cursor,
+        inner,
+        x_scale,
+        y_scale,
+        ...custom_resolvers(custom, x_scale, y_scale),
+    }
+
+    try {
+        return bounded_index(hit_test(custom, hit), custom)
+    } catch (error) {
+        console.warn('plot.custom: hit_test threw, treating as no hit.', error)
+        return null
+    }
+}
+
+/**
+ * Keep a caller's index inside the series, so a stray one reads as a miss rather than an undefined row.
+ * @param index - the index the caller's hit test returned
+ * @param series - the composed custom series
+ * @returns the index, or null if it names no point
+ */
+function bounded_index<TooltipContent>(index: number | null, series: ComposedCustom<TooltipContent>): number | null {
+    if (index === null) {
+        return null
+    }
+
+    if (!Number.isInteger(index) || index < 0 || index >= series.x.length) {
+        return null
+    }
+    return index
+}

--- a/plot/src/core/series/custom/index.ts
+++ b/plot/src/core/series/custom/index.ts
@@ -1,0 +1,21 @@
+import type { CustomSeries, SeriesType } from "../../types"
+import { custom_domain_extent, new_custom } from "./factory"
+import { custom_hit_test } from "./hit"
+import { draw_custom } from "./paint"
+
+export {
+    custom_domain_extent,
+    new_custom,
+    type CustomArgs,
+    type CustomAxisRangeArg,
+} from "./factory"
+export { custom_hit_test } from "./hit"
+export { custom_resolvers, draw_custom } from "./paint"
+
+export const custom_runtime = {
+    kind: 'custom',
+    factory: new_custom,
+    paint: draw_custom,
+    tooltip_hit_test: custom_hit_test,
+    domain_extent: custom_domain_extent,
+} satisfies SeriesType<unknown, CustomSeries>

--- a/plot/src/core/series/custom/paint.ts
+++ b/plot/src/core/series/custom/paint.ts
@@ -1,0 +1,47 @@
+import type { ComposedCustom, ComposedSeries, CustomRenderContext, PixelResolver, RenderContext, Scale } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { color_resolver } from "../../template/color"
+
+/**
+ * Draw a custom series by handing the composed series and the render context to the caller's `renderer`
+ * @param series - the composed custom series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color, band categories)
+ */
+export function draw_custom<TooltipContent>(series: ComposedSeries<TooltipContent>, render: RenderContext): void {
+    const custom = series as ComposedCustom<TooltipContent>
+    const custom_render: CustomRenderContext = {
+        ...render,
+        ...custom_resolvers(custom, render.x_scale, render.y_scale),
+        color_at: color_resolver(custom.colors, render.color),
+    }
+
+    try {
+        custom.renderer(custom, custom_render)
+    } catch (error) {
+        console.warn('plot.custom: renderer threw, skipping this series.', error)
+    }
+}
+
+// Build the pixel resolvers handed to a caller's renderer and hit test
+export function custom_resolvers<TooltipContent>(
+    series: ComposedCustom<TooltipContent>,
+    x_scale: Scale,
+    y_scale: Scale
+): { resolve_x: PixelResolver; resolve_y: PixelResolver } {
+    return {
+        resolve_x: skip_unplaceable(pixel_resolver(x_scale, series.x)),
+        resolve_y: skip_unplaceable(pixel_resolver(y_scale, series.y)),
+    }
+}
+
+// Collapse every position a caller cannot draw at into undefined
+function skip_unplaceable(resolve: PixelResolver): PixelResolver {
+    return (i) => {
+        const position = resolve(i)
+
+        if (position === undefined || !Number.isFinite(position)) {
+            return undefined
+        }
+        return position
+    }
+}

--- a/plot/src/core/series/line/factory.ts
+++ b/plot/src/core/series/line/factory.ts
@@ -1,0 +1,82 @@
+import { attach_resolved_columns, resolve_xy_columns } from "../../template/column"
+import { resolve_stroke } from "../../template/color"
+import { validate_hoverable, validate_non_negative, validate_positive } from "../../template/validate"
+import type { FieldArg, LineSeries, MarkShape, SelectFn, StrokeArg, ThemeColor, TooltipArg } from "../../types"
+
+export type LineArgs<TooltipContent = unknown> = {
+    data: Record<string, unknown>[]
+    x?: FieldArg
+    y?: FieldArg
+    color?: ThemeColor
+    width?: number
+    dash?: number[]
+    mark?: MarkShape
+    mark_size?: number
+    mark_stroke?: StrokeArg
+    tooltip?: TooltipArg<Record<string, unknown>, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown>>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+/**
+ * Resolve line arguments into aligned numeric/category columns and validated presentation options.
+ * @param args - line series arguments
+ * @returns the resolved line series
+ */
+export function new_line<TooltipContent = unknown>(args: LineArgs<TooltipContent>): LineSeries<TooltipContent> {
+    const x_arg = args.x ?? 'x'
+    const y_arg = args.y ?? 'y'
+    const resolved = resolve_xy_columns(args.data, x_arg, y_arg, 'plot.line', args.x === undefined, args.y === undefined)
+    const series: LineSeries<TooltipContent> = {
+        kind: 'line',
+        x: resolved.x,
+        y: resolved.y,
+    }
+
+    if (args.color !== undefined) {
+        series.color = args.color
+    }
+
+    if (args.width !== undefined) {
+        series.width = validate_positive(args.width, 'plot.line: width')
+    }
+
+    if (args.dash !== undefined) {
+        series.dash = args.dash.map((segment, i) => validate_non_negative(segment, `plot.line: dash[${i}]`))
+    }
+
+    if (args.mark !== undefined) {
+        series.mark = args.mark
+    }
+
+    if (args.mark_size !== undefined) {
+        series.mark_size = validate_non_negative(args.mark_size, 'plot.line: mark_size')
+    }
+    const stroke = resolve_stroke(args.mark_stroke, 'plot.line: mark_stroke')
+
+    if (stroke !== undefined) {
+        series.stroke = stroke
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+    const hoverable = validate_hoverable(args, 'plot.line')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+
+    series.rows = args.data // Keep the caller's original rows for tooltip and selection payloads.
+    attach_resolved_columns(series, resolved, x_arg, y_arg)
+    return series
+}

--- a/plot/src/core/series/line/highlight.ts
+++ b/plot/src/core/series/line/highlight.ts
@@ -1,0 +1,32 @@
+import type { ComposedLine, HighlightSpec, Scale } from "../../types"
+import { DEFAULT_SERIES_COLOR } from "../../template/color"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { vertex_radius } from "./paint"
+
+/**
+ * The hover-select halo for a line vertex. A line drawing no vertex marks gets no halo.
+ * @param series - the composed line series
+ * @param point_index - the hovered vertex's row index
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the halo spec, or null where the line draws no marks or the vertex has no pixel position
+ */
+export function line_highlight_spec(series: ComposedLine, point_index: number, x_scale: Scale, y_scale: Scale): HighlightSpec | null {
+    const mark = series.mark
+
+    if (mark === undefined) {
+        return null
+    }
+    const cx = pixel_resolver(x_scale, series.x)(point_index)
+
+    if (cx === undefined) {
+        return null
+    }
+    const cy = pixel_resolver(y_scale, series.y)(point_index)
+
+    if (cy === undefined) {
+        return null
+    }
+    const color = series.color ?? DEFAULT_SERIES_COLOR
+    return { shape: 'mark', mark, cx, cy, r: vertex_radius(series), color }
+}

--- a/plot/src/core/series/line/hit.ts
+++ b/plot/src/core/series/line/hit.ts
@@ -1,0 +1,16 @@
+import type { ComposedLine, Scale } from "../../types"
+import { nearest_point_hit } from "../../render/hit"
+
+/**
+ * The line vertex under the cursor, or null. A vertex is hittable within its marker radius or a minimum
+ * affordance, whichever is larger; where hit regions overlap, the nearest vertex wins.
+ * @param series - the composed line series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the point index under the cursor, or null
+ */
+export function line_hit_test(series: ComposedLine, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale): number | null {
+    const marker_radius = series.mark === undefined ? 0 : (series.mark_size ?? 0) / 2
+    return nearest_point_hit(series, cursor, x_scale, y_scale, () => marker_radius)
+}

--- a/plot/src/core/series/line/index.ts
+++ b/plot/src/core/series/line/index.ts
@@ -1,0 +1,20 @@
+import { xy_extent } from "../../template/extent"
+import type { LineSeries, SeriesType } from "../../types"
+import { new_line } from "./factory"
+import { line_highlight_spec } from "./highlight"
+import { line_hit_test } from "./hit"
+import { draw_line } from "./paint"
+
+export { new_line, type LineArgs } from "./factory"
+export { line_highlight_spec } from "./highlight"
+export { line_hit_test } from "./hit"
+export { draw_line, vertex_radius } from "./paint"
+
+export const line_runtime = {
+    kind: 'line',
+    factory: new_line,
+    paint: draw_line,
+    tooltip_hit_test: line_hit_test,
+    highlight_spec: line_highlight_spec,
+    domain_extent: xy_extent,
+} satisfies SeriesType<unknown, LineSeries>

--- a/plot/src/core/series/line/paint.ts
+++ b/plot/src/core/series/line/paint.ts
@@ -1,0 +1,94 @@
+import type { ComposedLine, RenderContext } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { draw_mark } from "../../render/mark"
+
+const DEFAULT_WIDTH = 2
+const DEFAULT_MARK_DIAMETER = 6
+
+/**
+ * Draw a line series: connect the points in data order with straight segments, clipped to the inner rect.
+ * A point that doesn't resolve (unknown category / non-finite) breaks the line, restarting a fresh segment
+ * at the next valid point. With `mark` set, a vertex marker is drawn at each point in the line color.
+ * @param series - the line series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_line(series: ComposedLine, render: RenderContext): void {
+    const { ctx, x_scale, y_scale, color } = render
+
+    if (series.x.length === 0) {
+        return
+    }
+    const length = series.x.length
+    const resolve_x = pixel_resolver(x_scale, series.x)
+    const resolve_y = pixel_resolver(y_scale, series.y)
+
+    ctx.strokeStyle = color
+    ctx.lineWidth = series.width ?? DEFAULT_WIDTH
+    ctx.setLineDash(series.dash ?? [])
+
+    ctx.beginPath()
+    let pen_down = false
+
+    for (let i = 0; i < length; i++) {
+        const px = resolve_x(i)
+        const py = resolve_y(i)
+
+        if (px === undefined || py === undefined) {
+            pen_down = false
+            continue
+        }
+
+        if (pen_down) {
+            ctx.lineTo(px, py)
+        } else {
+            ctx.moveTo(px, py)
+            pen_down = true
+        }
+    }
+    ctx.stroke()
+
+    if (series.mark !== undefined) {
+        draw_vertex_marks(ctx, series, resolve_x, resolve_y, color)
+    }
+}
+
+/**
+ * Draw a filled marker at each vertex, in the line color.
+ * @param ctx - canvas context
+ * @param series - the line series
+ * @param resolve_x - x pixel resolver
+ * @param resolve_y - y pixel resolver
+ * @param color - the line (and marker) color
+ */
+function draw_vertex_marks(
+    ctx: RenderContext['ctx'],
+    series: ComposedLine,
+    resolve_x: (i: number) => number | undefined,
+    resolve_y: (i: number) => number | undefined,
+    color: string,
+): void {
+    const radius = vertex_radius(series)
+    const mark = series.mark ?? 'circle'
+    const stroke = series.stroke
+    ctx.setLineDash([])
+    ctx.fillStyle = color
+
+    for (let i = 0; i < series.x.length; i++) {
+        const px = resolve_x(i)
+        const py = resolve_y(i)
+
+        if (px === undefined || py === undefined) {
+            continue
+        }
+        draw_mark(ctx, mark, px, py, radius, stroke)
+    }
+}
+
+/**
+ * A line vertex's marker radius in pixels: half the mark size, else the default.
+ * @param series - the line series
+ * @returns the vertex marker radius
+ */
+export function vertex_radius(series: ComposedLine): number {
+    return (series.mark_size ?? DEFAULT_MARK_DIAMETER) / 2
+}

--- a/plot/src/core/series/rect/factory.ts
+++ b/plot/src/core/series/rect/factory.ts
@@ -1,0 +1,418 @@
+import { attach_resolved_columns, resolve_column, validate_field_present, type ColumnMode, type ResolvedColumn } from "../../template/column"
+import { array_extent } from "../../template/extent"
+import { validate_finite, validate_non_negative, validate_hoverable, validate_hover_span } from "../../template/validate"
+import { resolve_color, resolve_stroke } from "../../template/color"
+import type { ColorArg, FieldArg, RectAlign, RectSeries, SelectFn, StrokeArg, TooltipArg } from "../../types"
+
+export type RectSizeArg = number | { width?: number; height?: number }
+export type RectOffsetArg = { x?: number; y?: number }
+
+export type RectArgs<TooltipContent = unknown> = {
+    data: Record<string, unknown>[]
+    x?: FieldArg
+    x2?: FieldArg
+    y?: FieldArg
+    y2?: FieldArg
+    span?: 'x' | 'y'
+    size?: RectSizeArg
+    band_align?: RectAlign
+    hover_span_x?: boolean
+    hover_span_y?: boolean
+    inset?: number
+    min_size?: number
+    offset?: RectOffsetArg
+    color?: ColorArg
+    stroke?: StrokeArg
+    tooltip?: TooltipArg<Record<string, unknown>, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown>>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+/**
+ * Rect series factory. Resolves x / y (and the opposite corners x2 / y2) into aligned Float64Arrays,
+ * validates each axis, and resolves color.
+ * @param args - rect series args (data, x, x2, y, y2, color)
+ * @returns the resolved RectSeries
+ */
+export function new_rect<TooltipContent = unknown>(args: RectArgs<TooltipContent>): RectSeries<TooltipContent> {
+    const span = args.span
+    validate_span(args, span)
+
+    const x_fields = axis_field_args(args, 'x')
+    const y_fields = axis_field_args(args, 'y')
+
+    const resolved = resolve_rect_columns(args.data, x_fields.value, x_fields.corner, y_fields.value, y_fields.corner, 'plot.rect', args.x === undefined, args.y === undefined)
+    const size = resolve_size(args.size)
+    const offset = resolve_offset(args.offset)
+    const stroke = resolve_stroke(args.stroke, 'plot.rect')
+
+    // empty data exposes no column types to detect; an empty series renders nothing
+    if (args.data.length > 0) {
+        if (span !== 'x') {
+            validate_rect_axis('x', 'x2', resolved.x_mode, x_fields.corner !== undefined, resolved.x2_mode, size?.width !== undefined)
+        }
+
+        if (span !== 'y') {
+            validate_rect_axis('y', 'y2', resolved.y_mode, y_fields.corner !== undefined, resolved.y2_mode, size?.height !== undefined)
+        }
+    }
+
+    const series: RectSeries<TooltipContent> = {
+        kind: 'rect',
+        x: resolved.x1,
+        y: resolved.y1,
+        ...resolve_color(args.data, args.color),
+    }
+
+    if (span !== undefined) {
+        series.span = span
+    }
+
+    if (resolved.x2 !== undefined) {
+        series.x2 = resolved.x2
+    }
+
+    if (resolved.y2 !== undefined) {
+        series.y2 = resolved.y2
+    }
+
+    if (size !== undefined) {
+        series.size = size
+    }
+
+    if (args.band_align !== undefined) {
+        series.band_align = args.band_align
+    }
+
+    if (args.inset !== undefined) {
+        series.inset = validate_non_negative(args.inset, 'plot.rect: inset')
+    }
+
+    if (args.min_size !== undefined) {
+        series.min_size = validate_non_negative(args.min_size, 'plot.rect: min_size')
+    }
+
+    if (offset !== undefined) {
+        series.offset = offset
+    }
+
+    if (stroke !== undefined) {
+        series.stroke = stroke
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+
+    const hoverable = validate_hoverable(args, 'plot.rect')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.hover_span_x !== undefined) {
+        series.hover_span_x = validate_hover_span(args.hover_span_x, hoverable, 'hover_span_x', 'plot.rect')
+    }
+
+    if (args.hover_span_y !== undefined) {
+        series.hover_span_y = validate_hover_span(args.hover_span_y, hoverable, 'hover_span_y', 'plot.rect')
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+
+    series.rows = args.data // caller's original for the tooltip
+    attach_resolved_columns(series, resolved, x_fields.value, y_fields.value)
+    return series
+}
+
+/**
+ * The field args for one axis. A spanned axis reads nothing on that side, so both come back undefined;
+ * otherwise the value column defaults to the axis' own name and the corner follows the x2 / y2 convention.
+ * @param args - the rect series args
+ * @param axis - the axis to resolve fields for
+ * @returns the value and corner field args for that axis
+ */
+function axis_field_args(args: RectArgs, axis: 'x' | 'y'): { value: FieldArg | undefined; corner: FieldArg | undefined } {
+    if (args.span === axis) {
+        return { value: undefined, corner: undefined }
+    }
+    const corner_field = axis === 'x' ? 'x2' : 'y2'
+    return {
+        value: args[axis] ?? axis,
+        corner: default_corner(args[corner_field], args.data, corner_field),
+    }
+}
+
+/**
+ * Default an optional corner field: the caller's arg wins; otherwise adopt the same-named field ('x2' /
+ * 'y2') when any row carries it, else leave it unset (so center+size or band mode applies).
+ * @param corner_arg - the caller's x2 / y2 arg, or undefined
+ * @param data - the data rows
+ * @param field - the conventional field name for this corner
+ * @returns the resolved corner field arg, or undefined when none applies
+ */
+function default_corner(corner_arg: FieldArg | undefined, data: Record<string, unknown>[], field: string): FieldArg | undefined {
+    if (corner_arg !== undefined) {
+        return corner_arg
+    }
+
+    if (data.some(row => field in row)) {
+        return field
+    }
+    return undefined
+}
+
+/**
+ * Normalize the size arg into per-axis pixel sizes, validating each is non-negative and finite.
+ * A number is a square; an object sets width / height independently.
+ * @param size - the size arg (number, object, or undefined)
+ * @returns the per-axis pixel size, or undefined when none applies
+ */
+function resolve_size(size: RectArgs['size']): { width?: number; height?: number } | undefined {
+    if (size === undefined) {
+        return undefined
+    }
+
+    if (typeof size === 'number') {
+        const pixels = validate_non_negative(size, 'plot.rect: size')
+        return { width: pixels, height: pixels }
+    }
+    const result: { width?: number; height?: number } = {}
+
+    if (size.width !== undefined) {
+        result.width = validate_non_negative(size.width, 'plot.rect: size.width')
+    }
+
+    if (size.height !== undefined) {
+        result.height = validate_non_negative(size.height, 'plot.rect: size.height')
+    }
+
+    if (result.width === undefined && result.height === undefined) {
+        return undefined
+    }
+    return result
+}
+
+/**
+ * Normalize the offset arg into a per-axis pixel shift.
+ * @param offset - the offset arg ({ x?, y? }, or undefined)
+ * @returns the per-axis pixel offset, or undefined when none applies
+ */
+function resolve_offset(offset: RectArgs['offset']): { x?: number; y?: number } | undefined {
+    if (offset === undefined) {
+        return undefined
+    }
+    const result: { x?: number; y?: number } = {}
+
+    if (offset.x !== undefined) {
+        result.x = validate_finite(offset.x, 'plot.rect: offset.x')
+    }
+
+    if (offset.y !== undefined) {
+        result.y = validate_finite(offset.y, 'plot.rect: offset.y')
+    }
+
+    if (result.x === undefined && result.y === undefined) {
+        return undefined
+    }
+    return result
+}
+
+/**
+ * Reject args that contradict `span`. A spanned axis gets its extent from the plot, so data or a pixel size on
+ * that side describes a different rect than the one the caller asked for.
+ * @param args - the rect series args
+ * @param span - the spanned axis, or undefined
+ */
+function validate_span(args: RectArgs, span: 'x' | 'y' | undefined): void {
+    if (span === undefined) {
+        return
+    }
+    const corner = span === 'x' ? 'x2' : 'y2'
+    const dimension = span === 'x' ? 'width' : 'height'
+    const conflicts: string[] = []
+
+    if (args[span] !== undefined) {
+        conflicts.push(span)
+    }
+
+    if (args[corner] !== undefined) {
+        conflicts.push(corner)
+    }
+    const size_conflict = spanned_size_conflict(args.size, dimension)
+
+    if (size_conflict !== undefined) {
+        conflicts.push(size_conflict)
+    }
+
+    if (conflicts.length === 0) {
+        return
+    }
+    const fields = conflicts.join(', ')
+    throw new Error(`plot.rect: span: '${span}' fills the whole ${span} axis, so ${fields} can't apply. Drop ${fields}, or drop span and place the rect on ${span} yourself.`)
+}
+
+/**
+ * The `size` conflict for a spanned axis, if any. A bare number sizes both axes, so it clashes even when the
+ * caller only meant the other one.
+ * @param size - the size arg
+ * @param dimension - the spanned axis' dimension
+ * @returns the conflicting field, for the error message, or undefined
+ */
+function spanned_size_conflict(size: RectArgs['size'], dimension: 'width' | 'height'): string | undefined {
+    if (typeof size === 'number') {
+        return `size (a bare number sizes both axes; pass { ${dimension === 'width' ? 'height' : 'width'} } for the other one)`
+    }
+
+    if (size?.[dimension] !== undefined) {
+        return `size.${dimension}`
+    }
+    return undefined
+}
+
+/**
+ * Enforce the rect rules for one axis: a categorical axis fills the band (no corner) unless a size
+ * overrides it with a centered pixel size; a numeric axis sets its span with exactly one of an opposite
+ * corner or a center-mode size.
+ * @param axis - axis side, for messages
+ * @param corner - the opposite-corner field name, for messages
+ * @param mode - the first column's detected type
+ * @param has_corner - whether the opposite corner was provided
+ * @param corner_mode - the opposite corner's detected type
+ * @param has_size - whether a center-mode size (width/height) applies to this axis
+ */
+function validate_rect_axis(axis: 'x' | 'y', corner: 'x2' | 'y2', mode: string, has_corner: boolean, corner_mode: string, has_size: boolean): void {
+    const dimension = axis === 'x' ? 'width' : 'height'
+
+    if (mode === 'categorical') {
+        if (has_corner) {
+            throw new Error(`plot.rect: ${axis} is categorical, so the rect fills the band; drop ${corner}.`)
+        }
+
+        return
+    }
+
+    if (has_corner && has_size) {
+        throw new Error(`plot.rect: numeric ${axis} got both ${corner} and a size ${dimension}; use one (a data span or a centered pixel size).`)
+    }
+
+    if (!has_corner && !has_size) {
+        throw new Error(`plot.rect: numeric ${axis} needs ${corner} (a data span) or a size ${dimension} (a centered pixel size).`)
+    }
+
+    if (has_corner && corner_mode === 'categorical') {
+        throw new Error(`plot.rect: ${corner} must be numeric to pair with ${axis}.`)
+    }
+}
+
+/**
+ * The rect's data extent per axis: a numeric axis spans x..x2 (so the domain must cover both corners),
+ * a categorical axis falls back to its band indices (unused, the band scale owns its layout).
+ * @param series - the rect series
+ * @returns the [min, max] per axis
+ */
+export function rect_domain_extent(series: RectSeries): { x: [number, number]; y: [number, number] } {
+    return {
+        x: span_extent(series.x, series.x2),
+        y: span_extent(series.y, series.y2),
+    }
+}
+
+/**
+ * The [min, max] across a column and its optional opposite corner.
+ * @param lo - the first corner per row
+ * @param hi - the opposite corner per row, or undefined
+ * @returns the combined extent
+ */
+function span_extent(lo: Float64Array, hi: Float64Array | undefined): [number, number] {
+    const [lo_min, lo_max] = array_extent(lo)
+
+    if (hi === undefined) {
+        return [lo_min, lo_max]
+    }
+    const [hi_min, hi_max] = array_extent(hi)
+    return [Math.min(lo_min, hi_min), Math.max(lo_max, hi_max)]
+}
+
+function unconstrained_column(length: number): ResolvedColumn {
+    return { values: new Float64Array(length).fill(NaN), mode: 'undecided', categories: null }
+}
+
+export type ResolvedRectColumns = {
+    x1: Float64Array
+    y1: Float64Array
+    x2?: Float64Array
+    y2?: Float64Array
+    x_mode: ColumnMode
+    y_mode: ColumnMode
+    x2_mode: ColumnMode
+    y2_mode: ColumnMode
+    x_categories: string[] | null
+    y_categories: string[] | null
+}
+
+/**
+ * Resolve a rect series' columns: x / y always, plus the optional opposite corners x2 / y2. Each column
+ * gets its own type detection; the factory enforces the rect rules (a corner must be numeric, a
+ * categorical axis carries no corner).
+ * @param data - the data rows
+ * @param x_arg - x (first corner / band) field name or accessor
+ * @param x2_arg - x2 (opposite corner) field name or accessor, or undefined
+ * @param y_arg - y field name or accessor
+ * @param y2_arg - y2 field name or accessor, or undefined
+ * @param error_prefix - label prefixed to thrown errors
+ * @param x_defaulted - whether x fell back to the default field name
+ * @param y_defaulted - whether y fell back to the default field name
+ * @returns the resolved arrays plus per-column mode and categories
+ */
+export function resolve_rect_columns(
+    data: Record<string, unknown>[],
+    x_arg: FieldArg | undefined,
+    x2_arg: FieldArg | undefined,
+    y_arg: FieldArg | undefined,
+    y2_arg: FieldArg | undefined,
+    error_prefix: string,
+    x_defaulted: boolean,
+    y_defaulted: boolean,
+): ResolvedRectColumns {
+    if (data.length > 0) {
+        if (x_arg !== undefined) {
+            validate_field_present(data[0], x_arg, x_defaulted, error_prefix, 'x')
+        }
+
+        if (y_arg !== undefined) {
+            validate_field_present(data[0], y_arg, y_defaulted, error_prefix, 'y')
+        }
+
+        if (x2_arg !== undefined) {
+            validate_field_present(data[0], x2_arg, false, error_prefix, 'x2')
+        }
+
+        if (y2_arg !== undefined) {
+            validate_field_present(data[0], y2_arg, false, error_prefix, 'y2')
+        }
+    }
+    const x = x_arg === undefined ? unconstrained_column(data.length) : resolve_column(data, x_arg, error_prefix, 'x')
+    const y = y_arg === undefined ? unconstrained_column(data.length) : resolve_column(data, y_arg, error_prefix, 'y')
+    const x2 = x2_arg === undefined ? undefined : resolve_column(data, x2_arg, error_prefix, 'x2')
+    const y2 = y2_arg === undefined ? undefined : resolve_column(data, y2_arg, error_prefix, 'y2')
+    return {
+        x1: x.values,
+        y1: y.values,
+        x2: x2?.values,
+        y2: y2?.values,
+        x_mode: x.mode,
+        y_mode: y.mode,
+        x2_mode: x2?.mode ?? 'undecided',
+        y2_mode: y2?.mode ?? 'undecided',
+        x_categories: x.categories,
+        y_categories: y.categories,
+    }
+}

--- a/plot/src/core/series/rect/highlight.ts
+++ b/plot/src/core/series/rect/highlight.ts
@@ -1,0 +1,23 @@
+import type { ComposedRect, HighlightSpec, Rect, Scale } from "../../types"
+import { DEFAULT_SERIES_COLOR } from "../../template/color"
+import { make_rect_resolver } from "./paint"
+
+/**
+ * The hover-select halo for a rect: its rectangle bounds in canvas pixels, in the rect's color. Reuses
+ * make_rect_resolver so the bounds match the drawn rect exactly (band fill / data span / sized, plus align and offset).
+ * @param series - the composed rect series
+ * @param point_index - the hovered rect's row index
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area, which a spanned axis covers edge to edge
+ * @returns the rect spec, or null if the rect has no pixel span (unknown category / non-finite)
+ */
+export function rect_highlight_spec(series: ComposedRect, point_index: number, x_scale: Scale, y_scale: Scale, inner: Rect): HighlightSpec | null {
+    const rect = make_rect_resolver(series, x_scale, y_scale, inner)(point_index)
+
+    if (rect === null) {
+        return null
+    }
+    const color = series.colors?.[point_index] ?? series.color ?? DEFAULT_SERIES_COLOR
+    return { shape: 'rect', x: rect.left, y: rect.top, width: rect.width, height: rect.height, color }
+}

--- a/plot/src/core/series/rect/hit.ts
+++ b/plot/src/core/series/rect/hit.ts
@@ -1,0 +1,106 @@
+import type { BandScale, ComposedRect, PixelRect, Rect, Scale } from "../../types"
+import { make_rect_resolver } from "./paint"
+
+// The band geometry a hit region widens across when that axis fills its hover span.
+type BandAxis = { band_scale: BandScale; bands: Float64Array }
+
+/**
+ * The rect whose hit region contains the cursor, or null. On overlap the last-drawn rect wins, matching paint
+ * order. hover_span_x / hover_span_y widen the region to the whole band on a categorical axis; otherwise only
+ * the drawn rect is hittable.
+ * @param series - the composed rect series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area, which a spanned axis covers edge to edge
+ * @returns the point index under the cursor, or null
+ */
+export function rect_hit_test(series: ComposedRect, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale, inner: Rect): number | null {
+    // a drawn span already covers the plot area edge to edge, so that axis has nothing left to widen
+    const widen_x = series.hover_span_x === true && series.span !== 'x'
+    const widen_y = series.hover_span_y === true && series.span !== 'y'
+    const rect_at = make_rect_resolver(series, x_scale, y_scale, inner)
+    const x_band = widen_x ? band_axis(x_scale, series.x) : null
+    const y_band = widen_y ? band_axis(y_scale, series.y) : null
+
+    // last drawn rect wins on overlap, so keep the highest hit index rather than returning early
+    let hit: number | null = null
+
+    for (let i = 0; i < series.x.length; i++) {
+        const drawn = rect_at(i)
+
+        if (drawn === null) {
+            continue
+        }
+        const rect = hit_region(drawn, i, x_band, y_band)
+        const in_x = cursor.x >= rect.left && cursor.x <= rect.left + rect.width
+        const in_y = cursor.y >= rect.top && cursor.y <= rect.top + rect.height
+
+        if (in_x && in_y) {
+            hit = i
+        }
+    }
+
+    return hit
+}
+
+function band_axis(scale: Scale, bands: Float64Array): BandAxis | null {
+    if ('bandwidth' in scale) {
+        return { band_scale: scale, bands }
+    }
+    return null
+}
+
+/**
+ * The region to hit-test one rect against: its drawn bounds, widened to the whole band on each axis that
+ * fills its hover span. Unioning rather than replacing keeps a rect whose `size` overhangs its band hittable
+ * over all of what it draws.
+ * @param drawn - the rect's drawn bounds
+ * @param i - the row index
+ * @param x_band - the x band axis, or null when x isn't widened
+ * @param y_band - the y band axis, or null when y isn't widened
+ * @returns the hit region in canvas pixels
+ */
+function hit_region(drawn: PixelRect, i: number, x_band: BandAxis | null, y_band: BandAxis | null): PixelRect {
+    const x = union_span(drawn.left, drawn.width, band_span(i, x_band))
+    const y = union_span(drawn.top, drawn.height, band_span(i, y_band))
+
+    return { left: x.start, top: y.start, width: x.extent, height: y.extent }
+}
+
+/**
+ * The band one mark fills on an axis, or null where there is nothing to widen to — an axis that isn't
+ * widened, or a band value outside the scale's domain.
+ * @param i - the row index
+ * @param axis - the axis' band geometry, or null
+ * @returns the band's two ends, in either order
+ */
+function band_span(i: number, axis: BandAxis | null): [number, number] | null {
+    if (axis === null) {
+        return null
+    }
+    const band_start = axis.band_scale(axis.bands[i])
+
+    if (band_start === undefined) {
+        return null
+    }
+    return [band_start, band_start + axis.band_scale.bandwidth()]
+}
+
+/**
+ * One axis of a hit region: the drawn span unioned with the band. A band range can run backwards, so its
+ * ends are ordered rather than assumed.
+ * @param start - the drawn span's low pixel
+ * @param extent - the drawn span's pixel extent
+ * @param span - the band to union in, or null to leave the drawn span alone
+ * @returns the hit span's start and extent
+ */
+function union_span(start: number, extent: number, span: [number, number] | null): { start: number; extent: number } {
+    if (span === null) {
+        return { start, extent }
+    }
+    const low = Math.min(start, span[0], span[1])
+    const high = Math.max(start + extent, span[0], span[1])
+
+    return { start: low, extent: high - low }
+}

--- a/plot/src/core/series/rect/index.ts
+++ b/plot/src/core/series/rect/index.ts
@@ -1,0 +1,27 @@
+import type { RectSeries, SeriesType } from "../../types"
+import { new_rect, rect_domain_extent } from "./factory"
+import { rect_highlight_spec } from "./highlight"
+import { rect_hit_test } from "./hit"
+import { draw_rect } from "./paint"
+
+export {
+    new_rect,
+    rect_domain_extent,
+    resolve_rect_columns,
+    type RectArgs,
+    type RectOffsetArg,
+    type RectSizeArg,
+    type ResolvedRectColumns,
+} from "./factory"
+export { rect_highlight_spec } from "./highlight"
+export { rect_hit_test } from "./hit"
+export { draw_rect, make_rect_resolver } from "./paint"
+
+export const rect_runtime = {
+    kind: 'rect',
+    factory: new_rect,
+    paint: draw_rect,
+    tooltip_hit_test: rect_hit_test,
+    highlight_spec: rect_highlight_spec,
+    domain_extent: rect_domain_extent,
+} satisfies SeriesType<unknown, RectSeries>

--- a/plot/src/core/series/rect/paint.ts
+++ b/plot/src/core/series/rect/paint.ts
@@ -1,0 +1,212 @@
+import type { ComposedRect, PixelRect, Rect, RectAlign, RenderContext, Scale } from "../../types"
+import { inset_band } from "../../render/band"
+
+/**
+ * Draw a rect series: each row is a rectangle spanning [x, x2] x [y, y2] in data space, or filling the
+ * band on a categorical axis. Per-row color overrides the series default. Clipped to the inner rect.
+ * @param series - the rect series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_rect(series: ComposedRect, render: RenderContext): void {
+    const { ctx, inner, x_scale, y_scale, color } = render
+
+    if (series.x.length === 0) {
+        return
+    }
+    ctx.fillStyle = color
+    const colors = series.colors
+    const stroke = series.stroke
+    const has_stroke = stroke !== undefined
+    const stroke_width = stroke?.width
+    const rect_at = make_rect_resolver(series, x_scale, y_scale, inner)
+
+    if (has_stroke) {
+        ctx.strokeStyle = stroke.color
+
+        if (stroke_width !== undefined) {
+            ctx.lineWidth = stroke_width
+        }
+    }
+
+    for (let i = 0; i < series.x.length; i++) {
+        const rect = rect_at(i)
+
+        if (rect === null) {
+            continue
+        }
+
+        if (colors !== undefined) {
+            ctx.fillStyle = colors[i] ?? color
+        }
+        ctx.fillRect(rect.left, rect.top, rect.width, rect.height)
+
+        if (has_stroke) {
+            if (stroke_width === undefined) {
+                ctx.lineWidth = auto_stroke_width(rect.width, rect.height)
+            }
+            ctx.strokeRect(rect.left, rect.top, rect.width, rect.height)
+        }
+    }
+}
+
+/**
+ * Build a per-row rectangle resolver: combines the x / y span resolvers with the band align and offset
+ * into one `(i) => PixelRect | null`. Shared by the rect paint, hit-test, and hover highlight so the rect
+ * bounds (band fill / data span / sized, plus align and offset) are computed one way.
+ * @param series - the composed rect series
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area, which a spanned axis covers edge to edge
+ * @returns a resolver mapping a row index to its { left, top, width, height } in canvas pixels, or null
+ */
+export function make_rect_resolver(series: ComposedRect, x_scale: Scale, y_scale: Scale, inner: Rect): (i: number) => PixelRect | null {
+    const align = series.band_align ?? 'center'
+    const offset_x = series.offset?.x ?? 0
+    const offset_y = series.offset?.y ?? 0
+    const inset = series.inset
+    const min_size = series.min_size
+    const resolve_x = series.span === 'x'
+        ? full_span_resolver([inner.left, inner.right])
+        : make_span_resolver(x_scale, series.x, series.x2, { size: series.size?.width, align, inset, min_size })
+    const resolve_y = series.span === 'y'
+        ? full_span_resolver([inner.top, inner.bottom])
+        : make_span_resolver(y_scale, series.y, series.y2, { size: series.size?.height, align, inset, min_size })
+
+    return (i) => {
+        const x_span = resolve_x(i)
+
+        if (x_span === undefined) {
+            return null
+        }
+        const y_span = resolve_y(i)
+
+        if (y_span === undefined) {
+            return null
+        }
+        // a scale can return the corners in either order (y inverts data to pixels), so normalize. offset
+        // shifts both endpoints equally, so only the origin moves; width / height are unchanged
+        return {
+            left: Math.min(x_span[0], x_span[1]) + offset_x,
+            top: Math.min(y_span[0], y_span[1]) + offset_y,
+            width: Math.abs(x_span[1] - x_span[0]),
+            height: Math.abs(y_span[1] - y_span[0]),
+        }
+    }
+}
+
+// A spanned axis covers the plot area edge to edge, through any axis padding — the scale's range stops short of
+// it, so this reads the inner rect instead. Matches how a rule is drawn across the axis it doesn't constrain.
+function full_span_resolver(span: [number, number]): (i: number) => [number, number] {
+    return () => span
+}
+
+const STROKE_AUTO_FRACTION = 0.04
+const STROKE_MIN_WIDTH = 0.2
+const STROKE_MAX_WIDTH = 1
+
+/**
+ * Derive a stroke width from a rect's pixel dimensions, scaling with the smaller side.
+ * @param width - the rect's pixel width
+ * @param height - the rect's pixel height
+ * @returns the clamped stroke width in pixels
+ */
+function auto_stroke_width(width: number, height: number): number {
+    const derived = Math.min(width, height) * STROKE_AUTO_FRACTION
+    return Math.max(STROKE_MIN_WIDTH, Math.min(derived, STROKE_MAX_WIDTH))
+}
+
+type SpanOptions = {
+    size: number | undefined
+    align: RectAlign
+    inset: number | undefined
+    min_size: number | undefined
+}
+
+/**
+ * Build a per-row pixel-span resolver. Band fills the whole band (unless a size overrides) and returns undefined for unknown categories
+ * A pixel size maps the center then spreads it by half the size.
+ * @param scale - the axis scale
+ * @param lo - the first corner / center / band value per row
+ * @param hi - the opposite corner per row, or undefined when not a data span
+ * @param options - sizing, band alignment, inset and the data-span floor
+ * @returns a resolver mapping row index to a pixel span, or undefined to skip
+ */
+function make_span_resolver(scale: Scale, lo: Float64Array, hi: Float64Array | undefined, options: SpanOptions): (i: number) => [number, number] | undefined {
+    const { size, align, inset, min_size } = options
+
+    if ('bandwidth' in scale) {
+        const bandwidth = scale.bandwidth()
+        return (i) => {
+            const raw_start = scale(lo[i])
+
+            if (raw_start === undefined) {
+                return undefined
+            }
+            const { start, extent } = inset_band(raw_start, bandwidth, inset)
+
+            // a size overrides the band fill, anchored per align, so a highlight rect can exceed the band height
+            if (size !== undefined) {
+                return align_band_span(start, extent, size, align)
+            }
+            return [start, start + extent]
+        }
+    }
+
+    if (size !== undefined) {
+        const half = size / 2
+        return (i) => {
+            const center = scale(lo[i])
+
+            if (!Number.isFinite(center)) {
+                return undefined
+            }
+            return [center - half, center + half]
+        }
+    }
+
+    if (hi !== undefined) {
+        return (i) => {
+            const start = scale(lo[i])
+            const end = scale(hi[i])
+            const finite = Number.isFinite(start) && Number.isFinite(end)
+
+            if (!finite) {
+                return undefined
+            }
+
+            if (min_size === undefined || Math.abs(end - start) >= min_size) {
+                return [start, end]
+            }
+            const center = (start + end) / 2
+            return [center - min_size / 2, center + min_size / 2]
+        }
+    }
+
+    // unreachable: validate_rect_axis guarantees we won't reach here.
+    throw new Error('plot.rect: internal — numeric axis resolved without a corner, size, or band')
+}
+
+/**
+ * Place a fixed-`size` rect within a band per `align`: centered, or flush to the start / end edge.
+ * `band` may be negative (inverted range), so edge offsets follow its sign to stay on the interior side.
+ * @param start - the band's scale-start pixel
+ * @param band - the signed band width in pixels
+ * @param size - the sized dimension in pixels
+ * @param align - center (default), or the start / end edge to anchor to
+ * @returns the pixel span (either order; the paint normalizes)
+ */
+function align_band_span(start: number, band: number, size: number, align: RectAlign): [number, number] {
+    const dir = Math.sign(band) || 1
+
+    if (align === 'start') {
+        return [start, start + dir * size]
+    }
+
+    if (align === 'end') {
+        const far = start + band
+        return [far, far - dir * size]
+    }
+    const half = size / 2
+    const center = start + band / 2
+    return [center - half, center + half]
+}

--- a/plot/src/core/series/rule/factory.ts
+++ b/plot/src/core/series/rule/factory.ts
@@ -1,0 +1,212 @@
+import { resolve_column, validate_field_present, type ColumnMode } from "../../template/column"
+import { resolve_color } from "../../template/color"
+import { validate_finite, validate_hoverable, validate_non_negative, validate_positive } from "../../template/validate"
+import type { ColorArg, FieldArg, RuleSeries, SelectFn, TooltipArg } from "../../types"
+
+export type RuleValueArg = number | FieldArg
+
+export type RuleArgs<TooltipContent = unknown> = {
+    data?: Record<string, unknown>[]
+    x?: RuleValueArg
+    y?: RuleValueArg
+    color?: ColorArg
+    width?: number
+    dash?: number[]
+    tooltip?: TooltipArg<Record<string, unknown> | undefined, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown> | undefined>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+// one resolved rule column: the values on the rule's axis, plus what that column turned out to be
+type ResolvedRule = {
+    values: Float64Array
+    mode: ColumnMode
+    categories: string[] | null
+    field?: string
+}
+
+/**
+ * Rule series factory. Resolves the one value column (a bare number, a category, or a field over data rows)
+ * and fills the other axis with NaN so the rule stays out of that axis' domain.
+ * @param args - rule series args (x or y, data, color, width, dash)
+ * @returns the resolved RuleSeries
+ */
+export function new_rule<TooltipContent = unknown>(args: RuleArgs<TooltipContent>): RuleSeries<TooltipContent> {
+    const side = rule_side(args)
+    const resolved = resolve_rule_column(args[side], args.data, side)
+    const unconstrained = new Float64Array(resolved.values.length).fill(NaN)
+    const series: RuleSeries<TooltipContent> = {
+        kind: 'rule',
+        side,
+        x: side === 'x' ? resolved.values : unconstrained,
+        y: side === 'y' ? resolved.values : unconstrained,
+    }
+    apply_rule_options(series, args)
+    attach_rule_column(series, side, resolved)
+    return series
+}
+
+/**
+ * Which axis the rule's value lives on. Exactly one of x / y carries it — that's the whole orientation
+ * declaration, mirroring how a bar takes its band from whichever side is categorical.
+ * @param args - the rule series args
+ * @returns the value's axis
+ */
+function rule_side(args: RuleArgs): 'x' | 'y' {
+    const has_x = args.x !== undefined
+    const has_y = args.y !== undefined
+
+    if (has_x && has_y) {
+        throw new Error('plot.rule: pass exactly one of x / y, got both. `y` draws a horizontal rule at that value, `x` a vertical one.')
+    }
+
+    if (!has_x && !has_y) {
+        throw new Error('plot.rule: pass one of x / y. `y` draws a horizontal rule at that value, `x` a vertical one.')
+    }
+    return has_x ? 'x' : 'y'
+}
+
+/**
+ * Resolve the rule's value column. Without data the value is the rule itself — a number, or a string naming a
+ * category on a categorical axis. With data it's a field name or accessor, giving one rule per row.
+ * @param value - the value arg from the rule's axis
+ * @param data - the data rows, when the value is a field
+ * @param side - the rule's axis, for error messages
+ * @returns the resolved values plus mode, categories, and source field
+ */
+function resolve_rule_column(value: RuleValueArg | undefined, data: Record<string, unknown>[] | undefined, side: 'x' | 'y'): ResolvedRule {
+    if (data === undefined) {
+        return resolve_bare_rule(value, side)
+    }
+
+    if (typeof value === 'number') {
+        throw new Error(`plot.rule: ${side} is a number (${value}) but data was passed. Drop data for a single rule at ${value}, or name the field holding each rule's value.`)
+    }
+    // rule_side established that value is present; after excluding number it is a field or accessor.
+    const field_value = value as Exclude<RuleValueArg, number>
+
+    if (data.length > 0) {
+        validate_field_present(data[0], field_value, false, 'plot.rule', side)
+    }
+    const column = resolve_column(data, field_value, 'plot.rule', side)
+    const resolved: ResolvedRule = { values: column.values, mode: column.mode, categories: column.categories }
+
+    if (typeof field_value === 'string') {
+        resolved.field = field_value
+    }
+    return resolved
+}
+
+/**
+ * Resolve a rule given as the value itself, with no data rows: a number on a continuous axis, or a category
+ * label on a categorical one (with no rows there's no field for a string to name).
+ * @param value - the value arg from the rule's axis
+ * @param side - the rule's axis, for error messages
+ * @returns the single-value resolved column
+ */
+function resolve_bare_rule(value: RuleValueArg | undefined, side: 'x' | 'y'): ResolvedRule {
+    if (typeof value === 'function') {
+        throw new Error(`plot.rule: ${side} is an accessor but no data was passed. An accessor reads a value per row, so it needs data; pass the value directly for a single rule.`)
+    }
+
+    if (typeof value === 'string') {
+        return { values: new Float64Array([0]), mode: 'categorical', categories: [value] }
+    }
+    return { values: new Float64Array([validate_finite(value as number, `plot.rule: ${side}`)]), mode: 'numeric', categories: null }
+}
+
+/**
+ * Apply the optional rule args onto the series, validating each.
+ * @param series - the series under construction
+ * @param args - the rule series args
+ */
+function apply_rule_options<TooltipContent>(series: RuleSeries<TooltipContent>, args: RuleArgs<TooltipContent>): void {
+    apply_rule_color(series, args)
+
+    if (args.width !== undefined) {
+        series.width = validate_positive(args.width, 'plot.rule: width')
+    }
+
+    if (args.dash !== undefined) {
+        series.dash = args.dash.map((segment, i) => validate_non_negative(segment, `plot.rule: dash[${i}]`))
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+    const hoverable = validate_hoverable(args, 'plot.rule')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+
+    if (args.data !== undefined) {
+        series.rows = args.data // Keep the caller's original rows for tooltip and selection payloads.
+    }
+}
+
+/**
+ * Resolve the rule color(s). With data, per-row colors work as they do for any series; a single rule takes a
+ * uniform color only, since an accessor has no row to read.
+ * @param series - the series under construction
+ * @param args - the rule series args
+ */
+function apply_rule_color<TooltipContent>(series: RuleSeries<TooltipContent>, args: RuleArgs<TooltipContent>): void {
+    const data = args.data
+
+    if (data !== undefined) {
+        const { color, colors } = resolve_color(data, args.color)
+
+        if (color !== undefined) {
+            series.color = color
+        }
+
+        if (colors !== undefined) {
+            series.colors = colors
+        }
+        return
+    }
+
+    if (args.color === undefined) {
+        return
+    }
+
+    if (typeof args.color === 'function') {
+        throw new Error('plot.rule: color is an accessor but no data was passed. A single rule takes a color string or {light, dark}; pass data to color rules per row.')
+    }
+    series.color = args.color
+}
+
+/**
+ * Attach the resolved column's axis kind, categories, and source field to the rule's own side. The other side
+ * stays bare, which is what lets a rule sit on any axis without constraining it.
+ * @param series - the series under construction
+ * @param side - the rule's axis
+ * @param resolved - the resolved value column
+ */
+function attach_rule_column<TooltipContent>(series: RuleSeries<TooltipContent>, side: 'x' | 'y', resolved: ResolvedRule): void {
+    const axis_kind_key = side === 'x' ? 'x_axis_kind' : 'y_axis_kind'
+    const categories_key = side === 'x' ? 'x_categories' : 'y_categories'
+    const field_key = side === 'x' ? 'x_field' : 'y_field'
+
+    if (resolved.mode !== 'undecided') {
+        series[axis_kind_key] = resolved.mode
+    }
+
+    if (resolved.categories !== null) {
+        series[categories_key] = resolved.categories
+    }
+
+    if (resolved.field !== undefined) {
+        series[field_key] = resolved.field
+    }
+}

--- a/plot/src/core/series/rule/highlight.ts
+++ b/plot/src/core/series/rule/highlight.ts
@@ -1,0 +1,33 @@
+import type { ComposedRule, HighlightSpec, Rect, Scale } from "../../types"
+import { DEFAULT_SERIES_COLOR } from "../../template/color"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { crisp_rule_pos, DEFAULT_RULE_WIDTH, rule_values } from "./paint"
+
+/**
+ * The hover-select halo for a rule: a band over the whole rule, as thick as the stroke. It spans the plot area
+ * on the other axis and snaps to the same device pixel the stroke does, so it covers the drawn line exactly
+ * rather than sitting half a pixel off or stopping short at the axis padding.
+ * @param series - the composed rule series
+ * @param point_index - the hovered rule's index
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @param inner - the plot area, which the rule spans on the axis it doesn't constrain
+ * @returns the halo spec, or null if the rule has no pixel position (unknown band / non-finite)
+ */
+export function rule_highlight_spec(series: ComposedRule, point_index: number, x_scale: Scale, y_scale: Scale, inner: Rect): HighlightSpec | null {
+    const is_vertical = series.side === 'x'
+    const pos = pixel_resolver(is_vertical ? x_scale : y_scale, rule_values(series))(point_index)
+
+    if (pos === undefined || !Number.isFinite(pos)) {
+        return null
+    }
+    const thickness = series.width ?? DEFAULT_RULE_WIDTH
+    const color = series.colors?.[point_index] ?? series.color ?? DEFAULT_SERIES_COLOR
+    const drawn = crisp_rule_pos(pos, thickness)
+
+    // edge to edge across the plot area, the same span draw_rule strokes
+    if (is_vertical) {
+        return { shape: 'rect', x: drawn - thickness / 2, y: inner.top, width: thickness, height: inner.bottom - inner.top, color }
+    }
+    return { shape: 'rect', x: inner.left, y: drawn - thickness / 2, width: inner.right - inner.left, height: thickness, color }
+}

--- a/plot/src/core/series/rule/hit.ts
+++ b/plot/src/core/series/rule/hit.ts
@@ -1,0 +1,42 @@
+import type { ComposedRule, Scale } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { DEFAULT_RULE_WIDTH, rule_values } from "./paint"
+
+// a hairline is too thin to hover, so hit-testing gets a grab band either side of it
+const MIN_GRAB_RADIUS = 4
+
+/**
+ * The rule under the cursor, or null. A rule is hittable anywhere along its span (it has no endpoints), within
+ * a grab band either side of the stroke; the nearest rule wins where two overlap.
+ * @param series - the composed rule series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the rule's index, or null
+ */
+export function rule_hit_test(series: ComposedRule, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale): number | null {
+    const values = rule_values(series)
+    const is_vertical = series.side === 'x'
+    const resolve = pixel_resolver(is_vertical ? x_scale : y_scale, values)
+    const cursor_pos = is_vertical ? cursor.x : cursor.y
+    const grab_radius = Math.max((series.width ?? DEFAULT_RULE_WIDTH) / 2, MIN_GRAB_RADIUS)
+
+    let nearest: number | null = null
+    let nearest_distance = Infinity
+
+    for (let i = 0; i < values.length; i++) {
+        const pos = resolve(i)
+
+        if (pos === undefined || !Number.isFinite(pos)) {
+            continue
+        }
+        const distance = Math.abs(pos - cursor_pos)
+        const is_closer = distance <= grab_radius && distance < nearest_distance
+
+        if (is_closer) {
+            nearest = i
+            nearest_distance = distance
+        }
+    }
+    return nearest
+}

--- a/plot/src/core/series/rule/index.ts
+++ b/plot/src/core/series/rule/index.ts
@@ -1,0 +1,21 @@
+import { xy_extent } from "../../template/extent"
+import type { RuleSeries, SeriesType } from "../../types"
+import { new_rule } from "./factory"
+import { rule_highlight_spec } from "./highlight"
+import { rule_hit_test } from "./hit"
+import { draw_rule } from "./paint"
+
+export { new_rule, type RuleArgs, type RuleValueArg } from "./factory"
+export { rule_highlight_spec } from "./highlight"
+export { rule_hit_test } from "./hit"
+export { crisp_rule_pos, DEFAULT_RULE_WIDTH, draw_rule, rule_values } from "./paint"
+
+export const rule_runtime = {
+    kind: 'rule',
+    factory: new_rule,
+    paint: draw_rule,
+    tooltip_hit_test: rule_hit_test,
+    highlight_spec: rule_highlight_spec,
+    // The rule's unconstrained column is all NaN, producing the inverted extent that aggregation ignores.
+    domain_extent: xy_extent,
+} satisfies SeriesType<unknown, RuleSeries>

--- a/plot/src/core/series/rule/paint.ts
+++ b/plot/src/core/series/rule/paint.ts
@@ -1,0 +1,85 @@
+import type { CanvasContext, ComposedRule, Rect, RenderContext } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+
+export const DEFAULT_RULE_WIDTH = 1
+
+/**
+ * The column carrying the rule values — the other one is all NaN. Shared by paint, hit-testing, and highlight.
+ * @param series - the composed rule series
+ * @returns the values on the rule's own axis
+ */
+export function rule_values(series: ComposedRule): Float64Array {
+    return series.side === 'x' ? series.x : series.y
+}
+
+/**
+ * Draw a rule series: one straight line per value, spanning the inner rect on the other axis. Unlike a line
+ * series the span isn't data-driven, so it reaches the plot edges exactly rather than stopping at the first
+ * and last point.
+ * @param series - the rule series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_rule(series: ComposedRule, render: RenderContext): void {
+    const { ctx, inner, x_scale, y_scale, color } = render
+    const values = rule_values(series)
+
+    if (values.length === 0) {
+        return
+    }
+    const width = series.width ?? DEFAULT_RULE_WIDTH
+    const resolve = pixel_resolver(series.side === 'x' ? x_scale : y_scale, values)
+    const colors = series.colors
+    ctx.lineWidth = width
+    ctx.setLineDash(series.dash ?? [])
+    ctx.strokeStyle = color
+
+    for (let i = 0; i < values.length; i++) {
+        const pos = resolve(i)
+
+        if (pos === undefined || !Number.isFinite(pos)) {
+            continue
+        }
+
+        if (colors !== undefined) {
+            ctx.strokeStyle = colors[i] ?? color
+        }
+        stroke_rule(ctx, series.side, crisp_rule_pos(pos, width), inner)
+    }
+}
+
+/**
+ * Stroke one rule edge to edge across the inner rect.
+ * @param ctx - canvas context
+ * @param side - the axis the rule's value lives on
+ * @param pos - the pixel position on that axis
+ * @param inner - inner plot rect
+ */
+function stroke_rule(ctx: CanvasContext, side: 'x' | 'y', pos: number, inner: Rect): void {
+    ctx.beginPath()
+
+    if (side === 'x') {
+        ctx.moveTo(pos, inner.top)
+        ctx.lineTo(pos, inner.bottom)
+    } else {
+        ctx.moveTo(inner.left, pos)
+        ctx.lineTo(inner.right, pos)
+    }
+    ctx.stroke()
+}
+
+/**
+ * Snap a rule to a device pixel so a thin line paints solid instead of antialiasing across two rows.
+ * @param pos - the raw scale position
+ * @param width - the stroke width in pixels
+ * @returns the pixel coordinate to stroke at
+ */
+export function crisp_rule_pos(pos: number, width: number): number {
+    if (!Number.isInteger(width)) {
+        return pos
+    }
+
+    if (width % 2 === 0) {
+        return Math.round(pos)
+    }
+    return Math.round(pos) + 0.5
+}

--- a/plot/src/core/series/scatter/factory.ts
+++ b/plot/src/core/series/scatter/factory.ts
@@ -1,0 +1,112 @@
+import { attach_resolved_columns, resolve_xy_columns } from "../../template/column"
+import { resolve_color, resolve_stroke } from "../../template/color"
+import { validate_hoverable, validate_non_negative } from "../../template/validate"
+import type { ColorArg, FieldArg, MarkShape, ScatterSeries, SelectFn, StrokeArg, TooltipArg } from "../../types"
+
+export type ScatterSizeArg = number | ((row: Record<string, unknown>, index: number) => number)
+
+export type ScatterArgs<TooltipContent = unknown> = {
+    data: Record<string, unknown>[]
+    x?: FieldArg
+    y?: FieldArg
+    color?: ColorArg
+    size?: ScatterSizeArg
+    mark?: MarkShape
+    stroke?: StrokeArg
+    tooltip?: TooltipArg<Record<string, unknown>, TooltipContent>
+    on_select?: SelectFn<Record<string, unknown>>
+    hoverable?: boolean
+    highlight?: boolean
+}
+
+/**
+ * Resolve scatter arguments into aligned numeric/category columns plus per-mark presentation data.
+ * @param args - scatter series arguments
+ * @returns the resolved scatter series
+ */
+export function new_scatter<TooltipContent = unknown>(args: ScatterArgs<TooltipContent>): ScatterSeries<TooltipContent> {
+    const x_arg = args.x ?? 'x'
+    const y_arg = args.y ?? 'y'
+    const resolved = resolve_xy_columns(args.data, x_arg, y_arg, 'plot.scatter', args.x === undefined, args.y === undefined)
+    const series: ScatterSeries<TooltipContent> = {
+        kind: 'scatter',
+        x: resolved.x,
+        y: resolved.y,
+        ...resolve_color(args.data, args.color),
+        ...resolve_size(args.data, args.size),
+    }
+
+    if (args.tooltip !== undefined) {
+        series.tooltip = args.tooltip
+    }
+
+    if (args.on_select !== undefined) {
+        series.on_select = args.on_select
+    }
+    const hoverable = validate_hoverable(args, 'plot.scatter')
+
+    if (hoverable !== undefined) {
+        series.hoverable = hoverable
+    }
+
+    if (args.highlight !== undefined) {
+        series.highlight = args.highlight
+    }
+
+    if (args.mark !== undefined) {
+        series.mark = args.mark
+    }
+    const stroke = resolve_stroke(args.stroke, 'plot.scatter')
+
+    if (stroke !== undefined) {
+        series.stroke = stroke
+    }
+
+    series.rows = args.data // Keep the caller's original rows for tooltip and selection payloads.
+    attach_resolved_columns(series, resolved, x_arg, y_arg)
+    return series
+}
+
+/**
+ * Per-dot size resolution.
+ * @param data - the data rows
+ * @param arg - uniform number, per-dot accessor, or undefined
+ * @returns the size and/or per-row sizes to attach to the series
+ */
+function resolve_size(
+    data: Record<string, unknown>[],
+    arg: ScatterSizeArg | undefined,
+): Pick<ScatterSeries, 'size' | 'sizes'> {
+    const accessor = typeof arg === 'function' ? arg : undefined
+    const uniform = typeof arg === 'number' ? arg : undefined
+
+    if (uniform !== undefined) {
+        validate_non_negative(uniform, 'plot.scatter: size arg')
+    }
+    const has_per_item = data.some(r => typeof r.size === 'number')
+    const result: Pick<ScatterSeries, 'size' | 'sizes'> = {}
+
+    if (has_per_item || accessor !== undefined) {
+        const sizes = new Array<number | null>(data.length)
+
+        for (let i = 0; i < data.length; i++) {
+            const row = data[i]
+            let resolved: number | null = null
+
+            if (typeof row.size === 'number') {
+                resolved = validate_non_negative(row.size, `plot.scatter: row ${i} field 'size'`)
+            } else if (accessor !== undefined) {
+                resolved = validate_non_negative(accessor(row, i), `plot.scatter: size accessor at row ${i}`)
+            } else if (uniform !== undefined) {
+                resolved = uniform
+            }
+            sizes[i] = resolved
+        }
+        result.sizes = sizes
+    }
+
+    if (uniform !== undefined) {
+        result.size = uniform
+    }
+    return result
+}

--- a/plot/src/core/series/scatter/highlight.ts
+++ b/plot/src/core/series/scatter/highlight.ts
@@ -1,0 +1,28 @@
+import type { ComposedScatter, HighlightSpec, Scale } from "../../types"
+import { DEFAULT_SERIES_COLOR } from "../../template/color"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { dot_radius } from "./paint"
+
+/**
+ * The hover-select halo for a scatter dot: a circle at the dot center sized to its radius, in the dot's color.
+ * Mirrors the paint/hit geometry so the ring lands exactly on the drawn mark.
+ * @param series - the composed scatter series
+ * @param point_index - the hovered dot's row index
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the halo spec, or null if the dot has no pixel position (unknown band category)
+ */
+export function scatter_highlight_spec(series: ComposedScatter, point_index: number, x_scale: Scale, y_scale: Scale): HighlightSpec | null {
+    const cx = pixel_resolver(x_scale, series.x)(point_index)
+
+    if (cx === undefined) {
+        return null
+    }
+    const cy = pixel_resolver(y_scale, series.y)(point_index)
+
+    if (cy === undefined) {
+        return null
+    }
+    const color = series.colors?.[point_index] ?? series.color ?? DEFAULT_SERIES_COLOR
+    return { shape: 'mark', mark: series.mark ?? 'circle', cx, cy, r: dot_radius(series, point_index), color }
+}

--- a/plot/src/core/series/scatter/hit.ts
+++ b/plot/src/core/series/scatter/hit.ts
@@ -1,0 +1,16 @@
+import type { ComposedScatter, Scale } from "../../types"
+import { nearest_point_hit } from "../../render/hit"
+import { dot_radius } from "./paint"
+
+/**
+ * The scatter dot under the cursor, or null. Each dot is hittable within its drawn radius or a minimum
+ * affordance, whichever is larger; where hit regions overlap, the nearest center wins.
+ * @param series - the composed scatter series
+ * @param cursor - cursor position in canvas pixels
+ * @param x_scale - x scale
+ * @param y_scale - y scale
+ * @returns the point index under the cursor, or null
+ */
+export function scatter_hit_test(series: ComposedScatter, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale): number | null {
+    return nearest_point_hit(series, cursor, x_scale, y_scale, i => dot_radius(series, i))
+}

--- a/plot/src/core/series/scatter/index.ts
+++ b/plot/src/core/series/scatter/index.ts
@@ -1,0 +1,20 @@
+import { xy_extent } from "../../template/extent"
+import type { ScatterSeries, SeriesType } from "../../types"
+import { new_scatter } from "./factory"
+import { scatter_highlight_spec } from "./highlight"
+import { scatter_hit_test } from "./hit"
+import { draw_scatter } from "./paint"
+
+export { new_scatter, type ScatterArgs, type ScatterSizeArg } from "./factory"
+export { scatter_highlight_spec } from "./highlight"
+export { scatter_hit_test } from "./hit"
+export { dot_radius, draw_scatter } from "./paint"
+
+export const scatter_runtime = {
+    kind: 'scatter',
+    factory: new_scatter,
+    paint: draw_scatter,
+    tooltip_hit_test: scatter_hit_test,
+    highlight_spec: scatter_highlight_spec,
+    domain_extent: xy_extent,
+} satisfies SeriesType<unknown, ScatterSeries>

--- a/plot/src/core/series/scatter/paint.ts
+++ b/plot/src/core/series/scatter/paint.ts
@@ -1,0 +1,51 @@
+import type { ComposedScatter, RenderContext } from "../../types"
+import { pixel_resolver } from "../../render/pixel_resolver"
+import { draw_mark } from "../../render/mark"
+
+const DOT_DIAMETER = 5
+
+/**
+ * Per-dot radius in pixels: per-row size, else the series size, else the default. Shared with
+ * hit-testing so the hover region matches the drawn dot.
+ * @param series - the scatter series
+ * @param i - the row index
+ * @returns the dot's pixel radius
+ */
+export function dot_radius(series: ComposedScatter, i: number): number {
+    return (series.sizes?.[i] ?? series.size ?? DOT_DIAMETER) / 2
+}
+
+/**
+ * Draw a scatter series as per-dot arcs, clipped to the inner rect. Per-row color and size override the series defaults.
+ * @param series - the scatter series
+ * @param render - the shared render context (canvas, inner rect, scales, fallback color)
+ */
+export function draw_scatter(series: ComposedScatter, render: RenderContext): void {
+    const { ctx, x_scale, y_scale, color } = render
+    ctx.fillStyle = color
+    const length = series.x.length
+    const colors = series.colors
+    const mark = series.mark ?? 'circle'
+    const stroke = series.stroke
+    const resolve_x = pixel_resolver(x_scale, series.x)
+    const resolve_y = pixel_resolver(y_scale, series.y)
+
+    for (let i = 0; i < length; i++) {
+        const center_x = resolve_x(i)
+
+        if (center_x === undefined) {
+            continue
+        }
+        const center_y = resolve_y(i)
+
+        if (center_y === undefined) {
+            continue
+        }
+
+        if (colors !== undefined) {
+            ctx.fillStyle = colors[i] ?? color
+        }
+        const radius = dot_radius(series, i)
+        draw_mark(ctx, mark, center_x, center_y, radius, stroke)
+    }
+}

--- a/plot/src/core/template/axis.ts
+++ b/plot/src/core/template/axis.ts
@@ -1,0 +1,696 @@
+import type { Axis, AxisArgs, AxisContext, AxisScale, AxisTemplate, CategoryAxisTemplate, Domain, LabelPosition, LinearAxisTemplate, LogarithmicAxisTemplate, PlotArgs, Series, ThemeColor, TimeAxisTemplate } from "../types"
+import { compute_domains, needs_auto } from "./domain"
+import { resolve_label } from "./plot_template"
+import { validate_finite, validate_non_negative, validate_optional } from "./validate"
+import { series_type } from "../registry"
+
+// scaleLog requires positive domains. Non-positive values clamp to this floor with a warn.
+const LOG_DOMAIN_FLOOR = 1
+
+// per-axis resolution at template stage. Turns an Axis spec into an AxisTemplate plus
+// per-series translation tables. dimension-independent, no scales or ranges.
+
+// translations[i]: null means no remap (local matches axis prefix). Int32Array remaps local
+// category index to canonical, with -1 marking unknowns to drop. Undefined for linear axes.
+type AxisTemplateResolution = {
+    axis_template: AxisTemplate
+    translations?: (Int32Array | null)[]
+}
+
+/**
+ * Resolve both axes end to end: validate and classify, compute auto domains, and build each
+ * AxisTemplate plus its per-series translations.
+ * @param series - the series
+ * @param axis - the caller's axis declaration
+ * @returns the resolved x and y axis templates and translations
+ */
+export function build_resolved_axes(series: Series[], axis: PlotArgs['axis']): { x_resolved: AxisTemplateResolution; y_resolved: AxisTemplateResolution } {
+    const { x_axis, y_axis } = validate_and_build_axes_context(series, axis)
+    const auto_domains = compute_auto_domains(series, x_axis, y_axis)
+
+    return {
+        x_resolved: resolve_axis_template(x_axis, series, 'x', auto_domains.x),
+        y_resolved: resolve_axis_template(y_axis, series, 'y', auto_domains.y),
+    }
+}
+
+/**
+ * Auto-computed domains for linear/log sides. Skips the data scan when both sides are categorical or
+ * fully pinned, returning a placeholder [0, 1] that resolve_axis_template won't read.
+ * @param series - the series
+ * @param x_axis - resolved x axis context
+ * @param y_axis - resolved y axis context
+ * @returns per-side auto domain
+ */
+function compute_auto_domains(series: Series[], x_axis: AxisContext, y_axis: AxisContext): { x: Domain; y: Domain } {
+    const x_needs_auto = !x_axis.is_category && needs_auto(x_axis.args)
+    const y_needs_auto = !y_axis.is_category && needs_auto(y_axis.args)
+
+    if (x_needs_auto || y_needs_auto) {
+        return compute_domains(series, x_axis.padding_mode, y_axis.padding_mode)
+    }
+    return { x: [0, 1] as Domain, y: [0, 1] as Domain }
+}
+
+/**
+ * Validate and classify both axes before per-side template resolution. Builds each side, then runs
+ * the cross-axis series-kind hooks (which compare both sides). Throws on any conflict.
+ * @param series - the series
+ * @param axis - the caller's axis declaration
+ * @returns the resolved x and y axes (kind, rendered, label, scale, padding mode)
+ */
+function validate_and_build_axes_context(series: Series[], axis: PlotArgs['axis']): { x_axis: AxisContext; y_axis: AxisContext } {
+    const x_axis = build_axis_side(series, axis?.x ?? {}, 'x')
+    const y_axis = build_axis_side(series, axis?.y ?? {}, 'y')
+
+    // cross-axis: these hooks compare both sides (e.g. bar needs exactly one band axis)
+    for (let i = 0; i < series.length; i++) {
+        series_type(series[i].kind).validate_axes?.(x_axis, y_axis, series[i], i)
+    }
+
+    apply_padding_modes(series, x_axis, y_axis)
+
+    return { x_axis, y_axis }
+}
+
+/**
+ * Flatten the overloaded axis input into the internal flat Axis
+ * @param input - the caller's axis args
+ * @returns the normalized flat axis
+ */
+function normalize_axis(input: AxisArgs): Axis {
+    const { label, tick_label, ...rest } = input
+    const label_parts = normalize_axis_label(label)
+
+    return {
+        ...rest,
+        ...label_parts,
+        tick_label_format: tick_label?.format,
+        tick_label_size: tick_label?.size,
+        tick_label_color: tick_label?.color,
+    }
+}
+
+// Split the label arg: a bare string is just text; an object carries text plus size / color / position.
+function normalize_axis_label(label: AxisArgs['label']): { label?: string; label_size?: number; label_color?: ThemeColor; label_position?: LabelPosition } {
+    if (label === undefined) {
+        return {}
+    }
+
+    if (typeof label === 'string') {
+        return { label }
+    }
+    return { label: label.text, label_size: label.size, label_color: label.color, label_position: label.position }
+}
+
+/**
+ * Build one side's resolved context: reconcile the declared/inferred kind, reject an incoherent
+ * scale, and derive the rendered flag, label, scale, and seeded padding. Throws on conflict.
+ * @param series - the series
+ * @param input - the caller's axis spec for this side
+ * @param side - axis side
+ * @returns the resolved axis context (padding seeded to 'default', overridden later)
+ */
+function build_axis_side(series: Series[], input: AxisArgs, side: 'x' | 'y'): AxisContext {
+    const args = normalize_axis(input)
+    validate_label_position(args, side)
+
+    // category declared by `scale: 'category'` or by a `categories` pin
+    const declared_category = args.scale === 'category' || args.categories !== undefined
+
+    // scale inference fires when the caller didn't pin a scale
+    const scale_unset = args.scale === undefined
+    const is_category = declared_category || reconcile_axis_kind(series, side, scale_unset, declared_category)
+
+    // a categorical axis can't have a numeric scale
+    if (is_category) {
+        validate_category_scale_coherence(args, side)
+    }
+
+    if (!is_category && args.grid_align !== undefined) {
+        throw new Error(`axis.${side}: grid_align is only valid on a categorical axis; remove it or set scale: 'category'.`)
+    }
+
+    validate_padding_orientation(args, side)
+
+    // padding set to 'default'; apply_padding_modes will override once both axes have been resolved
+    return {
+        is_category,
+        rendered: !args.hidden,
+        field_label: common_field(series, side),
+        scale: resolve_scale(args, is_category),
+        padding_mode: 'default',
+        args,
+    }
+}
+
+/**
+ * Reject pixel padding named for the wrong orientation: the x axis pads left / right, the y axis top / bottom.
+ * Applies to both continuous and categorical axes.
+ * @param args - the axis spec
+ * @param side - axis side
+ */
+function validate_padding_orientation(args: Axis, side: 'x' | 'y'): void {
+    if (side === 'x' && (args.padding_top !== undefined || args.padding_bottom !== undefined)) {
+        throw new Error(`axis.x: padding_top / padding_bottom apply to the y axis; use padding_left / padding_right (or padding for both ends) on x.`)
+    }
+
+    if (side === 'y' && (args.padding_left !== undefined || args.padding_right !== undefined)) {
+        throw new Error(`axis.y: padding_left / padding_right apply to the x axis; use padding_top / padding_bottom (or padding for both ends) on y.`)
+    }
+}
+
+/**
+ * Reject a label_position that doesn't match the axis orientation: the x axis reads left / right, the y axis top / bottom.
+ * @param args - the axis spec
+ * @param side - axis side
+ */
+function validate_label_position(args: Axis, side: 'x' | 'y'): void {
+    const position = args.label_position
+
+    if (position === undefined || position === 'center') {
+        return
+    }
+    const allowed = side === 'x' ? ['left', 'right'] : ['top', 'bottom']
+
+    if (!allowed.includes(position)) {
+        const allowed_list = allowed.map(value => `'${value}'`).join(' / ')
+        throw new Error(`axis.${side}: label.position '${position}' is invalid for the ${side} axis; use 'center' or ${allowed_list}.`)
+    }
+}
+
+/**
+ * The resolved scale kind: a categorical axis is 'category', otherwise the declared 'log' or the 'linear' default.
+ * @param axis_args - the axis spec
+ * @param is_category - whether the side resolved to categorical
+ * @returns the resolved scale
+ */
+function resolve_scale(axis_args: Axis, is_category: boolean): AxisScale {
+    if (is_category) {
+        return 'category'
+    }
+
+    if (axis_args.scale === 'log') {
+        return 'log'
+    }
+
+    if (axis_args.scale === 'time' || axis_args.scale === 'utc') {
+        return axis_args.scale
+    }
+    return 'linear'
+}
+
+/**
+ * Apply each side's domain padding mode in place: series-kind overrides (e.g. bar anchors at zero),
+ * then a log scale forces pass-through. padding_mode is seeded to 'default' by the caller.
+ * @param series - the series
+ * @param x_axis_ctx - the resolved x axis
+ * @param y_axis_ctx - the resolved y axis
+ */
+function apply_padding_modes(series: Series[], x_axis_ctx: AxisContext, y_axis_ctx: AxisContext): void {
+    for (const series_item of series) {
+        const series_padding = series_type(series_item.kind).padding_mode?.(x_axis_ctx, y_axis_ctx)
+
+        if (series_padding?.x !== undefined) {
+            x_axis_ctx.padding_mode = series_padding.x
+        }
+
+        if (series_padding?.y !== undefined) {
+            y_axis_ctx.padding_mode = series_padding.y
+        }
+    }
+
+    if (x_axis_ctx.scale === 'log') {
+        x_axis_ctx.padding_mode = 'log'
+    }
+
+    if (y_axis_ctx.scale === 'log') {
+        y_axis_ctx.padding_mode = 'log'
+    }
+}
+
+/**
+ * The field name shared by every series on a side, or undefined when they disagree or any series used an accessor. Drives the default axis label. Series that sit the axis out are skipped, so a rule doesn't cost the other series their label.
+ * @param series - the series
+ * @param side - axis side
+ * @returns the shared field name, or undefined
+ */
+function common_field(series: Series[], side: 'x' | 'y'): string | undefined {
+    let common: string | undefined
+
+    for (let i = 0; i < series.length; i++) {
+        if (!claims_axis(series[i], side)) {
+            continue
+        }
+        const field = side === 'x' ? series[i].x_field : series[i].y_field
+
+        if (field === undefined) {
+            return undefined
+        }
+
+        if (common !== undefined && field !== common) {
+            return undefined
+        }
+        common = field
+    }
+    return common
+}
+
+/**
+ * Whether a series constrains an axis at all. A series with no rows has nothing on either side, and a series
+ * that resolved only one column (a rule, which is a single value spanning the other axis) makes no claim on
+ * the axis it spans: it contributes no categories, needs no category remap, and isn't held to the axis' kind.
+ * @param series_item - the series
+ * @param side - axis side
+ * @returns true when the series has values on this side
+ */
+function claims_axis(series_item: Series, side: 'x' | 'y'): boolean {
+    if (series_item.x.length === 0) {
+        return false
+    }
+    const axis_kind = side === 'x' ? series_item.x_axis_kind : series_item.y_axis_kind
+    return axis_kind !== undefined
+}
+
+/**
+ * Reject a categorical axis combined with a linear or log scale.
+ * @param axis_args - the called defined axis args
+ * @param side - axis side, for the error message
+ */
+function validate_category_scale_coherence(axis_args: Axis, side: 'x' | 'y'): void {
+    if (axis_args.scale === 'linear' || axis_args.scale === 'log' || axis_args.scale === 'time' || axis_args.scale === 'utc') {
+        throw new Error(`axis.${side}: scale: '${axis_args.scale}' conflicts with the categories pin (categories require scale: 'category'). Drop one.`)
+    }
+}
+
+/**
+ * Reconcile one side's detected axis kind against the caller's declaration, inferring implicit
+ * category. Throws when string data collides with a declared numeric scale.
+ * @param series - the series
+ * @param side - axis side
+ * @param scale_unset - whether axis.<side>.scale was omitted
+ * @param declared_category - whether the side was declared categorical
+ * @returns whether the side is implicitly categorical
+ */
+function reconcile_axis_kind(series: Series[], side: 'x' | 'y', scale_unset: boolean, declared_category: boolean): boolean {
+    let implicit_category = false
+
+    for (let i = 0; i < series.length; i++) {
+        const s = series[i]
+        const kind = side === 'x' ? s.x_axis_kind : s.y_axis_kind
+
+        if (kind !== 'categorical') {
+            continue
+        }
+
+        if (!scale_unset && !declared_category) {
+            throw new Error(`plot: series at index ${i} has a string-valued ${side} column but axis.${side}.scale is declared as a non-categorical scale ('linear', 'log', 'time', or 'utc'). Either remove the scale declaration on axis.${side} (plot will infer 'category'), set axis.${side}.scale to 'category' explicitly, or pass numeric ${side} values to plot.${s.kind}.`)
+        }
+
+        if (scale_unset) {
+            implicit_category = true
+        }
+    }
+    return implicit_category
+}
+
+/**
+ * Resolve one axis's context into an AxisTemplate, plus per-series translations for categorical
+ * @param axis - the resolved axis context (carries the spec, scale, rendered, label)
+ * @param series - the series, for category collection
+ * @param side - axis side
+ * @param auto - auto-computed domain for linear/log
+ * @returns the resolved axis template and any translations
+ */
+function resolve_axis_template(
+    axis: AxisContext,
+    series: Series[],
+    side: 'x' | 'y',
+    auto: Domain,
+): AxisTemplateResolution {
+    const padding = resolve_continuous_padding(axis.args, side)
+
+    if (axis.scale === 'category') {
+        return resolve_categorical(axis.args, series, side, axis.rendered, axis.field_label, padding)
+    }
+
+    if (axis.scale === 'log') {
+        return resolve_logarithmic(axis.args, auto, side, axis.rendered, axis.field_label, padding)
+    }
+
+    if (axis.scale === 'time' || axis.scale === 'utc') {
+        return resolve_time(axis.args, auto, axis.scale === 'utc', axis.rendered, axis.field_label, padding)
+    }
+    return resolve_linear(axis.args, auto, axis.rendered, axis.field_label, padding)
+}
+
+// pixel padding per end of a continuous axis.
+type ContinuousPadding = { padding_min: number; padding_max: number }
+
+function resolve_continuous_padding(axis_in: Axis, side: 'x' | 'y'): ContinuousPadding {
+    const both = validate_optional(axis_in.padding, validate_non_negative, `plot: axis.${side}.padding`)
+
+    let min_key: number | undefined
+    let max_key: number | undefined
+    let min_label: string
+    let max_label: string
+
+    if (side === 'x') {
+        min_key = axis_in.padding_left
+        max_key = axis_in.padding_right
+        min_label = 'padding_left'
+        max_label = 'padding_right'
+    } else {
+        min_key = axis_in.padding_bottom
+        max_key = axis_in.padding_top
+        min_label = 'padding_bottom'
+        max_label = 'padding_top'
+    }
+    const padding_min = validate_optional(min_key, validate_non_negative, `plot: axis.${side}.${min_label}`)
+    const padding_max = validate_optional(max_key, validate_non_negative, `plot: axis.${side}.${max_label}`)
+
+    return {
+        padding_min: padding_min ?? both ?? 0,
+        padding_max: padding_max ?? both ?? 0,
+    }
+}
+
+/**
+ * Validate that any pinned min/max is finite and return the pinned bounds.
+ * @param axis_in - the axis spec
+ * @returns the pinned bounds, each undefined when the caller left it auto
+ */
+function validate_finite_bounds(axis_in: Axis): { min?: number, max?: number } {
+    return {
+        min: validate_optional(axis_in.min, validate_finite, 'plot: axis.min'),
+        max: validate_optional(axis_in.max, validate_finite, 'plot: axis.max'),
+    }
+}
+
+/**
+ * Resolve a time axis, niced to calendar boundaries at compose. utc picks the d3 scale (scaleUtc vs scaleTime).
+ * @param axis_in - the time axis spec
+ * @param auto - auto-computed domain in epoch ms
+ * @param utc - true for scale 'utc', false for local 'time'
+ * @param rendered - whether the axis paints
+ * @param auto_label - derived default label
+ * @returns the resolved axis template
+ */
+function resolve_time(axis_in: Axis, auto: Domain, utc: boolean, rendered: boolean, auto_label: string | undefined, padding: ContinuousPadding): AxisTemplateResolution {
+    const { min, max } = validate_finite_bounds(axis_in)
+
+    const axis_template: TimeAxisTemplate = {
+        kind: 'time',
+        domain: [min ?? auto[0], max ?? auto[1]],
+        utc,
+        rendered,
+        nice_min: min === undefined,
+        nice_max: max === undefined,
+        padding_min: padding.padding_min,
+        padding_max: padding.padding_max,
+    }
+
+    if (rendered) {
+        axis_template.axis = with_label(axis_in, auto_label)
+    }
+    return { axis_template }
+}
+
+function resolve_linear(axis_in: Axis, auto: Domain, rendered: boolean, auto_label: string | undefined, padding: ContinuousPadding): AxisTemplateResolution {
+    const { min, max } = validate_finite_bounds(axis_in)
+
+    const axis_template: LinearAxisTemplate = {
+        kind: 'linear',
+        domain: [min ?? auto[0], max ?? auto[1]],
+        rendered,
+        // an auto endpoint nices, a pinned one is preserved exactly
+        nice_min: min === undefined,
+        nice_max: max === undefined,
+        padding_min: padding.padding_min,
+        padding_max: padding.padding_max,
+    }
+
+    if (rendered) {
+        axis_template.axis = with_label(axis_in, auto_label)
+    }
+    return { axis_template }
+}
+
+/**
+ * Resolve a log axis. scaleLog needs positive domains, so non-positive bounds clamp to the floor with a warn (pinned non-positive throws).
+ * @param axis_in - the axis spec
+ * @param auto - auto-computed domain
+ * @param side - axis side, for messages
+ * @param rendered - whether the axis paints
+ * @param auto_label - derived default label
+ * @returns the resolved axis template
+ */
+function resolve_logarithmic(axis_in: Axis, auto: Domain, side: 'x' | 'y', rendered: boolean, auto_label: string | undefined, padding: ContinuousPadding): AxisTemplateResolution {
+    const { min, max } = validate_finite_bounds(axis_in)
+
+    const raw_min = min ?? auto[0]
+    const raw_max = max ?? auto[1]
+    const min_resolved = resolve_log_bound(raw_min, min !== undefined, side, 'min')
+    const max_resolved = resolve_log_bound(raw_max, max !== undefined, side, 'max')
+
+    if (min_resolved.clamped && max_resolved.clamped) {
+        throw new Error(`plot: axis.${side} has no positive data values for log scale (all rows non-positive). Filter the data, switch to a linear scale, or pin axis.${side}.{min,max} to positive values.`)
+    }
+
+    if (min_resolved.value === max_resolved.value) {
+        throw new Error(`plot: axis.${side} resolved to a degenerate log domain [${min_resolved.value}, ${max_resolved.value}]. Either filter the data or pin the endpoints to a non-degenerate positive range.`)
+    }
+    const axis_template: LogarithmicAxisTemplate = {
+        kind: 'log',
+        domain: [min_resolved.value, max_resolved.value],
+        rendered,
+        nice_min: min === undefined,
+        nice_max: max === undefined,
+        padding_min: padding.padding_min,
+        padding_max: padding.padding_max,
+    }
+
+    if (rendered) {
+        axis_template.axis = with_label(axis_in, auto_label)
+    }
+    return { axis_template }
+}
+
+/**
+ * Attach the resolved axis name: explicit caller label wins, empty string suppresses it, else the derived label.
+ * @param axis_in - the axis spec
+ * @param auto_label - derived default label
+ * @returns the axis spec with its label resolved
+ */
+function with_label(axis_in: Axis, auto_label: string | undefined): Axis {
+    return { ...axis_in, label: resolve_label(axis_in.label, auto_label) }
+}
+
+/**
+ * Resolve one log-scale endpoint. Positive passes through; non-positive throws when pinned, else clamps to the floor with a warn.
+ * @param value - the raw endpoint
+ * @param pinned - whether the caller pinned it
+ * @param side - axis side, for messages
+ * @param end - which endpoint
+ * @returns the resolved value and whether it was clamped
+ */
+function resolve_log_bound(value: number, pinned: boolean, side: 'x' | 'y', end: 'min' | 'max'): { value: number; clamped: boolean } {
+    if (value > 0) {
+        return { value, clamped: false }
+    }
+
+    // pinned non-positive throws, auto-computed clamps and warns
+    if (pinned) {
+        throw new Error(`plot: axis.${side}.${end} = ${value} is not positive; log scale requires positive domains. Drop the pin or pass a positive value.`)
+    }
+    console.warn(`plot: auto-computed ${side} ${end} = ${value} is not positive; clamped to ${LOG_DOMAIN_FLOOR} for log scale. Either filter non-positive rows from the data or pin axis.${side}.${end} to a positive value.`)
+    return { value: LOG_DOMAIN_FLOOR, clamped: true }
+}
+
+/**
+ * Resolve a categorical axis. A pinned axis.categories is canonical, otherwise collect first-seen across series. Pinned categories absent from all series render as empty bands.
+ * @param axis_in - the category axis spec
+ * @param series - the series
+ * @param side - axis side
+ * @param rendered - whether the axis paints
+ * @param auto_label - derived default label
+ * @param padding - the pixel padding per end of the band range
+ * @returns the resolved axis template and per-series translations
+ */
+function resolve_categorical(
+    axis_in: Axis,
+    series: Series[],
+    side: 'x' | 'y',
+    rendered: boolean,
+    auto_label: string | undefined,
+    padding: ContinuousPadding,
+): AxisTemplateResolution {
+    const { pinned, axis_categories, category_index } = seed_axis_categories(axis_in)
+
+    require_categorical_columns(series, side)
+
+    if (!pinned) {
+        append_series_categories(series, side, axis_categories, category_index)
+    }
+    const translations = build_translations(series, side, axis_categories, category_index)
+
+    const axis_template: CategoryAxisTemplate = {
+        kind: 'category',
+        categories: axis_categories,
+        rendered,
+        padding_min: padding.padding_min,
+        padding_max: padding.padding_max,
+    }
+
+    if (rendered) {
+        axis_template.axis = {
+            ...with_label(axis_in, auto_label),
+            scale: 'category',
+            categories: axis_categories,
+        }
+    }
+    return { axis_template, translations }
+}
+
+/**
+ * Seed the canonical category list from the caller's pin (deduped), empty when unpinned and filled later by the series walk.
+ * @param axis_in - the category axis spec
+ * @returns whether pinned, the seeded categories, and their index map
+ */
+function seed_axis_categories(axis_in: Axis): { pinned: boolean; axis_categories: string[]; category_index: Map<string, number> } {
+    const pinned = axis_in.categories !== undefined
+    // defensive copy and dedup so caller mutations don't leak
+    const axis_categories: string[] = pinned ? [...new Set(axis_in.categories!)] : []
+    const category_index = new Map<string, number>()
+
+    for (let i = 0; i < axis_categories.length; i++) {
+        category_index.set(axis_categories[i], i)
+    }
+    return { pinned, axis_categories, category_index }
+}
+
+/**
+ * Assert every series carries categorical data on this side, throwing otherwise.
+ * @param series - the series
+ * @param side - axis side
+ */
+function require_categorical_columns(series: Series[], side: 'x' | 'y'): void {
+    for (let i = 0; i < series.length; i++) {
+        const series_item = series[i]
+
+        if (!claims_axis(series_item, side)) {
+            continue
+        }
+        const categories = side === 'x' ? series_item.x_categories : series_item.y_categories
+
+        if (categories === undefined || categories.length === 0) {
+            throw new Error(`plot: axis.${side} is declared as 'category' but series at index ${i} has numeric ${side} values. Either pass string ${side} values, or declare axis.${side} as 'linear' (or omit the type declaration).`)
+        }
+    }
+}
+
+/**
+ * Append first-seen series categories into the shared list (mutating). Only called when unpinned.
+ * @param series - the series
+ * @param side - axis side
+ * @param axis_categories - the canonical list to grow
+ * @param category_index - the category-to-index map to grow
+ */
+function append_series_categories(
+    series: Series[],
+    side: 'x' | 'y',
+    axis_categories: string[],
+    category_index: Map<string, number>,
+): void {
+    for (let i = 0; i < series.length; i++) {
+        const series_item = series[i]
+
+        // a series that sits this axis out contributes no categories to collect
+        if (!claims_axis(series_item, side)) {
+            continue
+        }
+        const categories = (side === 'x' ? series_item.x_categories : series_item.y_categories)!
+
+        for (const category of categories) {
+            if (category_index.has(category)) {
+                continue
+            }
+            category_index.set(category, axis_categories.length)
+            axis_categories.push(category)
+        }
+    }
+}
+
+/**
+ * Build each series' local to axis category index map, or null when they already match. Unknown categories map to -1.
+ * @param series - the series
+ * @param side - axis side
+ * @param axis_categories - canonical category order
+ * @param category_index - category-to-index map
+ * @returns per-series translation tables
+ */
+function build_translations(
+    series: Series[],
+    side: 'x' | 'y',
+    axis_categories: string[],
+    category_index: Map<string, number>,
+): (Int32Array | null)[] {
+    const translations: (Int32Array | null)[] = []
+
+    for (let i = 0; i < series.length; i++) {
+        const series_item = series[i]
+
+        // nothing to remap for a series that sits this axis out
+        if (!claims_axis(series_item, side)) {
+            translations.push(null)
+            continue
+        }
+        const categories = side === 'x' ? series_item.x_categories! : series_item.y_categories!
+
+        // fast path: local already matches axis prefix, no remap
+        if (matches_prefix(categories, axis_categories)) {
+            translations.push(null)
+            continue
+        }
+        const translation_map = new Int32Array(categories.length)
+        const unknown_categories: string[] = []
+
+        // -1 marks an unknown category, dropped per-row by build_resolved_series
+        for (let j = 0; j < categories.length; j++) {
+            const index = category_index.get(categories[j])
+
+            if (index === undefined) {
+                translation_map[j] = -1
+                unknown_categories.push(categories[j])
+            } else {
+                translation_map[j] = index
+            }
+        }
+
+        if (unknown_categories.length > 0) {
+            const noun = unknown_categories.length === 1 ? 'category' : 'categories'
+            console.warn(`plot: series at index ${i} has ${side} ${noun} not in caller-pinned axis.${side}.categories: ${unknown_categories.map(category => `'${category}'`).join(', ')} — rows with these ${noun} will be dropped.`)
+        }
+        translations.push(translation_map)
+    }
+    return translations
+}
+
+/**
+ * Whether the local categories are a prefix of the canonical order, the fast path that needs no remap.
+ * @param local - the series' local categories
+ * @param axis_categories - canonical category order
+ * @returns true when local matches the canonical prefix
+ */
+function matches_prefix(local: string[], axis_categories: string[]): boolean {
+    if (local.length > axis_categories.length) {
+        return false
+    }
+
+    for (let i = 0; i < local.length; i++) {
+        if (local[i] !== axis_categories[i]) {
+            return false
+        }
+    }
+    return true
+}

--- a/plot/src/core/template/build_series.ts
+++ b/plot/src/core/template/build_series.ts
@@ -1,0 +1,210 @@
+import type { Series, ThemeColor } from "../types"
+
+// This file remaps band indices (if applicabble), drops rows with unknown categories, and strips
+// internal *_categories and *_axis_kind fields.
+
+/**
+ * Remap each series' band indices to canonical order, drop unknown-category rows
+ * @param input - the input series
+ * @param x_translations - per-series x translation tables, or undefined
+ * @param y_translations - per-series y translation tables, or undefined
+ * @returns the rebuilt series
+ */
+export function build_resolved_series(
+    input: Series[],
+    x_translations: (Int32Array | null)[] | undefined,
+    y_translations: (Int32Array | null)[] | undefined,
+): Series[] {
+    if (x_translations === undefined && y_translations === undefined) {
+        return input
+    }
+    return input.map((series_item, i) => rebuild_series(
+        series_item,
+        x_translations?.[i] ?? null,
+        y_translations?.[i] ?? null,
+    ))
+}
+
+/**
+ * Rebuild one series. Fast-paths to the input unchanged when there's no remap and nothing to strip.
+ * @param series_item - the series to rebuild
+ * @param x_translation - x translation table, or null for no remap
+ * @param y_translation - y translation table, or null for no remap
+ * @returns the rebuilt series
+ */
+function rebuild_series(
+    series_item: Series,
+    x_translation: Int32Array | null,
+    y_translation: Int32Array | null,
+): Series {
+    // null translation plus categorical means local matched prefix, still need to strip
+    const has_categories = series_item.x_axis_kind === 'categorical' || series_item.y_axis_kind === 'categorical'
+
+    if (x_translation === null && y_translation === null && !has_categories) {
+        return series_item
+    }
+    const remapped = remap_rows(series_item, x_translation, y_translation)
+    return assemble_output_series(series_item, remapped)
+}
+
+// walk rows, drop -1 hits, copy survivors. Arrays trimmed only when rows dropped.
+type RemappedBuffers = {
+    x: Float64Array
+    y: Float64Array
+    x2?: Float64Array
+    y2?: Float64Array
+    colors?: (ThemeColor | null)[]
+    sizes?: (number | null)[]
+    rows?: Record<string, unknown>[]
+    labels?: string[]
+}
+
+/**
+ * Walk the rows, drop unknown-category hits (-1), and copy survivors. Buffers are trimmed only when rows were dropped.
+ * @param series_item - the source series
+ * @param x_translation - x translation table, or null
+ * @param y_translation - y translation table, or null
+ * @returns the remapped x/y (and any x2/y2, colors, sizes, rows, labels) buffers
+ */
+function remap_rows(
+    series_item: Series,
+    x_translation: Int32Array | null,
+    y_translation: Int32Array | null,
+): RemappedBuffers {
+    const length = series_item.x.length
+    const buffer_x = new Float64Array(length)
+    const buffer_y = new Float64Array(length)
+    const input_colors = series_item.colors
+    const buffer_colors = input_colors !== undefined ? new Array<ThemeColor | null>(length) : undefined
+    const input_sizes = series_item.kind === 'scatter' ? series_item.sizes : undefined
+    const buffer_sizes = input_sizes !== undefined ? new Array<number | null>(length) : undefined
+
+    const input_x2 = 'x2' in series_item ? series_item.x2 : undefined
+    const input_y2 = 'y2' in series_item ? series_item.y2 : undefined
+    const buffer_x2 = input_x2 !== undefined ? new Float64Array(length) : undefined
+    const buffer_y2 = input_y2 !== undefined ? new Float64Array(length) : undefined
+
+    const input_rows = series_item.rows
+    const buffer_rows = input_rows !== undefined ? new Array<Record<string, unknown>>(length) : undefined
+    const input_labels = series_item.labels
+    const buffer_labels = input_labels !== undefined ? new Array<string>(length) : undefined
+
+    let write_index = 0
+
+    for (let row_index = 0; row_index < length; row_index++) {
+        const translated_x = x_translation !== null ? x_translation[series_item.x[row_index]] : series_item.x[row_index]
+        const translated_y = y_translation !== null ? y_translation[series_item.y[row_index]] : series_item.y[row_index]
+
+        // -1 marks unknown category, only meaningful when a translation table exists
+        if ((x_translation !== null && translated_x === -1) || (y_translation !== null && translated_y === -1)) {
+            continue
+        }
+        buffer_x[write_index] = translated_x
+        buffer_y[write_index] = translated_y
+
+        if (buffer_colors !== undefined) {
+            buffer_colors[write_index] = input_colors![row_index]
+        }
+
+        if (buffer_sizes !== undefined) {
+            buffer_sizes[write_index] = input_sizes![row_index]
+        }
+
+        if (buffer_x2 !== undefined) {
+            buffer_x2[write_index] = input_x2![row_index]
+        }
+
+        if (buffer_y2 !== undefined) {
+            buffer_y2[write_index] = input_y2![row_index]
+        }
+
+        if (buffer_rows !== undefined) {
+            buffer_rows[write_index] = input_rows![row_index]
+        }
+
+        if (buffer_labels !== undefined) {
+            buffer_labels[write_index] = input_labels![row_index]
+        }
+        write_index++
+    }
+    // trim only when rows were dropped, otherwise pass the full buffer through
+    const full = write_index === length
+    const result: RemappedBuffers = {
+        x: full ? buffer_x : buffer_x.slice(0, write_index),
+        y: full ? buffer_y : buffer_y.slice(0, write_index),
+    }
+
+    if (buffer_colors !== undefined) {
+        result.colors = full ? buffer_colors : buffer_colors.slice(0, write_index)
+    }
+
+    if (buffer_sizes !== undefined) {
+        result.sizes = full ? buffer_sizes : buffer_sizes.slice(0, write_index)
+    }
+
+    if (buffer_x2 !== undefined) {
+        result.x2 = full ? buffer_x2 : buffer_x2.slice(0, write_index)
+    }
+
+    if (buffer_y2 !== undefined) {
+        result.y2 = full ? buffer_y2 : buffer_y2.slice(0, write_index)
+    }
+
+    if (buffer_rows !== undefined) {
+        result.rows = full ? buffer_rows : buffer_rows.slice(0, write_index)
+    }
+
+    if (buffer_labels !== undefined) {
+        result.labels = full ? buffer_labels : buffer_labels.slice(0, write_index)
+    }
+    return result
+}
+
+/**
+ * Build the output series: carry over kind and public fields, re-attach the remapped row buffers, and drop the pipeline-internal *_axis_kind / *_categories / *_field (canonical info lives on the AxisTemplate). Kind-agnostic, so a new series type needs no branch here.
+ * @param series_item - the source series
+ * @param remapped - the remapped buffers
+ * @returns the output series
+ */
+function assemble_output_series(series_item: Series, remapped: RemappedBuffers): Series {
+    const output: Series = { ...series_item, x: remapped.x, y: remapped.y }
+    delete output.x_axis_kind
+    delete output.y_axis_kind
+    delete output.x_categories
+    delete output.y_categories
+    delete output.x_field
+    delete output.y_field
+
+    // replace the row-aligned buffers with the remapped (trimmed) versions, or drop them when the
+    // remap produced none
+    if (remapped.colors !== undefined) {
+        output.colors = remapped.colors
+    } else {
+        delete output.colors
+    }
+
+    if (output.kind === 'scatter') {
+        if (remapped.sizes !== undefined) {
+            output.sizes = remapped.sizes
+        } else {
+            delete output.sizes
+        }
+    }
+
+    if ('x2' in output && remapped.x2 !== undefined) {
+        output.x2 = remapped.x2
+    }
+
+    if ('y2' in output && remapped.y2 !== undefined) {
+        output.y2 = remapped.y2
+    }
+
+    if (remapped.rows !== undefined) {
+        output.rows = remapped.rows
+    }
+
+    if (remapped.labels !== undefined) {
+        output.labels = remapped.labels
+    }
+    return output
+}

--- a/plot/src/core/template/color.ts
+++ b/plot/src/core/template/color.ts
@@ -1,0 +1,301 @@
+// shared per-row color resolution. `color` arg accepts two shapes:
+//   string | { light, dark }   uniform for every row (a ThemeColor)
+//   (row, i) => ThemeColor      accessor called per row
+// per-row `color` field on data overrides the series-level shape for that row.
+// renderer fallback chain: colors[i], color, DEFAULT_SERIES_COLOR.
+
+import { validate_non_negative } from "./validate"
+import type { ColorArg, ColorTheme, Stroke, StrokeArg, ThemeColor } from "../types"
+
+const DEFAULT_BACKGROUND = '#fff'
+export const DEFAULT_SERIES_COLOR = '#000'
+
+/**
+ * Whether the plot's canvas gets the dark-mode CSS invert: an explicit theme_invert wins, otherwise the
+ * plot inverts unless its series or background already carry theme-specific ({ light, dark }) colors.
+ * @param template - the plot template
+ * @returns true when the canvas is CSS-inverted in dark mode
+ */
+type ColorBearingSeries = {
+    color?: ThemeColor
+    colors?: (ThemeColor | null)[]
+    stroke?: Stroke
+}
+
+type ColorTemplate = {
+    series: ColorBearingSeries[]
+    background?: boolean | ThemeColor
+    theme_invert?: boolean
+}
+
+export function should_invert_color(template: ColorTemplate): boolean {
+    const themes_own_colors = series_have_theme_color_pair(template.series) || background_is_theme_color_pair(template.background)
+    return template.theme_invert ?? !themes_own_colors
+}
+
+/**
+ * Resolve a plot's `background` for the theme: false = paint none, true / undefined = the default fill color,
+ * a ThemeColor = a concrete fill color (a { light, dark } pair collapses to the theme's variant).
+ * @param background - the plot background arg
+ * @param theme - the current browser color scheme
+ * @returns false (paint none) or a concrete color string
+ */
+export function resolve_plot_background(background: boolean | ThemeColor | undefined, theme: ColorTheme): string | false {
+    if (background === undefined) {
+        return DEFAULT_BACKGROUND
+    }
+
+    if (typeof background === 'boolean') {
+        return background ? DEFAULT_BACKGROUND : false
+    }
+    return resolve_theme_color(background, theme)
+}
+
+/**
+ * Whether a plot background is a { light, dark } pair, so the plot owns its theming and opts out of the
+ * dark-mode auto-invert (a plain string stays invertible, like a plain series color).
+ * @param background - the plot background arg
+ * @returns true when background is a light/dark pair
+ */
+export function background_is_theme_color_pair(background: boolean | ThemeColor | undefined): boolean {
+    return is_light_dark_color_pair(background)
+}
+
+type ColorFields = {
+    color?: ThemeColor
+    colors?: (ThemeColor | null)[]
+}
+
+type ResolvedColorFields = {
+    color?: string
+    colors?: (string | null)[]
+    stroke?: { color: string; width?: number }
+}
+
+type WithResolvedColors<S> = S extends unknown ? Omit<S, keyof ResolvedColorFields> & ResolvedColorFields : never
+
+/**
+ * Resolve per-row colors. A per-row `color` field wins, then the series arg (ThemeColor or accessor).
+ * @param data - the data rows
+ * @param arg - uniform ThemeColor, per-row accessor, or undefined
+ * @returns the color and/or per-row colors to attach to the series
+ */
+export function resolve_color(
+    data: Record<string, unknown>[],
+    arg: ColorArg | undefined,
+): ColorFields {
+    const has_per_item = data.some(r => is_theme_color(r.color))
+    const is_accessor = typeof arg === 'function'
+    const uniform = is_theme_color(arg) ? arg : undefined
+    const result: ColorFields = {}
+
+    if (has_per_item || is_accessor) {
+        const colors = new Array<ThemeColor | null>(data.length)
+
+        for (let i = 0; i < data.length; i++) {
+            const row = data[i]
+            const per_item = is_theme_color(row.color) ? row.color : undefined
+            colors[i] = per_item ?? resolve_color_arg(arg, row, i) ?? null
+        }
+        result.colors = colors
+    }
+
+    if (uniform !== undefined) {
+        result.color = uniform
+    }
+    return result
+}
+
+/**
+ * Normalize the stroke arg into { color, width? }, or undefined when unset. Shared by the mark / rect
+ * series factories. Width is validated non-negative; an unset width auto-scales to the mark at paint time.
+ * @param stroke - the stroke arg (a ThemeColor for just color, a { color, width } object, or undefined)
+ * @param error_prefix - label prefixed to a thrown width error (e.g. 'plot.scatter')
+ * @returns the resolved stroke, or undefined
+ */
+export function resolve_stroke(stroke: StrokeArg | undefined, error_prefix: string): Stroke | undefined {
+    if (stroke === undefined) {
+        return undefined
+    }
+
+    // a color string or light/dark pair: just the color, width auto-scales at paint time
+    if (is_theme_color(stroke)) {
+        return { color: stroke }
+    }
+    const { color, width } = stroke
+
+    if (width === undefined) {
+        return { color }
+    }
+
+    return { color, width: validate_non_negative(width, `${error_prefix}: stroke.width`) }
+}
+
+/**
+ * Resolve every ThemeColor field on a series to a concrete string for the theme
+ * @param series - the series template
+ * @param theme - the current browser color scheme
+ * @returns the series with its color fields resolved to strings
+ */
+export function resolve_series_colors<S extends ColorBearingSeries>(series: S, theme: ColorTheme): WithResolvedColors<S> {
+    const base = {
+        color: series.color === undefined ? undefined : resolve_theme_color(series.color, theme),
+        colors: resolve_colors_for_theme(series.colors, theme),
+    }
+
+    const stroke = series_stroke(series)
+
+    if (stroke !== undefined) {
+        const resolved_stroke = { ...stroke, color: resolve_theme_color(stroke.color, theme) }
+        // The spread replaces exactly the keys modeled by WithResolvedColors; TypeScript cannot prove
+        // that relationship for a distributive conditional over generic series unions.
+        return { ...series, ...base, stroke: resolved_stroke } as unknown as WithResolvedColors<S>
+    }
+    return { ...series, ...base, stroke: undefined } as unknown as WithResolvedColors<S>
+}
+
+/**
+ * Build a per-row color resolver, hoisting the has-per-row-colors branch out of the caller's loop. Mirrors
+ * pixel_resolver: the colors here are post-compose, so they are concrete strings rather than ThemeColors.
+ * @param colors - the resolved per-row colors, or undefined
+ * @param fallback - the series color, used where a row has none
+ * @returns a resolver mapping row index to a concrete color
+ */
+export function color_resolver(colors: (string | null)[] | undefined, fallback: string): (i: number) => string {
+    if (colors === undefined) {
+        return () => fallback
+    }
+    return (i) => colors[i] ?? fallback
+}
+
+/**
+ * Whether any series carries a { light, dark } pair
+ * @param series - the resolved series list
+ * @returns true when at least one color field is a light/dark pair
+ */
+export function series_have_theme_color_pair(series: ColorBearingSeries[]): boolean {
+    for (const s of series) {
+        if (is_light_dark_color_pair(s.color)) {
+            return true
+        }
+
+        if (s.colors?.some(is_light_dark_color_pair)) {
+            return true
+        }
+
+        const stroke = series_stroke(s)
+
+        if (stroke !== undefined && is_light_dark_color_pair(stroke.color)) {
+            return true
+        }
+    }
+    return false
+}
+
+/**
+ * The series' stroke, if its kind carries one: scatter, rect, area, and line — where the field holds the
+ * vertex marker's border (the caller's `mark_stroke`), not the line itself. Bar and rule have none.
+ * @param series - the series to test
+ * @returns the stroke, or undefined
+ */
+function series_stroke(series: ColorBearingSeries): Stroke | undefined {
+    return series.stroke
+}
+
+/**
+ * Resolve a per-row colors array for the theme. When the array holds no {light,dark} pair (the common case)
+ * it's already theme-independent, so it's reused untouched rather than reallocated on every compose (resize / theme).
+ * @param colors - the per-row ThemeColor array, or undefined
+ * @param theme - the current browser color scheme
+ * @returns the per-row concrete color strings, or undefined
+ */
+function resolve_colors_for_theme(colors: (ThemeColor | null)[] | undefined, theme: ColorTheme): (string | null)[] | undefined {
+    if (colors === undefined) {
+        return undefined
+    }
+
+    if (is_plain_string_colors(colors)) {
+        return colors
+    }
+    return colors.map(c => c === null ? null : resolve_theme_color(c, theme))
+}
+
+/**
+ * Whether a colors array is already all plain strings (no {light,dark} pair), i.e. theme-independent.
+ * @param colors - the per-row ThemeColor array
+ * @returns true when no element is a light/dark pair
+ */
+function is_plain_string_colors(colors: (ThemeColor | null)[]): colors is (string | null)[] {
+    return !colors.some(is_light_dark_color_pair)
+}
+
+// A resolved text color: the caller's ThemeColor for the theme, or the fallback when none is set.
+export function resolve_text_color(color: ThemeColor | undefined, theme: ColorTheme, fallback: string): string {
+    return color === undefined ? fallback : resolve_theme_color(color, theme)
+}
+
+/**
+ * Resolve a ThemeColor to a concrete color string for the current theme. A plain string is theme-independent
+ * @param color - the ThemeColor (string or { light, dark })
+ * @param theme - the current browser color scheme
+ * @returns the concrete color string
+ */
+export function resolve_theme_color(color: ThemeColor, theme: ColorTheme): string {
+    if (is_light_dark_color_pair(color)) {
+        return theme === 'dark' ? color.dark : color.light
+    }
+    return color
+}
+
+/**
+ * Whether a value is a usable ThemeColor: a non-empty color string or a { light, dark } pair.
+ * @param value - the value to test
+ * @returns true when value is a usable ThemeColor
+ */
+export function is_theme_color(value: unknown): value is ThemeColor {
+    if (is_nonempty_string(value)) {
+        return true
+    }
+    return is_light_dark_color_pair(value)
+}
+
+/**
+ * Whether a value is a non-empty string.
+ * @param value - the value to test
+ * @returns true when value is a non-empty string
+ */
+function is_nonempty_string(value: unknown): value is string {
+    return typeof value === 'string' && value !== ''
+}
+
+/**
+ * Whether a value is a { light, dark } color pair with non-empty string variants.
+ * @param value - the value to test
+ * @returns true when value is a color pair
+ */
+function is_light_dark_color_pair(value: unknown): value is { light: string; dark: string } {
+    if (typeof value !== 'object' || value === null) {
+        return false
+    }
+
+    if ('light' in value && 'dark' in value) {
+        return is_nonempty_string(value.light) && is_nonempty_string(value.dark)
+    }
+    return false
+}
+
+/**
+ * Resolve the series color arg for one mark, returning undefined for absent or empty values.
+ * @param arg - uniform ThemeColor, accessor, or undefined
+ * @param row - the data row
+ * @param index - the index handed to an accessor
+ * @returns the resolved ThemeColor, or undefined
+ */
+export function resolve_color_arg(
+    arg: ColorArg | undefined,
+    row: Record<string, unknown>,
+    index: number,
+): ThemeColor | undefined {
+    const value = typeof arg === 'function' ? arg(row, index) : arg
+    return is_theme_color(value) ? value : undefined
+}

--- a/plot/src/core/template/column.ts
+++ b/plot/src/core/template/column.ts
@@ -1,0 +1,253 @@
+// per-column type detection shared by series factories. A column must be uniformly numeric
+// or uniformly categorical, mixing throws on the first conflicting row. resolve_xy_columns is the
+// common two-column convenience; a series needing a different column shape composes the exported
+// primitives (make_column_resolver, validate_field_present) in its own directory.
+
+import type { AxisKind, FieldArg } from "../types"
+
+export type ColumnMode = 'undecided' | 'numeric' | 'categorical'
+
+type SeriesColumnFields = {
+    x_axis_kind?: AxisKind
+    y_axis_kind?: AxisKind
+    x_categories?: string[]
+    y_categories?: string[]
+    x_field?: string
+    y_field?: string
+}
+
+type ResolvedColumns = {
+    x: Float64Array
+    y: Float64Array
+} & ResolvedColumnMeta
+
+export type ResolvedColumnMeta = {
+    x_mode: ColumnMode
+    y_mode: ColumnMode
+    x_categories: string[] | null
+    y_categories: string[] | null
+}
+
+export type ColumnResolver = {
+    resolve(value: unknown, row: number, field: string): number
+    mode(): ColumnMode
+    categories(): string[] | null
+}
+
+export type ResolvedColumn = {
+    values: Float64Array
+    mode: ColumnMode
+    categories: string[] | null
+}
+
+/**
+ * Read a field off a row by name or (row, index) accessor.
+ * @param arg - field name or accessor
+ * @param row - the data row
+ * @param index - the row index
+ * @returns the raw cell value
+ */
+export function read_field(arg: FieldArg, row: Record<string, unknown>, index: number): unknown {
+    return typeof arg === 'function' ? arg(row, index) : row[arg]
+}
+
+/**
+ * Resolve one column to an aligned Float64Array plus its detected mode and categories. The shared per-column
+ * primitive: series factories that need more than the x/y pair (e.g. rect's corners) compose this directly.
+ * @param data - the data rows
+ * @param arg - field name or accessor
+ * @param error_prefix - label prefixed to thrown errors
+ * @param fallback_label - error-message label used when arg is an accessor (not a field name)
+ * @returns the resolved values plus mode and categories
+ */
+export function resolve_column(
+    data: Record<string, unknown>[],
+    arg: FieldArg,
+    error_prefix: string,
+    fallback_label: string,
+): ResolvedColumn {
+    const length = data.length
+    const values = new Float64Array(length)
+    const resolver = make_column_resolver(error_prefix)
+    // keep the field name in error messages when given, else the caller's fallback
+    const label = typeof arg === 'string' ? arg : fallback_label
+
+    for (let i = 0; i < length; i++) {
+        values[i] = resolver.resolve(read_field(arg, data[i], i), i, label)
+    }
+    return { values, mode: resolver.mode(), categories: resolver.categories() }
+}
+
+/**
+ * Walk the rows and resolve x/y into aligned Float64Arrays, returning each column's mode and categories.
+ * @param data - the data rows
+ * @param x_arg - x field name or accessor
+ * @param y_arg - y field name or accessor
+ * @param error_prefix - label prefixed to thrown errors
+ * @param x_defaulted - whether x fell back to the default field name
+ * @param y_defaulted - whether y fell back to the default field name
+ * @returns the resolved x/y arrays plus per-column mode and categories
+ */
+export function resolve_xy_columns(
+    data: Record<string, unknown>[],
+    x_arg: FieldArg,
+    y_arg: FieldArg,
+    error_prefix: string,
+    x_defaulted: boolean,
+    y_defaulted: boolean,
+): ResolvedColumns {
+    if (data.length > 0) {
+        validate_field_present(data[0], x_arg, x_defaulted, error_prefix, 'x')
+        validate_field_present(data[0], y_arg, y_defaulted, error_prefix, 'y')
+    }
+    const x = resolve_column(data, x_arg, error_prefix, 'x')
+    const y = resolve_column(data, y_arg, error_prefix, 'y')
+    return {
+        x: x.values,
+        y: y.values,
+        x_mode: x.mode,
+        y_mode: y.mode,
+        x_categories: x.categories,
+        y_categories: y.categories,
+    }
+}
+
+/**
+ * Attach resolved column metadata (axis kind, categories, source field name) onto a freshly built series, mutating it in place. Shared by series factories so the gated-attach pattern lives in one place.
+ * @param series - the series under construction
+ * @param resolved - the resolved column metadata (modes and categories)
+ * @param x_arg - x field name or accessor
+ * @param y_arg - y field name or accessor
+ */
+export function attach_resolved_columns(
+    series: SeriesColumnFields,
+    resolved: ResolvedColumnMeta,
+    x_arg: FieldArg | undefined,
+    y_arg: FieldArg | undefined,
+): void {
+    if (resolved.x_mode !== 'undecided') {
+        series.x_axis_kind = resolved.x_mode
+    }
+
+    if (resolved.y_mode !== 'undecided') {
+        series.y_axis_kind = resolved.y_mode
+    }
+
+    if (resolved.x_categories !== null) {
+        series.x_categories = resolved.x_categories
+    }
+
+    if (resolved.y_categories !== null) {
+        series.y_categories = resolved.y_categories
+    }
+
+    if (typeof x_arg === 'string') {
+        series.x_field = x_arg
+    }
+
+    if (typeof y_arg === 'string') {
+        series.y_field = y_arg
+    }
+}
+
+/**
+ * Up-front check on row 0 for string field args, catching forgotten x/y and typo'd field names.
+ * @param row - the first data row
+ * @param arg - the field name or accessor
+ * @param defaulted - whether the field name was defaulted
+ * @param error_prefix - label prefixed to the error
+ * @param slot - which axis slot, for the message
+ */
+export function validate_field_present(
+    row: Record<string, unknown>,
+    arg: FieldArg,
+    defaulted: boolean,
+    error_prefix: string,
+    slot: string,
+): void {
+    if (typeof arg !== 'string') {
+        return
+    }
+
+    if (arg in row) {
+        return
+    }
+    const available = Object.keys(row)
+        .filter(k => typeof row[k] === 'number' || typeof row[k] === 'string')
+        .sort()
+    const available_str = available.length > 0 ? available.map(f => `'${f}'`).join(', ') : '(none)'
+    const reason = defaulted
+        ? `${slot} defaulted to '${arg}' (no ${slot} arg passed) but row 0 has no '${arg}' field`
+        : `${slot}: '${arg}' but row 0 has no '${arg}' field`
+
+    throw new Error(`${error_prefix}: ${reason}. Available numeric/string fields: ${available_str}.`)
+}
+
+/**
+ * Build a per-column resolver that assigns each distinct category an index and enforces a uniform numeric-or-categorical type.
+ * @param error_prefix - label prefixed to thrown errors
+ * @returns a resolver with resolve, mode, and categories accessors
+ */
+export function make_column_resolver(error_prefix: string): ColumnResolver {
+    let mode: ColumnMode = 'undecided'
+    const string_map = new Map<string, number>()
+    const categories: string[] = []
+    return {
+        resolve(value, row, field) {
+            if (typeof value === 'string') {
+                // strings don't mix with numeric
+                if (mode === 'numeric') {
+                    throw new Error(`${error_prefix}: row ${row} field '${field}' is a string but earlier rows were numeric (a column must be uniformly one type)`)
+                }
+
+                // first string sets categorical mode
+                mode = 'categorical'
+                let index = string_map.get(value)
+
+                // assign the next index to each new category on first sight
+                if (index === undefined) {
+                    index = categories.length
+                    categories.push(value)
+                    string_map.set(value, index)
+                }
+                return index
+            }
+
+            if (typeof value === 'number' && Number.isFinite(value)) {
+                if (mode === 'categorical') {
+                    throw new Error(`${error_prefix}: row ${row} field '${field}' is a number but earlier rows were strings (a column must be uniformly one type)`)
+                }
+                mode = 'numeric'
+                return value
+            }
+            throw new Error(`${error_prefix}: row ${row} field '${field}' is not a finite number or a string (got ${format_bad_value(value)})`)
+        },
+        mode() {
+            return mode
+        },
+        categories() {
+            return mode === 'categorical' ? categories : null
+        },
+    }
+}
+
+/**
+ * Format a rejected cell value for an error message.
+ * @param value - the offending value
+ * @returns a short human-readable description
+ */
+function format_bad_value(value: unknown): string {
+    if (value === undefined) {
+        return 'undefined'
+    }
+
+    if (typeof value === 'number') {
+        return String(value)
+    }
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TODO: fix when next touching this code
+        return JSON.stringify(value) ?? `<${typeof value}>`
+    } catch {
+        return `<${typeof value}>`
+    }
+}

--- a/plot/src/core/template/domain.ts
+++ b/plot/src/core/template/domain.ts
@@ -1,0 +1,163 @@
+import type { Axis, Domain, Series, SideMode } from "../types"
+import { series_type } from "../registry"
+
+// domain computation. Walks series for min/max, pads per side. Sits between series factories
+// (raw x/y) and axis resolution (d3 scale).
+
+// headroom past the tallest/deepest bar so it doesn't sit flush against the plot border.
+const BAR_HEADROOM = 0.05
+
+/**
+ * Whether an axis needs auto domain computation, true when min or max is unset.
+ * @param axis - the axis spec
+ * @returns true when either endpoint is unset
+ */
+export function needs_auto(axis: Axis): boolean {
+    return axis.min === undefined || axis.max === undefined
+}
+
+/**
+ * Compute x and y domains by walking every series for min/max, then padding per side.
+ * @param series - the series to scan
+ * @param x_padding_mode - padding mode for x
+ * @param y_padding_mode - padding mode for y
+ * @returns the padded x and y domains
+ */
+export function compute_domains(
+    series: Series[],
+    x_padding_mode: SideMode,
+    y_padding_mode: SideMode,
+): { x: Domain; y: Domain } {
+    let x_min = Infinity, x_max = -Infinity
+    let y_min = Infinity, y_max = -Infinity
+
+    for (const series_item of series) {
+        const { x, y } = series_type(series_item.kind).domain_extent(series_item)
+
+        if (x[0] < x_min) {
+            x_min = x[0]
+        }
+
+        if (x[1] > x_max) {
+            x_max = x[1]
+        }
+
+        if (y[0] < y_min) {
+            y_min = y[0]
+        }
+
+        if (y[1] > y_max) {
+            y_max = y[1]
+        }
+    }
+    return {
+        x: pad_or_fallback(x_min, x_max, x_padding_mode),
+        y: pad_or_fallback(y_min, y_max, y_padding_mode),
+    }
+}
+
+/**
+ * Pad a raw [min, max] per the side's mode, falling back to [0, 1] for non-finite input.
+ * @param min - raw minimum
+ * @param max - raw maximum
+ * @param padding_mode - the side's padding mode
+ * @returns the padded domain
+ */
+function pad_or_fallback(min: number, max: number, padding_mode: SideMode): Domain {
+    if (!Number.isFinite(min) || !Number.isFinite(max)) {
+        return [0, 1]
+    }
+
+    if (padding_mode === 'log') {
+        return [min, max]
+    }
+
+    if (padding_mode === 'anchor_zero') {
+        if (min >= 0 && max >= 0) {
+            if (max === 0) {
+                return [0, 1]
+            }
+            return [0, max * (1 + BAR_HEADROOM)]
+        }
+
+        if (min <= 0 && max <= 0) {
+            if (min === 0) {
+                return [-1, 0]
+            }
+            return [min * (1 + BAR_HEADROOM), 0]
+        }
+        // straddles zero: pad both ends, both carry bars away from the baseline
+        return [min * (1 + BAR_HEADROOM), max * (1 + BAR_HEADROOM)]
+    }
+
+    if (padding_mode === 'spark_symmetric') {
+        const low = Math.min(min, 0)
+        const high = Math.max(max, 0)
+
+        if (low === high) {
+            return [low - 0.5, high + 0.5]
+        }
+        // no visible baseline, so float both ends off the edges
+        const headroom = (high - low) * BAR_HEADROOM
+        return [low - headroom, high + headroom]
+    }
+
+    if (min === max) {
+        return [min - 0.5, max + 0.5]
+    }
+    // 5% pad
+    const padding = (max - min) * 0.05
+    let padded_min = min - padding
+    let padded_max = max + padding
+
+    if (min >= 0 && padded_min < 0) {
+        padded_min = 0
+    }
+
+    if (max <= 0 && padded_max > 0) {
+        padded_max = 0
+    }
+    return [padded_min, padded_max]
+}
+
+export type AxisSpace = {
+    to: (data_value: number) => number
+    from: (space_value: number) => number
+}
+
+export const LINEAR_SPACE: AxisSpace = { to: (v) => v, from: (v) => v }
+export const LOG_SPACE: AxisSpace = { to: Math.log10, from: (v) => 10 ** v }
+
+/**
+ * Clamp a window into `full_domain`: never wider than full (returns null, the full view), and shifted back
+ * inside when an endpoint spills past an edge. Shared by the zoom/pan gestures and by a caller-supplied
+ * viewport. Invalid working-space windows return the full view (for example, log of a non-positive
+ * bound). The tightest-zoom floor is enforced upstream in `zoom_domain`.
+ * @param domain - the window to clamp, in the axis's working space
+ * @param full_domain - the full unzoomed domain, in the same space
+ * @returns the clamped window, or null for the full view
+ */
+export function clamp_domain(domain: Domain, full_domain: Domain): Domain | null {
+    const full_span = full_domain[1] - full_domain[0]
+    let lo = domain[0]
+    let hi = domain[1]
+
+    // Reject bounds that the axis cannot represent before comparisons can let NaN propagate.
+    if (!Number.isFinite(lo) || !Number.isFinite(hi) || lo >= hi) {
+        return null
+    }
+    if (hi - lo >= full_span) {
+        return null
+    }
+
+    if (lo < full_domain[0]) {
+        hi += full_domain[0] - lo
+        lo = full_domain[0]
+    }
+
+    if (hi > full_domain[1]) {
+        lo -= hi - full_domain[1]
+        hi = full_domain[1]
+    }
+    return [lo, hi]
+}

--- a/plot/src/core/template/extent.ts
+++ b/plot/src/core/template/extent.ts
@@ -1,0 +1,37 @@
+/**
+ * The [min, max] of a numeric column, or [Infinity, -Infinity] when empty.
+ * NaN values naturally do not affect the result.
+ * @param values - the column values
+ * @returns the column extent
+ */
+export function array_extent(values: Float64Array): [number, number] {
+    let min = Infinity, max = -Infinity
+
+    for (const value of values) {
+        if (value < min) {
+            min = value
+        }
+
+        if (value > max) {
+            max = value
+        }
+    }
+    return [min, max]
+}
+
+type XYColumns = {
+    x: Float64Array
+    y: Float64Array
+}
+
+/**
+ * The extent of a series that occupies just its x / y points.
+ * @param series - an object containing resolved x and y columns
+ * @returns the [min, max] per axis
+ */
+export function xy_extent(series: XYColumns): { x: [number, number]; y: [number, number] } {
+    return {
+        x: array_extent(series.x),
+        y: array_extent(series.y),
+    }
+}

--- a/plot/src/core/template/plot_template.ts
+++ b/plot/src/core/template/plot_template.ts
@@ -1,0 +1,222 @@
+import type { AxisTemplate, Domain, Margin, PlotArgs, PlotTemplate, RequestedViewportWindow, Series, ThemeColor, TitleArg, ViewportRequest, ZoomPan } from "../types"
+import { build_resolved_axes } from "./axis"
+import { build_resolved_series } from "./build_series"
+import { validate_non_negative, validate_positive } from "./validate"
+
+// Plot template factory. Runs at user-call time, validates, throws on bad config.
+// Output is dimension-independent. compose_plot turns it into a renderable Plot.
+
+/**
+ * Build the dimension-independent PlotTemplate: validate args, infer axis kinds, compute domains.
+ * @param args - the unvalidated plot args
+ * @returns the resolved PlotTemplate
+ */
+export function new_plot_template<TooltipContent = unknown>(args: PlotArgs<TooltipContent>): PlotTemplate<TooltipContent> {
+    validate_dimensions(args)
+    const { series, axis } = args
+
+    // Axis resolution and row remapping never inspect host tooltip content. Keep those helpers
+    // non-generic while preserving the caller's tooltip type on the returned template.
+    const structural_series = series as unknown as Series[]
+
+    // validate, classify, and resolve both axes end to end
+    const { x_resolved, y_resolved } = build_resolved_axes(structural_series, axis)
+
+    // resolve series and using translations to map the series categories to the axis' category union if applicable
+    const resolved_series = build_resolved_series(structural_series, x_resolved.translations, y_resolved.translations) as unknown as Series<TooltipContent>[]
+
+    const title = normalize_title(args.title)
+
+    return {
+        series: resolved_series,
+        x: x_resolved.axis_template,
+        y: y_resolved.axis_template,
+        title: resolve_label(title.text),
+        title_size: title.size,
+        title_color: title.color,
+        margin: args.margin,
+        width: args.width,
+        height: args.height,
+        border: args.border,
+        grid: args.grid,
+        chrome_color: args.chrome_color,
+        background: args.background,
+        theme_invert: args.theme_invert,
+        zoom_pan: resolve_zoom_pan(args.zoom_pan),
+        viewport: resolve_viewport(args.viewport, x_resolved.axis_template, y_resolved.axis_template),
+        on_viewport_change: args.on_viewport_change,
+    }
+}
+
+/**
+ * Resolve the zoom/pan config into its enabled + modifier + per-axis flags. `true` and an absent arg both mean
+ * the Ctrl-gated default on both axes; an object tunes the modifier and opts axes out. `enabled` mirrors
+ * "some axis may move", so opting both out is the same as `zoom_pan: false`.
+ * @param zoom_pan - the caller's zoom_pan arg
+ * @returns the resolved config
+ */
+function resolve_zoom_pan(zoom_pan: PlotArgs['zoom_pan']): ZoomPan {
+    if (zoom_pan === undefined || zoom_pan === true) {
+        return { enabled: true, modifier: true, x: true, y: true }
+    }
+
+    if (zoom_pan === false) {
+        return { enabled: false, modifier: true, x: false, y: false }
+    }
+    const x = zoom_pan.x ?? true
+    const y = zoom_pan.y ?? true
+
+    return { enabled: x || y, modifier: zoom_pan.modifier ?? true, x, y }
+}
+
+const KEEP = 'keep' as const // this side was omitted: leave that axis wherever it is
+const UNUSABLE = 'unusable' as const // the data made this side nonsense: warned, and the request is dropped
+
+/**
+ * Resolve the window the caller wants the plot on. An absent side means that axis goes to its full extent.
+ * The window is a request, not a limit: compose clamps it to the axis's full domain, so it can't widen the
+ * zoom range, and it only lands at mount and on each `key` change, so a gesture may leave it behind.
+ * @param viewport - the caller's viewport arg
+ * @param x - the resolved x axis
+ * @param y - the resolved y axis
+ * @returns the resolved request, or undefined when the caller passed none
+ */
+function resolve_viewport(viewport: PlotArgs['viewport'], x: AxisTemplate, y: AxisTemplate): ViewportRequest | undefined {
+    if (viewport === undefined) {
+        return undefined
+    }
+    const x_window = viewport.x === undefined ? KEEP : resolve_window(viewport.x, x, 'plot: viewport.x')
+    const y_window = viewport.y === undefined ? KEEP : resolve_window(viewport.y, y, 'plot: viewport.y')
+
+    // One unusable side drops the whole request: leaving the plot where it is says "not applied", where
+    // falling back to a side's full extent would be a move the caller never asked for.
+    if (x_window === UNUSABLE || y_window === UNUSABLE) {
+        return undefined
+    }
+    const window: RequestedViewportWindow = {}
+
+    if (x_window !== KEEP) {
+        window.x = x_window
+    }
+
+    if (y_window !== KEEP) {
+        window.y = y_window
+    }
+    return { window, key: viewport.key }
+}
+
+/**
+ * Validate one axis's requested window: a [low, high] pair of finite numbers, low first, and above zero on a
+ * log axis. Shape mistakes throw, because only code can write them and they never come right on their own.
+ * Unusable *values* only warn: a window derived from live data goes bad whenever a filter empties or matches
+ * a single row, and a plot that's rendering fine shouldn't die for a request it can simply ignore.
+ * @param window - the caller's window for this axis
+ * @param axis - the resolved axis the window belongs to
+ * @param label - fully-qualified label for the error
+ * @returns the window, null when the caller asked for the full extent, or UNUSABLE when the values are
+ *          nonsense and the whole request should be dropped
+ */
+function resolve_window(window: number[] | null, axis: AxisTemplate, label: string): Domain | null | typeof UNUSABLE {
+    if (window === null) {
+        return null
+    }
+
+    if (axis.kind === 'category') {
+        throw new Error(`${label} is a categorical axis, which has no numeric window to move to; drop this side`)
+    }
+
+    if (window.length !== 2) {
+        throw new Error(`${label} must be a [low, high] pair; got ${window.length} values`)
+    }
+    const [low, high] = window
+
+    if (!Number.isFinite(low) || !Number.isFinite(high)) {
+        return unusable_window(`${label} must be finite numbers; got [${low}, ${high}]`)
+    }
+
+    if (low >= high) {
+        return unusable_window(`${label} must run low to high; got [${low}, ${high}]`)
+    }
+
+    if (axis.kind === 'log' && low <= 0) {
+        return unusable_window(`${label} must be above zero on a log axis; got [${low}, ${high}]`)
+    }
+    return [low, high]
+}
+
+/**
+ * Report a window the plot can't use and drop it. The template is memoized on the args hash, so a window
+ * that's stuck bad warns once rather than once per render.
+ * @param message - what's wrong with the window
+ * @returns UNUSABLE, the signal that the whole request should be dropped
+ */
+function unusable_window(message: string): typeof UNUSABLE {
+    console.warn(`${message} — viewport not applied`)
+    return UNUSABLE
+}
+
+/**
+ * Validate width, height, and margin.
+ * @param args - the plot args
+ * @returns the validated args
+ */
+function validate_dimensions<TooltipContent>(args: PlotArgs<TooltipContent>): PlotArgs<TooltipContent> {
+    if (args.width !== undefined) {
+        validate_positive(args.width, 'plot: width')
+    }
+
+    if (args.height !== undefined) {
+        validate_positive(args.height, 'plot: height')
+    }
+    validate_margin(args.margin)
+    return args
+}
+
+/**
+ * Validate the margin: a number applies to all four sides, an object per side. Every value must be non-negative.
+ * @param margin - the margin arg, or undefined
+ */
+function validate_margin(margin: Margin | undefined): void {
+    if (margin === undefined) {
+        return
+    }
+
+    if (typeof margin === 'number') {
+        validate_non_negative(margin, 'plot: margin')
+        return
+    }
+
+    for (const side of ['top', 'right', 'bottom', 'left'] as const) {
+        const value = margin[side]
+
+        if (value !== undefined) {
+            validate_non_negative(value, `plot: margin.${side}`)
+        }
+    }
+}
+
+/**
+ * Resolve an optional label: an explicit empty string opts out, otherwise the explicit value wins over the fallback
+ * @param explicit - caller label, if any
+ * @param fallback - derived default, used when no explicit label is given
+ * @returns the label, or undefined
+ */
+export function resolve_label(explicit: string | undefined, fallback?: string): string | undefined {
+    // explicit empty string is an intentional opt-out
+    if (explicit === '') {
+        return undefined
+    }
+    return explicit ?? fallback
+}
+
+/**
+ * Split a title arg into its parts: a bare string is just text, an object carries text plus size / color.
+ * @param title - the title arg, or undefined
+ * @returns the text, size, and color (any of which may be undefined)
+ */
+function normalize_title(title: TitleArg | undefined): { text: string | undefined; size: number | undefined; color: ThemeColor | undefined } {
+    if (title === undefined || typeof title === 'string') {
+        return { text: title, size: undefined, color: undefined }
+    }
+    return { text: title.text, size: title.size, color: title.color }
+}

--- a/plot/src/core/template/validate.ts
+++ b/plot/src/core/template/validate.ts
@@ -1,0 +1,113 @@
+/**
+ * Validate that a number is finite
+ * @param value - the number to check
+ * @param label - fully-qualified label for the error (e.g. 'plot: axis.min')
+ * @returns the validated value
+ */
+export function validate_finite(value: number, label: string): number {
+    if (!Number.isFinite(value)) {
+        throw new Error(`${label} must be a finite number; got ${value}`)
+    }
+    return value
+}
+
+/**
+ * Validate that a number is finite and non-negative
+ * @param value - the number to check
+ * @param label - fully-qualified label for the error (e.g. 'plot.rect: size')
+ * @returns the validated value
+ */
+export function validate_non_negative(value: number, label: string): number {
+    if (!Number.isFinite(value) || value < 0) {
+        throw new Error(`${label} must be a non-negative finite number; got ${value}`)
+    }
+    return value
+}
+
+/**
+ * Validate that a number is finite and positive
+ * @param value - the number to check
+ * @param label - fully-qualified label for the error (e.g. 'plot: width')
+ * @returns the validated value
+ */
+export function validate_positive(value: number, label: string): number {
+    if (!Number.isFinite(value) || value <= 0) {
+        throw new Error(`${label} must be a positive finite number; got ${value}`)
+    }
+    return value
+}
+
+/**
+ * Validate that a number is finite and within [0, 1]
+ * @param value - the number to check
+ * @param label - fully-qualified label for the error (e.g. 'plot: axis.x.padding_inner')
+ * @returns the validated value
+ */
+export function validate_unit_interval(value: number, label: string): number {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+        throw new Error(`${label} must be a number between 0 and 1; got ${value}`)
+    }
+    return value
+}
+
+/**
+ * Validate that `hoverable: false` isn't combined with a tooltip or on_select. A non-hoverable series is
+ * excluded from hover hit-testing entirely, so those callbacks could never fire — the combination is a bug.
+ * @param args - the series args, carrying hoverable / tooltip / on_select
+ * @param label - fully-qualified label for the error (e.g. 'plot.rect')
+ * @returns the validated hoverable value
+ */
+export function validate_hoverable(
+    args: { hoverable?: boolean; tooltip?: unknown; on_select?: unknown },
+    label: string,
+): boolean | undefined {
+    if (args.hoverable !== false) {
+        return args.hoverable
+    }
+    const conflicting: string[] = []
+
+    if (args.tooltip !== undefined) {
+        conflicting.push('tooltip')
+    }
+
+    if (args.on_select !== undefined) {
+        conflicting.push('on_select')
+    }
+
+    if (conflicting.length === 0) {
+        return args.hoverable
+    }
+    const fields = conflicting.join(' and ')
+    throw new Error(`${label}: hoverable is false but ${fields} is set. A non-hoverable series is excluded from hover entirely, so ${fields} would never fire. Remove hoverable: false, or drop ${fields}.`)
+}
+
+/**
+ * Validate that a hover span isn't asked for on a series excluded from hover. A non-hoverable series never
+ * reaches the hit test, so widening its hit region could do nothing.
+ * @param hover_span - the caller's hover_span_x / hover_span_y arg
+ * @param hoverable - the validated hoverable value
+ * @param field - the field being validated, for the error
+ * @param label - fully-qualified label for the error (e.g. 'plot.rect')
+ * @returns the validated hover span value
+ */
+export function validate_hover_span(hover_span: boolean, hoverable: boolean | undefined, field: string, label: string): boolean {
+    if (hover_span && hoverable === false) {
+        throw new Error(`${label}: ${field} is set but hoverable is false. A non-hoverable series is excluded from hover entirely, so ${field} has no effect. Drop one of them.`)
+    }
+    return hover_span
+}
+
+/**
+ * Apply a validator only when the value is set; an undefined value passes through unchecked.
+ * @param value - the number to validate, or undefined
+ * @param validate - the validator to run when value is set
+ * @param label - fully-qualified label for the error
+ * @returns the validated value, or undefined
+ */
+export function validate_optional(
+    value: number | undefined,
+    validate: (value: number, label: string) => number,
+    label: string,
+): number | undefined {
+    return value === undefined ? undefined : validate(value, label)
+}

--- a/plot/src/core/types.ts
+++ b/plot/src/core/types.ts
@@ -1,0 +1,503 @@
+/**
+ * Transitional core type surface. Callback types here are ordinary JavaScript functions.
+ * The production notebook API remains in ui/plotting/types.ts and continues to require
+ * engine PureFunction values for serialization and equality hashing.
+ *
+ * Tooltip content is host-supplied so this surface has no framework dependency.
+ */
+import type { ScaleBand, ScaleLinear, ScaleLogarithmic, ScaleTime } from "d3-scale"
+
+export type Domain = [number, number]
+export type Viewport = { x: Domain | null; y: Domain | null }
+
+// margin is the space between the plot area and the canvas edge, per side. Chrome (tick
+// labels, axis names, title) paints inside this band. A number applies to all four sides.
+export type SideMargins = {
+    top?: number
+    right?: number
+    bottom?: number
+    left?: number
+}
+
+export type Margin = number | SideMargins
+
+type SeriesTypes = 'scatter' | 'rect' | 'bar' | 'line' | 'rule' | 'area' | 'custom'
+
+type BaseSeries<TooltipContent = unknown> = {
+    kind: SeriesTypes
+    x: Float64Array
+    y: Float64Array
+    color?: ThemeColor
+    colors?: (ThemeColor | null)[]
+    tooltip?: TooltipArg<any, TooltipContent>
+    on_select?: SelectFn<any>
+    hoverable?: boolean
+    highlight?: boolean
+    rows?: Record<string, unknown>[]
+    labels?: string[]
+    x_axis_kind?: AxisKind
+    y_axis_kind?: AxisKind
+    x_categories?: string[]
+    y_categories?: string[]
+    x_field?: string
+    y_field?: string
+}
+
+export type Stroke = { color: ThemeColor; width?: number }
+
+export type ScatterSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'scatter'
+    size?: number
+    sizes?: (number | null)[]
+    mark?: MarkShape
+    stroke?: Stroke
+}
+
+export type RectSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'rect'
+    span?: 'x' | 'y'
+    x2?: Float64Array
+    y2?: Float64Array
+    size?: { width?: number; height?: number }
+    band_align?: RectAlign
+    hover_span_x?: boolean
+    hover_span_y?: boolean
+    offset?: { x?: number; y?: number }
+    inset?: number
+    min_size?: number
+    stroke?: Stroke
+}
+
+export type BarSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'bar'
+    border_radius?: number
+    inset?: number
+    min_size?: number
+    hover_span_x?: boolean
+    hover_span_y?: boolean
+    stack_base?: Float64Array
+    is_tip?: Uint8Array
+}
+
+// where each bar (segment) starts and ends on the value axis, in pixels
+export type BarPixelSpan = { baseline: Float64Array; tip: Float64Array }
+
+export type LineSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'line'
+    width?: number
+    dash?: number[]
+    mark?: MarkShape
+    mark_size?: number
+    stroke?: Stroke
+}
+
+export type RuleSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'rule'
+    side: 'x' | 'y'
+    width?: number
+    dash?: number[]
+}
+
+export type AreaSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'area'
+    x2?: Float64Array
+    y2?: Float64Array
+    bound_pinned?: boolean
+    dash?: number[]
+    stroke?: Stroke
+}
+
+export type AreaPixelRuns = {
+    along: Float64Array
+    edge: Float64Array
+    base: Float64Array
+    row: Int32Array
+    run_starts: Int32Array
+}
+
+export type CustomSeries<TooltipContent = unknown> = BaseSeries<TooltipContent> & {
+    kind: 'custom'
+    renderer: CustomRendererFn<TooltipContent>
+    hit_test?: CustomHitTestFn<TooltipContent>
+    axis_range?: { x?: Domain; y?: Domain }
+}
+
+export type Series<TooltipContent = unknown> =
+    | ScatterSeries<TooltipContent>
+    | RectSeries<TooltipContent>
+    | BarSeries<TooltipContent>
+    | LineSeries<TooltipContent>
+    | RuleSeries<TooltipContent>
+    | AreaSeries<TooltipContent>
+    | CustomSeries<TooltipContent>
+
+// color fields after compose resolves each ThemeColor to a concrete string for the current theme
+type ResolvedColorFields = {
+    color?: string
+    colors?: (string | null)[]
+    stroke?: { color: string; width?: number }
+}
+
+// T, but with R's keys overridden
+type ReplaceKeys<T, R> = Omit<T, keyof R> & R
+
+// each series with its color fields resolved to plain strings — compose's output, what the paints read
+export type ComposedScatter<TooltipContent = unknown> = ReplaceKeys<ScatterSeries<TooltipContent>, ResolvedColorFields>
+export type ComposedRect<TooltipContent = unknown> = ReplaceKeys<RectSeries<TooltipContent>, ResolvedColorFields>
+export type ComposedBar<TooltipContent = unknown> = ReplaceKeys<BarSeries<TooltipContent>, ResolvedColorFields & { value_span?: BarPixelSpan }>
+export type ComposedLine<TooltipContent = unknown> = ReplaceKeys<LineSeries<TooltipContent>, ResolvedColorFields>
+export type ComposedRule<TooltipContent = unknown> = ReplaceKeys<RuleSeries<TooltipContent>, ResolvedColorFields>
+export type ComposedArea<TooltipContent = unknown> = ReplaceKeys<AreaSeries<TooltipContent>, ResolvedColorFields & { pixel_runs?: AreaPixelRuns }>
+export type ComposedCustom<TooltipContent = unknown> = ReplaceKeys<CustomSeries<TooltipContent>, ResolvedColorFields>
+export type ComposedSeries<TooltipContent = unknown> =
+    | ComposedScatter<TooltipContent>
+    | ComposedRect<TooltipContent>
+    | ComposedBar<TooltipContent>
+    | ComposedLine<TooltipContent>
+    | ComposedRule<TooltipContent>
+    | ComposedArea<TooltipContent>
+    | ComposedCustom<TooltipContent>
+
+export type AxisKind = 'numeric' | 'categorical'
+
+export type ColorPair = { light: string; dark: string }
+export type ThemeColor = string | ColorPair
+
+export type LabelPosition = 'center' | 'top' | 'bottom' | 'left' | 'right'
+export type TickFormat = (value: number | string, index: number) => string
+
+export type LabelArg = string | {
+    text: string
+    size?: number
+    color?: ThemeColor
+    position?: LabelPosition
+}
+
+export type TickLabelArg = {
+    format?: TickFormat
+    size?: number
+    color?: ThemeColor
+}
+
+export type AxisArgs = {
+    scale?: AxisScale
+    label?: LabelArg
+    min?: number
+    max?: number
+    categories?: string[]
+    padding?: number
+    padding_top?: number
+    padding_bottom?: number
+    padding_left?: number
+    padding_right?: number
+    grid_align?: 'center' | 'edge'
+    line?: boolean
+    hidden?: boolean
+    tick_label?: TickLabelArg
+    tick_mark?: boolean
+}
+
+export type Axis = {
+    scale?: AxisScale
+    label?: string
+    label_size?: number
+    label_color?: ThemeColor
+    label_position?: LabelPosition
+    min?: number
+    max?: number
+    categories?: string[]
+    padding?: number
+    padding_top?: number
+    padding_bottom?: number
+    padding_left?: number
+    padding_right?: number
+    grid_align?: 'center' | 'edge'
+    line?: boolean
+    hidden?: boolean
+    tick_label_format?: TickFormat
+    tick_label_size?: number
+    tick_label_color?: ThemeColor
+    tick_mark?: boolean
+}
+
+export type AxisTemplateKind = 'linear' | 'log' | 'category' | 'time'
+
+type BaseAxisTemplate = {
+    kind: AxisTemplateKind
+    rendered: boolean
+    axis?: Axis
+}
+
+// linear / log / time: a numeric domain with per-end nicing and pixel padding
+type ContinuousAxisTemplate = BaseAxisTemplate & {
+    domain: Domain
+    nice_min: boolean
+    nice_max: boolean
+    padding_min: number
+    padding_max: number
+}
+
+export type LinearAxisTemplate = ContinuousAxisTemplate & {
+    kind: 'linear'
+}
+
+export type LogarithmicAxisTemplate = ContinuousAxisTemplate & {
+    kind: 'log'
+}
+
+export type TimeAxisTemplate = ContinuousAxisTemplate & {
+    kind: 'time'
+    utc: boolean
+}
+
+export type CategoryAxisTemplate = BaseAxisTemplate & {
+    kind: 'category'
+    categories: string[]
+    padding_min: number
+    padding_max: number
+}
+
+export type AxisTemplate = LinearAxisTemplate | LogarithmicAxisTemplate | CategoryAxisTemplate | TimeAxisTemplate
+
+export type GridSpec = boolean | { x?: boolean; y?: boolean }
+export type ZoomPanArg = boolean | { modifier?: boolean; x?: boolean; y?: boolean }
+
+export type ZoomPan = { enabled: boolean; modifier: boolean; x: boolean; y: boolean }
+
+export type RequestedViewportWindow = { x?: Domain | null; y?: Domain | null }
+
+export type ViewportRequest = { window: RequestedViewportWindow; key: string | number | undefined }
+
+export type PlotTemplate<TooltipContent = unknown> = {
+    series: Series<TooltipContent>[]
+    x: AxisTemplate
+    y: AxisTemplate
+    title?: string
+    title_size?: number
+    title_color?: ThemeColor
+    margin?: Margin
+    width?: number
+    height?: number
+    border?: boolean
+    grid?: GridSpec
+    chrome_color?: ThemeColor
+    background?: boolean | ThemeColor
+    theme_invert?: boolean
+    zoom_pan: ZoomPan
+    viewport?: ViewportRequest
+    on_viewport_change?: ViewportChangeFn
+}
+
+// args to plot(): the series plus optional axis / size / style. new_plot_template resolves it into a PlotTemplate.
+export type PlotArgs<TooltipContent = unknown> = {
+    series: Series<TooltipContent>[]
+    axis?: { x?: AxisArgs; y?: AxisArgs }
+    title?: TitleArg
+    width?: number
+    height?: number
+    margin?: Margin
+    border?: boolean
+    grid?: GridSpec
+    chrome_color?: ThemeColor
+    background?: boolean | ThemeColor
+    theme_invert?: boolean
+    zoom_pan?: ZoomPanArg
+    viewport?: { x?: number[] | null; y?: number[] | null; key?: string | number }
+    on_viewport_change?: ViewportChangeFn
+}
+
+// canvas dimensions and resolved per-side margins. Produced by core/compose/layout.ts at compose time.
+export type Layout = {
+    width: number
+    height: number
+    margin_top: number
+    margin_right: number
+    margin_bottom: number
+    margin_left: number
+}
+
+export type ComposedPlot<TooltipContent = unknown> = {
+    layout: Layout
+    inner: Rect
+    x_scale: Scale
+    y_scale: Scale
+    // full (unzoomed) continuous domain per axis, for zoom/pan reset & clamping; null on a categorical axis
+    x_full_domain: Domain | null
+    y_full_domain: Domain | null
+    x_axis?: Axis
+    y_axis?: Axis
+    x_categories?: string[]
+    y_categories?: string[]
+    title?: string
+    title_size?: number
+    title_color?: ThemeColor
+    series: ComposedSeries<TooltipContent>[]
+    border?: boolean
+    grid?: GridSpec
+    background?: string | false
+    chrome_theme: ColorTheme
+    chrome_color?: string // resolved stroke color for border / grid / axis lines / tick marks
+}
+
+export type Scale = ScaleLinear<number, number> | ScaleLogarithmic<number, number> | ScaleBand<number> | ScaleTime<number, number>
+export type NumericalScale = ScaleLinear<number, number> | ScaleLogarithmic<number, number>
+export type ContinuousScale = ScaleLinear<number, number> | ScaleLogarithmic<number, number> | ScaleTime<number, number>
+export type BandScale = ScaleBand<number>
+
+// same paint code runs on main-thread 2D and Worker-thread OffscreenCanvas contexts
+export type CanvasContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+
+// pixel rect for the inner plot area and clip rects
+export type Rect = {
+    left: number
+    right: number
+    top: number
+    bottom: number
+}
+
+export type PixelRect = {
+    left: number
+    top: number
+    width: number
+    height: number
+}
+
+// the render environment a series paints into: canvas, inner rect, both scales, the resolved fallback color, and each band axis' category labels
+export type RenderContext = {
+    ctx: CanvasContext
+    inner: Rect
+    x_scale: Scale
+    y_scale: Scale
+    color: string
+    x_categories?: string[]
+    y_categories?: string[]
+}
+
+export type CustomRenderContext = RenderContext & {
+    resolve_x: PixelResolver
+    resolve_y: PixelResolver
+    color_at: ColorResolver
+}
+
+export type CustomRendererFn<TooltipContent = unknown> = (series: ComposedCustom<TooltipContent>, render_props: CustomRenderContext) => void
+
+export type HitContext = {
+    cursor: { x: number; y: number }
+    inner: Rect
+    x_scale: Scale
+    y_scale: Scale
+    resolve_x: PixelResolver
+    resolve_y: PixelResolver
+}
+
+export type PixelResolver = (i: number) => number | undefined
+
+export type ColorResolver = (i: number) => string
+
+export type CustomHitTestFn<TooltipContent = unknown> = (series: ComposedCustom<TooltipContent>, hit: HitContext) => number | null
+
+export type HighlightSpec =
+    | { shape: 'mark'; mark: MarkShape; cx: number; cy: number; r: number; color: string }
+    | { shape: 'rect'; x: number; y: number; width: number; height: number; color: string; border_radius?: string }
+
+// per-side domain padding mode, set by series padding_mode hooks and consumed by core/template/domain.ts:
+//   default         5% symmetric additive pad so .nice() has room to round
+//   anchor_zero     bar height on a declared axis, includes zero on the data side
+//   spark_symmetric bar height on an undeclared axis, includes zero on both sides
+//   log             pass through [min, max], scaleLog().nice() rounds to powers of 10
+export type SideMode = 'default' | 'anchor_zero' | 'spark_symmetric' | 'log'
+
+
+// resolved scale kind for an axis after inference. 'time' is local, 'utc' is UTC; both render via the continuous path.
+export type AxisScale = 'linear' | 'log' | 'category' | 'time' | 'utc'
+
+// one side's resolved axis facts, built per side (x and y) by validate_and_build_axis_context: kind,
+// whether it paints, the derived label, the resolved scale, and the domain padding mode. Also the
+// contract the series-kind hooks read (validate_axes / padding_mode receive both sides).
+export type AxisContext = {
+    is_category: boolean
+    rendered: boolean
+    field_label?: string
+    scale: AxisScale
+    padding_mode: SideMode
+    args: Axis
+}
+
+export interface SeriesType<TooltipContent = unknown, S extends Series<TooltipContent> = Series<TooltipContent>> {
+    kind: S['kind']
+    // build the series from validated user args (runs at user-call time)
+    factory(args: any): S
+    // draw the series to the canvas (runs at render time).
+    // series is the composed (string-color) form for this kind; the concrete paint narrows it
+    paint(series: ComposedSeries<TooltipContent>, render: RenderContext): void
+    // the point index under the cursor, or null. Each kind defines its own hit region
+    // inner is the plot area the paint draws into, for kinds whose geometry spans it (rect's `span`)
+    tooltip_hit_test(series: ComposedSeries<TooltipContent>, cursor: { x: number; y: number }, x_scale: Scale, y_scale: Scale, inner: Rect): number | null
+    // optional: hover-select halo geometry for a point. Consumed by the DOM overlay, not the canvas.
+    highlight_spec?(series: ComposedSeries<TooltipContent>, point_index: number, x_scale: Scale, y_scale: Scale, inner: Rect): HighlightSpec | HighlightSpec[] | null
+    // optional: precompute pixel geometry that depends on the scales, once per compose, for the paint /
+    // hit-test / highlight to share rather than each deriving it (bar places its stacked segments here)
+    compose_layout?(series: ComposedSeries<TooltipContent>, x_scale: Scale, y_scale: Scale): ComposedSeries<TooltipContent>
+    // optional: throw if this kind's axis requirements aren't met (e.g. bar needs one band axis)
+    validate_axes?(x: AxisContext, y: AxisContext, series: S, index: number): void
+    // optional: override the default domain padding for this kind (e.g. bar anchors at zero)
+    padding_mode?(x: AxisContext, y: AxisContext): { x?: SideMode, y?: SideMode }
+    // the [min, max] this series spans per axis, for domain computation. Most series use xy_extent (scan
+    // x / y); rect widens x by x2. compute_domains merges these and pads, knowing nothing series-specific.
+    domain_extent(series: S): { x: [number, number]; y: [number, number] }
+}
+
+// the browser color scheme a plot resolves theme colors against (resolved UI-side at compose time)
+export type ColorTheme = 'light' | 'dark'
+
+export type ColorArg = ThemeColor | ((row: Record<string, unknown>, index: number) => ThemeColor)
+export type TitleArg = string | { text: string; size?: number; color?: ThemeColor }
+
+export type StrokeArg = ThemeColor | Stroke
+
+// defaults to circle
+export type MarkShape = 'circle' | 'square' | 'diamond' | 'triangle'
+
+export type RectAlign = 'center' | 'start' | 'end'
+
+export type FieldArg = string | ((row: Record<string, unknown>, index: number) => number | string)
+
+// the resolved x / y values, plus the original data row, under the cursor, handed to a caller's tooltip
+// callback. `label` names the hovered mark when its series has per-mark names — a stacked bar's segment field
+export type PointData = {
+    x: number | string
+    y: number | string
+    row?: Record<string, unknown>
+    label?: string
+}
+
+export type TooltipData<Row = Record<string, unknown>> = Omit<PointData, 'row'> & { row: Row }
+
+export type TooltipFn<Row = Record<string, unknown>, TooltipContent = unknown> = (data: TooltipData<Row>) => TooltipContent
+
+// per-series tooltip: `true` for the default axis-value body, or a callback for a custom one. Default is no tooltip
+export type TooltipArg<Row = Record<string, unknown>, TooltipContent = unknown> = true | TooltipFn<Row, TooltipContent>
+
+export type SelectFn<Row = Record<string, unknown>> = (data: TooltipData<Row>) => unknown
+
+export type AxisViewport = { window: number[]; full: number[] }
+
+export type ViewportChange = {
+    x: AxisViewport | null
+    y: AxisViewport | null
+}
+
+export type ViewportChangeFn = (change: ViewportChange) => void
+
+export type RowTypedArgs<SchemaArgs extends object, RowT extends object, TooltipContent = unknown> = Omit<SchemaArgs, 'data' | 'tooltip' | 'on_select'> & {
+    data: RowT[]
+    tooltip?: TooltipArg<RowT, TooltipContent>
+    on_select?: SelectFn<RowT>
+}
+
+/** The same as RowTypedArgs, for a kind whose `data` is optional (plot.rule) */
+export type OptionalRowTypedArgs<SchemaArgs extends object, RowT extends object, TooltipContent = unknown> = Omit<SchemaArgs, 'data' | 'tooltip' | 'on_select'> & {
+    data?: RowT[]
+    tooltip?: TooltipArg<RowT | undefined, TooltipContent>
+    on_select?: SelectFn<RowT | undefined>
+}

--- a/plot/src/entries/anta.ts
+++ b/plot/src/entries/anta.ts
@@ -1,0 +1,1 @@
+export { create_anta_host, type AntaHost, type AntaHostAdapter } from '../integrations/anta_host'

--- a/plot/src/entries/auto.ts
+++ b/plot/src/entries/auto.ts
@@ -1,0 +1,2 @@
+import '../browser/plot.css'
+export { plotElementReady } from '../browser/auto'

--- a/plot/src/entries/browser.ts
+++ b/plot/src/entries/browser.ts
@@ -1,0 +1,2 @@
+import '../browser/plot.css'
+export * from '../browser/index'

--- a/plot/src/entries/host.ts
+++ b/plot/src/entries/host.ts
@@ -1,0 +1,8 @@
+export { resolve_canvas_size, type Dimensions } from '../core/compose/layout'
+export { prepare_canvas_context } from '../core/render/canvas'
+export { clear_highlights, update_highlight_canvas } from '../core/render/highlight'
+export { plot_color_filter, plot_wrapper_size } from '../core/presentation/plot'
+export { reset_zoom_presentation } from '../core/presentation/reset_zoom'
+export {
+    render_tooltip_body, TOOLTIP_DIVIDER_STYLE, TOOLTIP_OPTIONS, tooltip_wrapper_style,
+} from '../core/presentation/tooltip'

--- a/plot/src/entries/index.ts
+++ b/plot/src/entries/index.ts
@@ -1,0 +1,30 @@
+export { new_scatter as scatter, type ScatterArgs } from '../core/series/scatter/factory'
+export { new_bar as bar, type BarArgs } from '../core/series/bar/factory'
+export { new_rect as rect, type RectArgs } from '../core/series/rect/factory'
+export { new_line as line, type LineArgs } from '../core/series/line/factory'
+export { new_rule as rule, type RuleArgs } from '../core/series/rule/factory'
+export { new_area as area, type AreaArgs } from '../core/series/area/factory'
+export { new_custom as custom, type CustomArgs } from '../core/series/custom/factory'
+export { PlotController, type PlotEnvironment, type PlotDrawHost, type PlotLifecycleError } from '../core/controller'
+export { PlotInteractionController, type PanInput, type PanUpdate } from '../core/interaction_controller'
+export type { NearestPoint } from '../core/interactions/hit'
+export type { ResolvedTooltip } from '../core/interactions/tooltip'
+export type {
+    Domain, Viewport, SideMargins, Margin, Stroke,
+    ScatterSeries, RectSeries, BarSeries, BarPixelSpan, LineSeries,
+    RuleSeries, AreaSeries, AreaPixelRuns, CustomSeries, Series,
+    ComposedScatter, ComposedRect, ComposedBar, ComposedLine, ComposedRule,
+    ComposedArea, ComposedCustom, ComposedSeries, AxisKind, ColorPair,
+    ThemeColor, LabelPosition, TickFormat, LabelArg, TickLabelArg,
+    AxisArgs, Axis, AxisTemplateKind, LinearAxisTemplate, LogarithmicAxisTemplate,
+    TimeAxisTemplate, CategoryAxisTemplate, AxisTemplate, GridSpec, ZoomPanArg,
+    ZoomPan, RequestedViewportWindow, ViewportRequest, PlotTemplate, PlotArgs,
+    Layout, ComposedPlot, Scale, NumericalScale, ContinuousScale,
+    BandScale, CanvasContext, Rect, PixelRect, RenderContext,
+    CustomRenderContext, CustomRendererFn, HitContext, PixelResolver, ColorResolver,
+    CustomHitTestFn, HighlightSpec, SideMode, AxisScale, AxisContext,
+    ColorTheme, ColorArg, TitleArg, StrokeArg, MarkShape,
+    RectAlign, FieldArg, PointData, TooltipData, TooltipFn,
+    TooltipArg, SelectFn, AxisViewport, ViewportChange, ViewportChangeFn,
+    RowTypedArgs, OptionalRowTypedArgs,
+} from '../core/types'

--- a/plot/src/integrations/anta_gestures.ts
+++ b/plot/src/integrations/anta_gestures.ts
@@ -1,0 +1,40 @@
+// Shared Anta event translation for both worker and browser hosts; no runtime Anta or DOM dependency.
+import type { PanInput } from "../core/interaction_controller"
+import type { WheelClaim } from "../core/interactions/zoom_pan"
+import type { CaptureInputDirections, CapturePointerInput, CaptureWheelInput } from "@antadesign/anta"
+
+/** Convert Capture's drag coordinates to the shared controller input. */
+export function capture_pointer_input(detail: CapturePointerInput): PanInput {
+    const pointer = detail.phase === 'start' ? detail.start.pointerEvent : detail.pointerEvent
+    return {
+        phase: detail.phase,
+        pointer: pointer === null ? null : { x: pointer.clientX, y: pointer.clientY },
+    }
+}
+
+export type PlotWheelInput = {
+    offsetX: number
+    offsetY: number
+    deltaY: number
+    ctrlKey: boolean
+}
+
+/** Keep Capture enabled at bounds so its settled-pointer state survives direction changes. */
+export function capture_wheel_directions(claim: WheelClaim): CaptureInputDirections {
+    return {
+        up: claim === 'up' || claim === 'both',
+        down: claim === 'down' || claim === 'both',
+        left: false,
+        right: false,
+    }
+}
+
+/** Native target offsets may refer to tooltip children; Capture's local coordinates refer to the overlay. */
+export function capture_wheel_input(detail: CaptureWheelInput): PlotWheelInput {
+    return {
+        offsetX: detail.localX,
+        offsetY: detail.localY,
+        deltaY: detail.wheelEvent.deltaY,
+        ctrlKey: detail.wheelEvent.ctrlKey,
+    }
+}

--- a/plot/src/integrations/anta_host.ts
+++ b/plot/src/integrations/anta_host.ts
@@ -1,0 +1,165 @@
+import throttle from 'lodash/throttle'
+import type {
+    BoxContextChange, BoxMeasurementChange, CapturePointerInput, CaptureProps, CaptureWheelInput,
+} from '@antadesign/anta'
+import type { PlotController } from '../core/controller'
+import type { Dimensions } from '../core/compose/layout'
+import type { ColorTheme, ComposedPlot, Viewport, ViewportChange } from '../core/types'
+import type { NearestPoint } from '../core/interactions/hit'
+import { create_interaction_coordinator } from '../core/interactions/coordinator'
+import { compatible_viewport } from '../core/interactions/viewport'
+import { UPDATE_INTERVAL_MS } from '../core/interactions/viewport_schedule'
+import { resolve_capture_configuration, zoom_pan_enabled } from '../core/interactions/zoom_pan'
+import { capture_pointer_input, capture_wheel_directions, capture_wheel_input } from './anta_gestures'
+
+export type AntaHost<T> = {
+    controller: PlotController<T>
+    on_measure(dimensions: Dimensions): void
+    on_context(theme: ColorTheme, device_pixel_ratio: number): void
+    on_viewport(viewport: Viewport): void
+    on_viewport_report(change: ViewportChange): void
+    on_hover(points: NearestPoint[]): void
+    on_pointer_change(): void
+}
+
+type MouseHandler = (event: MouseEvent) => void
+type PointerHandler = (event: CustomEvent<CapturePointerInput>) => void
+type WheelHandler = (event: CustomEvent<CaptureWheelInput>) => void
+
+type HostCaptureProps = Pick<CaptureProps,
+    'wheelCapture' | 'wheelActivation' | 'wheelModifier' | 'wheelSettle' | 'pointerCapture'
+> & {
+    onMouseMove: MouseHandler
+    onMouseLeave(): void
+    onClick: MouseHandler
+    ondblclick(): void
+    onWheelInput: WheelHandler
+    onPointerInput: PointerHandler
+}
+
+/** Host-facing handlers omit internal timer controls; disconnect owns cancellation. */
+export type AntaHostAdapter<T> = {
+    on_measure_change(event: CustomEvent<BoxMeasurementChange>): void
+    on_context_change(event: CustomEvent<BoxContextChange>): void
+    on_pointer_input: PointerHandler
+    on_wheel_input: WheelHandler
+    on_mouse_move: MouseHandler
+    on_mouse_leave(): void
+    on_click: MouseHandler
+    on_double_click(): void
+    reset(): void
+    viewport_for_render(snapshot: Viewport): Viewport
+    reconcile_viewport(snapshot: Viewport): Viewport
+    capture_props(plot: ComposedPlot<T> | null, viewport: Viewport): HostCaptureProps
+    cursor_style(): string | undefined
+    disconnect(): void
+}
+
+/** Accept Anta events directly, retaining the worker host's measurement and interaction cadence. */
+export function create_anta_host<T>(host: AntaHost<T>): AntaHostAdapter<T> {
+    const controller = host.controller
+    const interactions = controller.interactions
+    let measured: Dimensions | null = null
+    const sync_hover = () => host.on_hover(interactions.hovered)
+    const coordinator = create_interaction_coordinator({
+        controller: () => controller,
+        commit_mode: 'throttled',
+        resolve_hover: (event: MouseEvent) => event,
+        on_viewport_commit: host.on_viewport,
+        on_viewport_report: host.on_viewport_report,
+        on_hover_update: changed => {
+            if (changed) {
+                sync_hover()
+                host.on_pointer_change()
+            }
+        },
+        on_hover_clear: sync_hover,
+        on_pointer_change: host.on_pointer_change,
+    })
+
+    // Keep the previous height during transient zero-height measurements and publish only changed sizes.
+    const on_measure_change = throttle((event: CustomEvent<BoxMeasurementChange>) => {
+        const current = event.detail.current
+        const height = current.height > 0 ? current.height : (measured?.height ?? current.height)
+        if (measured?.width === current.width && measured.height === height) {
+            return
+        }
+        measured = { width: current.width, height }
+        host.on_measure(measured)
+    }, UPDATE_INTERVAL_MS, { leading: false, trailing: true })
+
+    const on_pointer_input = (event: CustomEvent<CapturePointerInput>): void => {
+        coordinator.handle_pan(capture_pointer_input(event.detail))
+    }
+    const on_wheel_input = (event: CustomEvent<CaptureWheelInput>): void => {
+        coordinator.handle_wheel(capture_wheel_input(event.detail))
+    }
+
+    return {
+        on_measure_change,
+        on_context_change(event: CustomEvent<BoxContextChange>): void {
+            const { mode, devicePixelRatio } = event.detail.current
+            host.on_context(mode, devicePixelRatio)
+        },
+        on_pointer_input,
+        on_wheel_input,
+        on_mouse_move: coordinator.move,
+        on_mouse_leave: coordinator.leave,
+        on_click: coordinator.handle_click,
+        on_double_click: coordinator.handle_double_click,
+        reset: coordinator.reset,
+        viewport_for_render(snapshot: Viewport): Viewport {
+            return compatible_viewport(snapshot, controller.template)
+        },
+        reconcile_viewport(snapshot: Viewport): Viewport {
+            if (!controller.has_current_composition) {
+                return snapshot
+            }
+            return coordinator.reconcile_rendered_viewport(
+                snapshot, controller.template, controller.template.viewport,
+            )
+        },
+        capture_props(plot: ComposedPlot<T> | null, viewport: Viewport) {
+            const zoom_pan = controller.template.zoom_pan
+            const capture = resolve_capture_configuration(
+                zoom_pan_enabled(controller.template), zoom_pan.modifier,
+                interactions.wheel_claim(plot, viewport, zoom_pan),
+            )
+            const settings = {
+                wheelCapture: capture.wheel_capture === null ? false : capture_wheel_directions(capture.wheel_capture),
+                wheelActivation: capture.wheel_activation,
+                wheelModifier: capture.wheel_modifier,
+                wheelSettle: {
+                    delay: capture.wheel_delay,
+                    tolerance: capture.wheel_tolerance,
+                    resetOnMove: capture.wheel_reset_on_move,
+                },
+                pointerCapture: capture.pointer_capture === null ? false : {
+                    pointerTypes: [capture.pointer_capture],
+                    buttons: capture.pointer_buttons,
+                    threshold: capture.pointer_threshold,
+                    modifier: capture.pointer_modifier,
+                },
+            } satisfies CaptureProps
+            return {
+                ...settings,
+                onMouseMove: coordinator.move,
+                onMouseLeave: coordinator.leave,
+                onClick: coordinator.handle_click,
+                ondblclick: coordinator.handle_double_click,
+                onWheelInput: on_wheel_input,
+                onPointerInput: on_pointer_input,
+            }
+        },
+        cursor_style(): string | undefined {
+            return interactions.cursor_style({
+                ...controller.template.zoom_pan,
+                enabled: zoom_pan_enabled(controller.template),
+            })
+        },
+        disconnect(): void {
+            on_measure_change.cancel()
+            coordinator.disconnect()
+        },
+    }
+}

--- a/plot/tsconfig.build.json
+++ b/plot/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": [],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "rootDir": "src",
+    "outDir": "dist/types"
+  },
+  "include": [
+    "src/entries/*.ts"
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,6 +34,43 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  plot:
+    dependencies:
+      '@antadesign/anta':
+        specifier: workspace:*
+        version: link:..
+      '@types/d3-scale':
+        specifier: 4.0.3
+        version: 4.0.3
+      chroma-js:
+        specifier: 2.4.2
+        version: 2.4.2
+      d3-scale:
+        specifier: 3.2.3
+        version: 3.2.3
+      lodash:
+        specifier: 4.18.1
+        version: 4.18.1
+      react:
+        specifier: ^18.0.0 || ^19.0.0
+        version: 19.2.8
+    devDependencies:
+      '@types/chroma-js':
+        specifier: 2.1.4
+        version: 2.1.4
+      '@types/lodash':
+        specifier: 4.17.25
+        version: 4.17.25
+      '@types/react':
+        specifier: ^19.0.0
+        version: 19.2.18
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   site:
     dependencies:
       '@antadesign/anta':
@@ -1458,8 +1495,17 @@ packages:
   '@speed-highlight/core@1.2.24':
     resolution: {integrity: sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==}
 
+  '@types/chroma-js@2.1.4':
+    resolution: {integrity: sha512-l9hWzP7cp7yleJUI7P2acmpllTJNYf5uU6wh50JzSIZt3fFHe+w2FM6w9oZGBTYzjjm2qHdnQvI+fF/JF/E5jQ==}
+
   '@types/chroma-js@3.1.2':
     resolution: {integrity: sha512-YBTQqArPN8A0niHXCwrO1z5x++a+6l0mLBykncUpr23oIPW7L4h39s6gokdK/bDrPmSh8+TjMmrhBPnyiaWPmQ==}
+
+  '@types/d3-scale@4.0.3':
+    resolution: {integrity: sha512-PATBiMCpvHJSMtZAMEhc2WyL+hnzarKzI6wAHYjhsonjWJYGq5BXTzQjv4l8m2jO183/4wZ90rKvSeT7o72xNQ==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1478,6 +1524,9 @@ packages:
 
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/lodash@4.17.25':
+    resolution: {integrity: sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==}
 
   '@types/mark.js@8.11.12':
     resolution: {integrity: sha512-244ZnaIBpz4c6xutliAnYVZp6xJlmC569jZqnR3ElO1Y01ooYASSVQEqpd2x0A2UfrgVMs5V9/9tUAdZaDMytQ==}
@@ -1687,6 +1736,9 @@ packages:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
 
+  chroma-js@2.4.2:
+    resolution: {integrity: sha512-U9eDw6+wt7V8z5NncY2jJfZa+hUH8XEj8FQHgFJTrUFnJfXYf4Ml4adI2vXZOjqRDpFWtYVWypDfZwnJ+HIR4A==}
+
   chroma-js@3.2.0:
     resolution: {integrity: sha512-os/OippSlX1RlWWr+QDPcGUZs0uoqr32urfxESG9U93lhUfbnlyckte84Q8P1UQY/qth983AS1JONKmLS4T0nw==}
 
@@ -1788,6 +1840,27 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-color@2.0.0:
+    resolution: {integrity: sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==}
+
+  d3-format@2.0.0:
+    resolution: {integrity: sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==}
+
+  d3-interpolate@2.0.1:
+    resolution: {integrity: sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==}
+
+  d3-scale@3.2.3:
+    resolution: {integrity: sha512-8E37oWEmEzj57bHcnjPVOBS3n4jqakOeuv1EDdQSiSrYnMCBdMd3nc4HtKk7uia8DUHcY/CGuJ42xxgtEYrX0g==}
+
+  d3-time-format@3.0.0:
+    resolution: {integrity: sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==}
+
+  d3-time@2.1.1:
+    resolution: {integrity: sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -2188,6 +2261,9 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
@@ -2311,6 +2387,9 @@ packages:
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -4617,7 +4696,15 @@ snapshots:
 
   '@speed-highlight/core@1.2.24': {}
 
+  '@types/chroma-js@2.1.4': {}
+
   '@types/chroma-js@3.1.2': {}
+
+  '@types/d3-scale@4.0.3':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-time@3.0.4': {}
 
   '@types/debug@4.1.13':
     dependencies:
@@ -4636,6 +4723,8 @@ snapshots:
   '@types/jquery@4.0.1': {}
 
   '@types/katex@0.16.8': {}
+
+  '@types/lodash@4.17.25': {}
 
   '@types/mark.js@8.11.12':
     dependencies:
@@ -4924,6 +5013,8 @@ snapshots:
     dependencies:
       readdirp: 5.0.0
 
+  chroma-js@2.4.2: {}
+
   chroma-js@3.2.0: {}
 
   ci-info@4.4.0: {}
@@ -5002,6 +5093,34 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-color@2.0.0: {}
+
+  d3-format@2.0.0: {}
+
+  d3-interpolate@2.0.1:
+    dependencies:
+      d3-color: 2.0.0
+
+  d3-scale@3.2.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-format: 2.0.0
+      d3-interpolate: 2.0.1
+      d3-time: 2.1.1
+      d3-time-format: 3.0.0
+
+  d3-time-format@3.0.0:
+    dependencies:
+      d3-time: 2.1.1
+
+  d3-time@2.1.1:
+    dependencies:
+      d3-array: 2.12.1
 
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
@@ -5596,6 +5715,8 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  internmap@1.0.1: {}
+
   iron-webcrypto@1.2.1: {}
 
   is-alphabetical@2.0.1: {}
@@ -5682,6 +5803,8 @@ snapshots:
       uc.micro: 2.1.0
 
   lodash.truncate@4.4.2: {}
+
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "stickers"
+  - "plot"
   - "site"
 
 onlyBuiltDependencies:

--- a/scripts/dev-watch.mjs
+++ b/scripts/dev-watch.mjs
@@ -11,6 +11,7 @@ const pnpm = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 const workspaceTasks = [
   ['run', 'build:dev'],
   ['--filter', '@antadesign/stickers', 'run', 'build:dev'],
+  ['--filter', '@antadesign/plot', 'run', 'build:dev'],
   ['--filter', 'anta-site', 'run', 'docs'],
 ]
 
@@ -71,7 +72,7 @@ function schedule(kind) {
   }, 150)
 }
 
-for (const path of ['src', 'stickers/src']) {
+for (const path of ['src', 'stickers/src', 'plot/src']) {
   watch(path, { recursive: true }, () => schedule('workspace'))
 }
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,9 +2,10 @@
 
 Published as `@antadesign/anta` on npm. Portable UI component library. Works in React apps out of the box, in Preact via compat aliasing (`react` → `preact/compat`), and in custom runtimes via `configure()`.
 
-This repo is a pnpm workspace with **two publishable packages** plus the docs site:
+This repo is a pnpm workspace with **three publishable packages** plus the docs site:
 - `@antadesign/anta` — this package, at the repo root (`src/`, `dist/`).
 - `@antadesign/stickers` — the sticker pack, in top-level [`stickers/`](../stickers/AGENTS.md). It owns the `<a-sticker>` / `<a-sticker-animated>` elements, the `Sticker` / `StickerAnimated` wrappers, the artwork, and the **only** `lottie-web` dependency. It depends on `@antadesign/anta` for the JSX runtime and shared helpers. Kept separate so anta carries no animation runtime. **Anything sticker-related — components, tokens, docs page, the generator — lives there, not here.**
+- `@antadesign/plot` — the separate canvas plot library in `plot/`; its core and browser host live outside this package.
 - `site/` — the docs site (not published).
 
 ## Architecture


### PR DESCRIPTION
### Changes
- Add @antadesign/plot as a separate npm package, following the stickers package structure.
- Move plotting implementation from the notebook into Anta, preserving behavior.
- Provides shared controllers, host integration helpers, and an optional <a-plot> browser component.
- Add package exports, build tooling, workspace integration, and CI checks.
- Notebook adapter remained in the star repo. Updating star with this anta plot release will come after.

### Changes in plot
While plot API surface and behavior were preserved, the internal mechanisms have shifted to a framework agnostic implementation. The preact hooks used previously to manage the plot state and lifecycle are now plain TypeScript controllers and functions.
* Using Anta Box and Capture components in place of notebook external components such as x-measurer for example.
* Highlight marks are now drawn on an overlay canvas. This was the correct way to do it from the beginning and it made sense to do it now during migration due to the previous implementation requiring additional DOM manipulation which complicates the notebook integration (b/c worker thread).

### Deferred
- Documentation on Anta public docs
- React and Preact wrappers - not necessary for use in the notebook
- Publish to npm and verification in the notebook